### PR TITLE
chore: consistency round 2 — AGENTS.md and .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,4 +27,6 @@ dist/
 
 # Docs
 site/
+
+# Review
 .venv-review/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,6 @@
 ## Read First
 - `README.md`
 - `CONTRIBUTING.md`
-- `docs/agent-playbook.md`
 
 ## Working Rules
 - The root logger is never modified by this library — only named loggers are configured.


### PR DESCRIPTION
## Summary
- Remove nonexistent `docs/agent-playbook.md` reference from AGENTS.md Read First section
- Standardize .gitignore to compact format aligned across all azure-functions-* repos