### PR TITLE
docs: add missing exception field to README JSON example

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,8 @@ Output per log line (NDJSON — one JSON object per line):
 ```json
 {"timestamp": "2024-01-15T10:30:00Z", "level": "INFO", "logger": "my_module",
  "message": "order accepted", "invocation_id": "abc-123", "function_name": "OrderHandler",
- "cold_start": false, "trace_id": "00-abc...", "extra": {"order_id": "o-999"}}
+ "cold_start": false, "trace_id": "00-abc...", "exception": null,
+ "extra": {"order_id": "o-999"}}
 ```
 
 Extra fields appear in `extra` and are indexable in Application Insights:


### PR DESCRIPTION
## Summary
- The JSON output example in README showed 8 fields but `JsonFormatter` actually emits 10 fields including `exception`
- Added the missing `"exception": null` field to keep documentation accurate

Closes #24