### PR TITLE
chore: release v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,14 +4,23 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-03-21
+
 ### Added
 
 - Real Azure end-to-end test workflow (`e2e-azure.yml`) deploying to Consumption plan (`koreacentral`)
 - `docs/testing.md` — Real Azure E2E Tests section
+- Pre-commit config, SBOM/CodeQL workflows, codecov config
 
 ### Changed
 
-- GitHub Actions versions upgraded to Node.js 24 compatible: `checkout@v6`, `setup-python@v6`, `upload-artifact@v7`, `azure/login@v2.3.0`
+- GitHub Actions versions upgraded to Node.js 24 compatible versions
+- Repository consistency fixes (AGENTS.md, .gitignore standardization)
+
+### Fixed
+
+- Treat arbitrary logger kwargs as structured extra fields (#6)
+- Recursively redact nested dict/list log extras (#7)
 ## [0.3.0] - 2026-03-15
 
 ### Added

--- a/src/azure_functions_logging/__init__.py
+++ b/src/azure_functions_logging/__init__.py
@@ -19,7 +19,7 @@ __all__ = [
     "setup_logging",
 ]
 
-__version__ = "0.3.0"
+__version__ = "0.4.0"
 
 
 def get_logger(name: str | None = None) -> FunctionLogger:

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -1,6 +1,6 @@
 """Tests for the public API surface of azure-functions-logging."""
 
-import azure_functions_logging
+import azure_functions_logging  # pyright: ignore[reportMissingImports]
 
 
 class TestAPISurface:
@@ -18,14 +18,14 @@ class TestAPISurface:
             "setup_logging",
         }
 
-    def test_version_is_0_3_0(self) -> None:
-        assert azure_functions_logging.__version__ == "0.3.0"
+    def test_version_is_0_4_0(self) -> None:
+        assert azure_functions_logging.__version__ == "0.4.0"
 
     def test_version_is_string(self) -> None:
         assert isinstance(azure_functions_logging.__version__, str)
 
     def test_public_names_are_importable(self) -> None:
-        from azure_functions_logging import (  # noqa: F401
+        from azure_functions_logging import (  # noqa: F401  # pyright: ignore[reportMissingImports]
             FunctionLogger,
             JsonFormatter,
             RedactionFilter,


### PR DESCRIPTION
## Summary
- Cut the `v0.4.0` release with version alignment in public API tests and changelog release sectioning.
- Document release highlights including Azure E2E workflow, CI/tooling additions, Actions runtime compatibility, and repository consistency updates.
- Include fixes for structured extra kwargs handling and recursive nested redaction.

## Validation
- `make test`
- `make build`