### PR TITLE
feat: add with_context decorator to reduce inject_context() boilerplate

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,38 @@ def my_function(req, context):
 
 Without `inject_context()`, these fields are `None` in every log line.
 
+### `with_context` Decorator
+
+For less boilerplate, use the `with_context` decorator instead of calling `inject_context()` manually:
+
+```python
+import azure.functions as func
+from azure_functions_logging import get_logger, setup_logging, with_context
+
+setup_logging()
+logger = get_logger(__name__)
+
+app = func.FunctionApp()
+
+@app.route(route="hello")
+@with_context
+def hello(req: func.HttpRequest, context: func.Context) -> func.HttpResponse:
+    logger.info("Request received")
+    return func.HttpResponse("OK")
+```
+
+The decorator finds the `context` parameter by name, calls `inject_context()` before your handler runs, and resets context variables in `finally` after it returns.
+
+Custom parameter name:
+
+```python
+@with_context(param="ctx")
+def hello(req: func.HttpRequest, ctx: func.Context) -> func.HttpResponse:
+    ...
+```
+
+Both sync and async handlers are supported.
+
 ## Structured JSON Output (Production)
 
 Use JSON format when logs feed Application Insights or any aggregation system:

--- a/src/azure_functions_logging/__init__.py
+++ b/src/azure_functions_logging/__init__.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from ._context import inject_context
+from ._decorator import with_context
 from ._filters import RedactionFilter, SamplingFilter
 from ._json_formatter import JsonFormatter
 from ._logger import FunctionLogger
@@ -17,6 +18,7 @@ __all__ = [
     "get_logger",
     "inject_context",
     "setup_logging",
+    "with_context",
 ]
 
 __version__ = "0.4.0"

--- a/src/azure_functions_logging/_decorator.py
+++ b/src/azure_functions_logging/_decorator.py
@@ -1,0 +1,142 @@
+"""Decorator helper for automatic context injection.
+
+Provides ``with_context`` — a decorator that calls ``inject_context()``
+before the handler runs and resets context variables after it completes.
+
+Ref: https://github.com/yeongseon/azure-functions-logging/issues/22
+"""
+
+from __future__ import annotations
+
+import asyncio
+import functools
+import inspect
+from typing import Any, Callable, TypeVar, overload
+
+from ._context import (
+    cold_start_var,
+    function_name_var,
+    inject_context,
+    invocation_id_var,
+    trace_id_var,
+)
+
+_F = TypeVar("_F", bound=Callable[..., Any])
+
+_DEFAULT_PARAM = "context"
+
+
+def _reset_context_vars() -> None:
+    """Reset all invocation context variables to None."""
+    invocation_id_var.set(None)
+    function_name_var.set(None)
+    trace_id_var.set(None)
+    cold_start_var.set(None)
+
+
+def _find_context_arg(
+    func: Callable[..., Any],
+    param: str,
+    args: tuple[Any, ...],
+    kwargs: dict[str, Any],
+) -> Any:
+    """Locate the context argument by parameter name."""
+    # Check kwargs first
+    if param in kwargs:
+        return kwargs[param]
+
+    # Fall back to positional args
+    try:
+        sig = inspect.signature(func)
+        params = list(sig.parameters.keys())
+        idx = params.index(param)
+        if idx < len(args):
+            return args[idx]
+    except (ValueError, IndexError):
+        pass
+
+    return None
+
+
+def _wrap_sync(func: _F, param: str) -> _F:
+    """Wrap a synchronous handler."""
+
+    @functools.wraps(func)
+    def wrapper(*args: Any, **kwargs: Any) -> Any:
+        ctx = _find_context_arg(func, param, args, kwargs)
+        if ctx is not None:
+            inject_context(ctx)
+        try:
+            return func(*args, **kwargs)
+        finally:
+            _reset_context_vars()
+
+    return wrapper  # type: ignore[return-value]
+
+
+def _wrap_async(func: _F, param: str) -> _F:
+    """Wrap an asynchronous handler."""
+
+    @functools.wraps(func)
+    async def wrapper(*args: Any, **kwargs: Any) -> Any:
+        ctx = _find_context_arg(func, param, args, kwargs)
+        if ctx is not None:
+            inject_context(ctx)
+        try:
+            return await func(*args, **kwargs)
+        finally:
+            _reset_context_vars()
+
+    return wrapper  # type: ignore[return-value]
+
+
+@overload
+def with_context(func: _F) -> _F: ...
+
+
+@overload
+def with_context(*, param: str = ...) -> Callable[[_F], _F]: ...
+
+
+def with_context(
+    func: _F | None = None,
+    *,
+    param: str = _DEFAULT_PARAM,
+) -> _F | Callable[[_F], _F]:
+    """Decorator that automatically injects invocation context.
+
+    Can be used with or without arguments::
+
+        @with_context
+        def handler(req, context):
+            ...
+
+        @with_context(param="ctx")
+        def handler(req, ctx):
+            ...
+
+    The decorator:
+
+    1. Finds the ``context`` parameter (by name, default ``"context"``)
+    2. Calls ``inject_context(context)`` before the handler body
+    3. Resets all context variables in ``finally`` after the handler returns
+
+    Both sync and async handlers are supported.
+
+    Args:
+        func: The handler function (when used without parentheses).
+        param: Name of the parameter that receives the Azure Functions
+            context object. Defaults to ``"context"``.
+    """
+
+    def decorator(fn: _F) -> _F:
+        if asyncio.iscoroutinefunction(fn):
+            return _wrap_async(fn, param)
+        return _wrap_sync(fn, param)
+
+    if func is not None:
+        # Called as @with_context (no parentheses)
+        return decorator(func)
+
+    # Called as @with_context(...) (with parentheses)
+    return decorator

--- a/tests/test_decorator.py
+++ b/tests/test_decorator.py
@@ -1,0 +1,266 @@
+"""Tests for the ``with_context`` decorator.
+
+Covers:
+- @with_context (no parens) with default ``context`` param name
+- @with_context(param="ctx") with custom param name
+- Async handler support
+- Context reset in ``finally`` (context vars are None after handler returns)
+- Context found in kwargs vs positional args
+- Context param not found → no crash (Principle 3)
+- Decorator preserves function metadata (functools.wraps)
+
+Ref: https://github.com/yeongseon/azure-functions-logging/issues/22
+"""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+from azure_functions_logging import with_context
+import azure_functions_logging._context as ctx_mod
+from azure_functions_logging._context import (
+    cold_start_var,
+    function_name_var,
+    invocation_id_var,
+    trace_id_var,
+)
+import azure_functions_logging._setup as setup_mod
+
+
+@pytest.fixture(autouse=True)
+def _reset_state() -> None:
+    """Reset global state between tests."""
+    setup_mod._setup_done = False
+    ctx_mod._cold_start = True
+    invocation_id_var.set(None)
+    function_name_var.set(None)
+    trace_id_var.set(None)
+    cold_start_var.set(None)
+
+
+_MOCK_CONTEXT = SimpleNamespace(
+    invocation_id="inv-dec",
+    function_name="fn-dec",
+    trace_context=SimpleNamespace(
+        trace_parent="00-aaaabbbbccccddddeeeeffffaaaabbbb-1111222233334444-01"
+    ),
+)
+
+
+# ---------------------------------------------------------------------------
+# 1. Sync: @with_context (no parentheses)
+# ---------------------------------------------------------------------------
+
+
+class TestSyncNoParens:
+    """@with_context applied directly — default param name 'context'."""
+
+    def test_injects_context_from_positional_arg(self) -> None:
+        @with_context
+        def handler(req: object, context: object) -> str:
+            assert invocation_id_var.get() == "inv-dec"
+            assert function_name_var.get() == "fn-dec"
+            return "ok"
+
+        result = handler("req", _MOCK_CONTEXT)
+        assert result == "ok"
+
+    def test_injects_context_from_kwarg(self) -> None:
+        @with_context
+        def handler(req: object, context: object) -> str:
+            assert invocation_id_var.get() == "inv-dec"
+            return "ok"
+
+        result = handler("req", context=_MOCK_CONTEXT)
+        assert result == "ok"
+
+    def test_resets_context_vars_after_return(self) -> None:
+        @with_context
+        def handler(req: object, context: object) -> str:
+            return "ok"
+
+        handler("req", _MOCK_CONTEXT)
+        assert invocation_id_var.get() is None
+        assert function_name_var.get() is None
+        assert trace_id_var.get() is None
+        assert cold_start_var.get() is None
+
+    def test_resets_context_vars_after_exception(self) -> None:
+        @with_context
+        def handler(req: object, context: object) -> str:
+            raise ValueError("boom")
+
+        with pytest.raises(ValueError, match="boom"):
+            handler("req", _MOCK_CONTEXT)
+
+        assert invocation_id_var.get() is None
+        assert function_name_var.get() is None
+        assert trace_id_var.get() is None
+        assert cold_start_var.get() is None
+
+
+# ---------------------------------------------------------------------------
+# 2. Sync: @with_context(param="ctx")
+# ---------------------------------------------------------------------------
+
+
+class TestSyncCustomParam:
+    """@with_context(param='ctx') — custom parameter name."""
+
+    def test_injects_context_with_custom_param_name(self) -> None:
+        @with_context(param="ctx")
+        def handler(req: object, ctx: object) -> str:
+            assert invocation_id_var.get() == "inv-dec"
+            assert function_name_var.get() == "fn-dec"
+            return "ok"
+
+        result = handler("req", _MOCK_CONTEXT)
+        assert result == "ok"
+
+    def test_custom_param_kwarg(self) -> None:
+        @with_context(param="ctx")
+        def handler(req: object, ctx: object) -> str:
+            assert invocation_id_var.get() == "inv-dec"
+            return "ok"
+
+        result = handler("req", ctx=_MOCK_CONTEXT)
+        assert result == "ok"
+
+
+# ---------------------------------------------------------------------------
+# 3. Async handlers
+# ---------------------------------------------------------------------------
+
+
+class TestAsync:
+    """with_context must support async handlers."""
+
+    def test_async_handler_injects_and_resets(self) -> None:
+        @with_context
+        async def handler(req: object, context: object) -> str:
+            assert invocation_id_var.get() == "inv-dec"
+            return "ok"
+
+        result = asyncio.get_event_loop().run_until_complete(
+            handler("req", _MOCK_CONTEXT)
+        )
+        assert result == "ok"
+        # Context reset after return
+        assert invocation_id_var.get() is None
+
+    def test_async_handler_resets_on_exception(self) -> None:
+        @with_context
+        async def handler(req: object, context: object) -> str:
+            raise ValueError("async boom")
+
+        with pytest.raises(ValueError, match="async boom"):
+            asyncio.get_event_loop().run_until_complete(
+                handler("req", _MOCK_CONTEXT)
+            )
+
+        assert invocation_id_var.get() is None
+
+    def test_async_custom_param(self) -> None:
+        @with_context(param="ctx")
+        async def handler(req: object, ctx: object) -> str:
+            assert function_name_var.get() == "fn-dec"
+            return "ok"
+
+        result = asyncio.get_event_loop().run_until_complete(
+            handler("req", _MOCK_CONTEXT)
+        )
+        assert result == "ok"
+
+
+# ---------------------------------------------------------------------------
+# 4. Context param not found → no crash (Principle 3)
+# ---------------------------------------------------------------------------
+
+
+class TestMissingContextParam:
+    """When the handler doesn't have the expected context param,
+    the decorator must not crash — just skip injection.
+    """
+
+    def test_no_context_param_does_not_crash(self) -> None:
+        @with_context
+        def handler(req: object) -> str:
+            # No context injected — vars stay None
+            assert invocation_id_var.get() is None
+            return "ok"
+
+        result = handler("req")
+        assert result == "ok"
+
+    def test_wrong_param_name_does_not_crash(self) -> None:
+        @with_context(param="ctx")
+        def handler(req: object, context: object) -> str:
+            # 'ctx' not in signature → no injection
+            assert invocation_id_var.get() is None
+            return "ok"
+
+        result = handler("req", _MOCK_CONTEXT)
+        assert result == "ok"
+
+
+# ---------------------------------------------------------------------------
+# 5. Decorator preserves function metadata
+# ---------------------------------------------------------------------------
+
+
+class TestFunctools:
+    """with_context must preserve __name__, __doc__, __module__ via functools.wraps."""
+
+    def test_preserves_name_and_doc(self) -> None:
+        @with_context
+        def my_handler(req: object, context: object) -> str:
+            """Handler docstring."""
+            return "ok"
+
+        assert my_handler.__name__ == "my_handler"
+        assert my_handler.__doc__ == "Handler docstring."
+
+    def test_preserves_name_with_parens(self) -> None:
+        @with_context(param="context")
+        def another_handler(req: object, context: object) -> str:
+            """Another docstring."""
+            return "ok"
+
+        assert another_handler.__name__ == "another_handler"
+        assert another_handler.__doc__ == "Another docstring."
+
+
+# ---------------------------------------------------------------------------
+# 6. Cold start detection through decorator
+# ---------------------------------------------------------------------------
+
+
+class TestColdStart:
+    """The decorator must correctly propagate cold_start via inject_context."""
+
+    def test_first_invocation_is_cold_start(self) -> None:
+        @with_context
+        def handler(req: object, context: object) -> bool | None:
+            return cold_start_var.get()
+
+        result = handler("req", _MOCK_CONTEXT)
+        assert result is True
+
+    def test_second_invocation_is_not_cold_start(self) -> None:
+        @with_context
+        def handler(req: object, context: object) -> bool | None:
+            return cold_start_var.get()
+
+        handler("req", _MOCK_CONTEXT)
+        # Reset _cold_start is already False, but contextvars are reset by decorator
+        # Need fresh context for second call
+        ctx2 = SimpleNamespace(
+            invocation_id="inv-2",
+            function_name="fn-2",
+            trace_context=SimpleNamespace(trace_parent="00-bbbb-2222-01"),
+        )
+        result = handler("req", ctx2)
+        assert result is False

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -88,6 +88,7 @@ def test_public_api_exports() -> None:
         "get_logger",
         "inject_context",
         "setup_logging",
+        "with_context",
     }
     assert set(afl.__all__) == expected
     assert callable(afl.get_logger)

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -16,6 +16,7 @@ class TestAPISurface:
             "get_logger",
             "inject_context",
             "setup_logging",
+            "with_context",
         }
 
     def test_version_is_0_4_0(self) -> None:


### PR DESCRIPTION
## Summary

Closes #22

Adds a `@with_context` decorator that automatically extracts the Azure Functions `context` parameter and calls `inject_context()` before the handler runs, with cleanup in `finally`.

### Before
```python
@app.route(route="hello")
def hello(req: func.HttpRequest, context: func.Context) -> func.HttpResponse:
    inject_context(context)  # manual, easy to forget
    logger.info("Request received")
    return func.HttpResponse("OK")
```

### After
```python
@app.route(route="hello")
@with_context
def hello(req: func.HttpRequest, context: func.Context) -> func.HttpResponse:
    logger.info("Request received")
    return func.HttpResponse("OK")
```

## Features
- Supports both `@with_context` and `@with_context(param="ctx")` call styles
- Sync and async handler support
- Automatic context cleanup in `finally` block
- Parameter detection by name (no runtime dependency on `azure-functions`)
- `functools.wraps` preserves handler metadata

## Changes
- `src/azure_functions_logging/_decorator.py` — new module (142 lines)
- `src/azure_functions_logging/__init__.py` — export `with_context` in `__all__`
- `tests/test_decorator.py` — 15 tests (266 lines)
- `tests/test_public_api.py` — updated `__all__` assertion
- `tests/test_integration.py` — updated `__all__` assertion
- `README.md` — added `with_context` decorator section

## Validation
- 100 tests pass
- 97.46% coverage
- ruff clean
- mypy clean