### PR TITLE
fix: recursively redact nested dict/list log extras

### DIFF
--- a/src/azure_functions_logging/_filters.py
+++ b/src/azure_functions_logging/_filters.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import logging
 import threading
 import time
-from typing import Iterable
+from typing import Any, Iterable
 
 # Default set of sensitive keys masked by RedactionFilter
 _DEFAULT_SENSITIVE_KEYS: frozenset[str] = frozenset(
@@ -26,6 +26,25 @@ _DEFAULT_SENSITIVE_KEYS: frozenset[str] = frozenset(
 )
 
 _MASK = "***"
+
+
+def _redact_value(
+    value: Any,
+    sensitive_keys: frozenset[str],
+    mask: str = _MASK,
+) -> Any:
+    if isinstance(value, dict):
+        return {
+            key: (
+                mask
+                if isinstance(key, str) and key.lower() in sensitive_keys
+                else _redact_value(item, sensitive_keys, mask)
+            )
+            for key, item in value.items()
+        }
+    if isinstance(value, list):
+        return [_redact_value(item, sensitive_keys, mask) for item in value]
+    return value
 
 # Standard LogRecord fields that RedactionFilter should never touch
 _STANDARD_RECORD_FIELDS: frozenset[str] = frozenset(
@@ -152,4 +171,8 @@ class RedactionFilter(logging.Filter):
                 continue
             if key.lower() in self._sensitive_keys:
                 setattr(record, key, _MASK)
+            else:
+                value = getattr(record, key)
+                if isinstance(value, (dict, list)):
+                    setattr(record, key, _redact_value(value, self._sensitive_keys))
         return True

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -135,3 +135,80 @@ def test_redaction_filter_key_matching_is_case_insensitive() -> None:
 
     assert getattr(record, "PASSWORD") == "***"
     assert getattr(record, "Token") == "***"
+
+
+def test_redaction_filter_recursively_masks_nested_dict_keys() -> None:
+    flt = RedactionFilter()
+    record = _make_record(msg="nested")
+    setattr(
+        record,
+        "payload",
+        {"password": "secret", "nested": {"token": "abc", "safe": "ok"}},
+    )
+
+    flt.filter(record)
+
+    assert getattr(record, "payload") == {
+        "password": "***",
+        "nested": {"token": "***", "safe": "ok"},
+    }
+
+
+def test_redaction_filter_recursively_masks_deeply_nested_dict_keys() -> None:
+    flt = RedactionFilter()
+    record = _make_record(msg="deep")
+    setattr(
+        record,
+        "context",
+        {"level_1": {"level_2": {"authorization": "Bearer x", "value": 42}}},
+    )
+
+    flt.filter(record)
+
+    assert getattr(record, "context") == {
+        "level_1": {"level_2": {"authorization": "***", "value": 42}}
+    }
+
+
+def test_redaction_filter_recursively_masks_dicts_inside_lists() -> None:
+    flt = RedactionFilter()
+    record = _make_record(msg="list")
+    setattr(
+        record,
+        "events",
+        [{"token": "abc"}, {"safe": "value"}, {"authorization": "Bearer y"}],
+    )
+
+    flt.filter(record)
+
+    assert getattr(record, "events") == [
+        {"token": "***"},
+        {"safe": "value"},
+        {"authorization": "***"},
+    ]
+
+
+def test_redaction_filter_recursively_masks_mixed_nested_structures() -> None:
+    flt = RedactionFilter()
+    record = _make_record(msg="mixed")
+    setattr(
+        record,
+        "metadata",
+        {
+            "items": [
+                {"secret": "s-1", "nested": [{"api_key": "k-1"}, {"safe": "ok"}]},
+                "raw",
+            ],
+            "profile": {"passwd": "p-1", "name": "alice"},
+        },
+    )
+
+    flt.filter(record)
+
+    assert getattr(record, "metadata") == {
+        "items": [
+            {"secret": "***", "nested": [{"api_key": "***"}, {"safe": "ok"}]},
+            "raw",
+        ],
+        "profile": {"passwd": "***", "name": "alice"},
+    }


### PR DESCRIPTION
## Summary
- add recursive redaction for nested `dict` and `list` values on non-standard `LogRecord` extra attributes
- preserve existing top-level key redaction while recursively masking sensitive keys at any depth
- add regression tests for nested dicts, deeply nested structures, lists of dicts, and mixed nested payloads

## Validation
- make test
- make lint
- make typecheck

Closes #5