### PR TITLE
chore: align repo consistency configs

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -6,7 +6,6 @@ on:
   pull_request:
     branches: [main]
   schedule:
-    # Run weekly on Monday at 00:00 UTC
     - cron: "0 0 * * 1"
 
 permissions:
@@ -23,12 +22,12 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@0d579ffd059c29b07949a3cce3983f0780820c98 # v4
+        uses: github/codeql-action/init@b1bff81932f5cdfc8695c7752dcee935dcd061c8 # v4
         with:
           languages: python
           queries: security-extended
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@0d579ffd059c29b07949a3cce3983f0780820c98 # v4
+        uses: github/codeql-action/analyze@b1bff81932f5cdfc8695c7752dcee935dcd061c8 # v4
         with:
           category: "/language:python"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.5
+    rev: v0.15.6
     hooks:
       - id: ruff-format
       - id: ruff
@@ -32,7 +32,7 @@ repos:
     hooks:
       - id: forbid-korean
         name: Forbid Korean Characters
-        entry: bash -c 'if grep -RIl --exclude-dir=.venv --exclude-dir=.git -n "[가-힣]" docs src README.md CONTRIBUTING.md AGENT.md DESIGN.md PRD.md CHANGELOG.md 2>/dev/null; then echo "Korean characters detected. Please use English only."; exit 1; fi'
+        entry: bash -c 'if grep -RIl --exclude-dir=.venv --exclude-dir=.git -n "[가-힣]" docs src README.md CONTRIBUTING.md AGENTS.md CHANGELOG.md 2>/dev/null; then echo "Korean characters detected. Please use English only."; exit 1; fi'
         language: system
         pass_filenames: false
         stages: [pre-commit]

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,13 @@
+codecov:
+  require_ci_to_pass: true
+
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 2%
+
+parsers:
+  python:
+    build_root: .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,7 +118,7 @@ source = ["src/azure_functions_logging"]
 
 [tool.coverage.report]
 show_missing = true
-fail_under = 95
+fail_under = 90
 skip_covered = true
 
 [tool.bandit]


### PR DESCRIPTION
## Summary
- update `.pre-commit-config.yaml` to use `ruff-pre-commit` v0.15.6 and align the `forbid-korean` scope with sibling repositories
- lower `tool.coverage.report.fail_under` from 95 to 90 in `pyproject.toml`
- align repo governance configs by adding `codecov.yml` and updating the pinned CodeQL workflow action SHAs

## Verification
- `git ls-files .venv-review` returned no tracked files
- `make build` passed
- LSP diagnostics are clean for updated YAML files