### PR TITLE
docs: standardize architecture docs with Mermaid diagrams, Sources, See Also

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -26,7 +26,7 @@ This project does not aim to:
 
 ## Design Principles
 
-- **Principle 1**: The root logger is never modified. All configuration targets named child loggers.
+- **Principle 1**: The root logger's handlers and level are never modified. In Azure environments, only a `ContextFilter` is installed on existing handlers and the root logger (for future handler coverage).
 - **Principle 2**: In Azure environments, behavior is safe by default — no forced colors, no excessive handler additions, no interference with the worker's `AsyncLoggingHandler`.
 - **Principle 3**: Context injection failures never cause application failures. Logging helpers are auxiliary — they must never become a source of outages.
 - **Principle 4**: The API surface stays as close to standard `logging` as possible. Users should not need to learn a new logging framework.
@@ -37,26 +37,20 @@ This project does not aim to:
 
 The architecture uses Python's `contextvars` as the primary context propagation mechanism, with a `logging.Filter` that copies context variable values onto every `LogRecord`.
 
-```
-┌─────────────────────────────────────────────────────┐
-│  inject_context(func_context)                       │
-│  Sets contextvars: invocation_id, function_name,    │
-│  trace_id, cold_start                               │
-└──────────────────────┬──────────────────────────────┘
-                       │
-                       ▼
-┌─────────────────────────────────────────────────────┐
-│  ContextFilter (logging.Filter)                     │
-│  Copies contextvars → LogRecord attributes          │
-│  Covers ALL loggers (including third-party)         │
-└──────────────────────┬──────────────────────────────┘
-                       │
-                       ▼
-┌─────────────────────────────────────────────────────┐
-│  Formatter reads record.invocation_id, etc.         │
-│  Local: ColorFormatter with context fields          │
-│  Azure: Worker's handler uses formatted message     │
-└─────────────────────────────────────────────────────┘
+```mermaid
+flowchart TD
+    subgraph Startup ["Startup / Configuration"]
+        SL["setup_logging()"] --> ENV{Environment?}
+        ENV -->|Azure / Core Tools| AZ["Install ContextFilter\non root handlers + root logger"]
+        ENV -->|Standalone local| LOCAL["Add StreamHandler +\nColorFormatter or JsonFormatter\n(only if no handlers exist)"]
+        AZ --> HOST["warn_host_json_level_conflict()"]
+    end
+
+    subgraph Invocation ["Per-Invocation / Log Enrichment"]
+        CTX["inject_context(context)\nor @with_context decorator"] --> VARS["contextvars\ninvocation_id, function_name,\ntrace_id, cold_start"]
+        VARS --> FILT["ContextFilter\ncopies vars → LogRecord"]
+        FILT --> FMT["Formatter reads\nrecord attributes"]
+    end
 ```
 
 ### Why `contextvars` + Filter (not `extra={}` per call)
@@ -109,7 +103,7 @@ Four exports plus a logger class:
 - `WEBSITE_INSTANCE_ID` → "Azure hosted" (not present locally)
 - Absence of both → "standalone local development"
 
-`setup_logging()` adds a `StreamHandler` with `ColorFormatter` only in standalone local development. In Functions environments, it installs only the `ContextFilter` (no handlers, no formatters on the worker's handler).
+`setup_logging()` adds a `StreamHandler` with `ColorFormatter` only in standalone local development when the target logger has no existing handlers. In Functions environments, it installs only the `ContextFilter` on existing root handlers and the root logger itself; when `functions_formatter` is passed, it also sets that formatter on each existing handler.
 
 ### Cold Start Detection
 
@@ -174,3 +168,19 @@ bound.info("Processing")  # includes user_id + operation + invocation_id (from f
 - Context injection semantics must be covered by regression tests
 - Formatter output changes are user-facing behavior changes
 - Experimental APIs must be clearly labeled in code and docs
+
+
+## Sources
+
+- [Azure Functions Python developer reference](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-python)
+- [Monitor Azure Functions](https://learn.microsoft.com/en-us/azure/azure-functions/functions-monitoring)
+- [host.json logging configuration](https://learn.microsoft.com/en-us/azure/azure-functions/functions-host-json#logging)
+- [Supported languages in Azure Functions](https://learn.microsoft.com/en-us/azure/azure-functions/supported-languages)
+
+## See Also
+
+- [azure-functions-validation — Architecture](https://github.com/yeongseon/azure-functions-validation) — Request/response validation pipeline
+- [azure-functions-openapi — Architecture](https://github.com/yeongseon/azure-functions-openapi) — OpenAPI spec generation
+- [azure-functions-doctor — Architecture](https://github.com/yeongseon/azure-functions-doctor) — Pre-deploy diagnostic CLI
+- [azure-functions-scaffold — Architecture](https://github.com/yeongseon/azure-functions-scaffold) — Project scaffolding CLI
+- [azure-functions-langgraph — Architecture](https://github.com/yeongseon/azure-functions-langgraph) — LangGraph agent deployment

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -23,6 +23,8 @@ Core modules and responsibilities:
 - `_formatter.py`: local color formatter.
 - `_json_formatter.py`: structured JSON formatter.
 - `_host_config.py`: host policy mismatch warning logic.
+- `_decorator.py`: `with_context` decorator for automatic context injection and cleanup.
+- `_filters.py`: `SamplingFilter` (rate-limiting) and `RedactionFilter` (PII masking).
 
 ## Public API Boundary
 
@@ -33,8 +35,11 @@ Public symbols intentionally kept small:
 - `FunctionLogger`
 - `JsonFormatter`
 - `inject_context`
-
-Everything else remains internal to keep migration and evolution manageable.
+- `with_context`
+- `RedactionFilter`
+- `SamplingFilter`
+- `__version__`
+Everything else remains internal to keep migration and evolution manageable. (`__version__` is exported for programmatic version checks.)
 
 ## Setup Pipeline
 
@@ -67,8 +72,9 @@ In Functions runtime contexts, setup avoids replacing host handler graph.
 
 Instead, it:
 
-- Installs `ContextFilter` onto existing handlers.
+- Installs `ContextFilter` onto existing root handlers.
 - Installs filter on root logger for future handler coverage.
+- Optionally sets `functions_formatter` on existing handlers when provided.
 - Preserves host-managed output pipeline.
 
 This prevents duplicate output and alignment issues with platform logging.
@@ -78,7 +84,7 @@ This prevents duplicate output and alignment issues with platform logging.
 In non-Functions environments:
 
 - Target logger level is set.
-- `StreamHandler` is created when needed.
+- `StreamHandler` is created only when the target logger has no existing handlers.
 - Formatter is selected by `format` parameter.
 - `ContextFilter` is attached for metadata fields.
 
@@ -103,10 +109,30 @@ Benefits of `contextvars`:
 
 Request-level flow:
 
-1. Handler calls `inject_context(context)`.
+1. Handler calls `inject_context(context)` (or uses the `@with_context` decorator).
 2. Context values are extracted and stored in context variables.
-3. `ContextFilter` reads values for each log record.
-4. Formatter outputs record with context fields.
+3. `ContextFilter` copies context variable values onto each `LogRecord`.
+4. Formatter reads enriched `LogRecord` attributes and outputs the message.
+
+```mermaid
+sequenceDiagram
+    participant Trigger as HTTP Trigger
+    participant Handler as Function Handler
+    participant CTX as inject_context()
+    participant Vars as contextvars
+    participant CF as ContextFilter
+    participant Fmt as Formatter
+
+    Trigger->>Handler: invoke with func.Context
+    Handler->>CTX: inject_context(context)
+    CTX->>Vars: set invocation_id, function_name, trace_id, cold_start
+    Handler->>Handler: logger.info("Processing request")
+    Handler->>CF: LogRecord passes through filter
+    CF->>Vars: read context variable values
+    CF->>CF: copy values onto LogRecord attributes
+    CF->>Fmt: enriched LogRecord
+    Fmt-->>Handler: formatted output with context fields
+```
 
 This decouples business code from formatter implementation details.
 
@@ -182,9 +208,51 @@ For production teams, this architecture means:
 - Local and runtime behavior differ intentionally to match platform constraints.
 - Cold start analysis becomes available without custom plumbing.
 
+## Module Boundaries
+
+```mermaid
+flowchart TD
+    INIT["__init__.py\nPublic API exports"]
+    SETUP["_setup.py\nsetup_logging()"]
+    CTX["_context.py\ninject_context() + ContextFilter"]
+    LOG["_logger.py\nFunctionLogger + bind()"]
+    DEC["_decorator.py\n@with_context"]
+    FILT["_filters.py\nSamplingFilter + RedactionFilter"]
+    FMT["_formatter.py\nColorFormatter"]
+    JSON["_json_formatter.py\nJsonFormatter"]
+    HOST["_host_config.py\nhost.json conflict detection"]
+
+    INIT --> SETUP
+    INIT --> CTX
+    INIT --> LOG
+    INIT --> JSON
+    INIT --> DEC
+    INIT --> FILT
+    SETUP --> CTX
+    SETUP --> FMT
+    SETUP --> JSON
+    SETUP --> HOST
+    DEC --> CTX
+```
+
 ## Related Documents
 
 - [Usage Guide](usage.md)
 - [Configuration](configuration.md)
 - [API Reference](api.md)
 - [Troubleshooting](troubleshooting.md)
+
+## Sources
+
+- [Azure Functions Python developer reference](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-python)
+- [Monitor Azure Functions](https://learn.microsoft.com/en-us/azure/azure-functions/functions-monitoring)
+- [host.json logging configuration](https://learn.microsoft.com/en-us/azure/azure-functions/functions-host-json#logging)
+- [Supported languages in Azure Functions](https://learn.microsoft.com/en-us/azure/azure-functions/supported-languages)
+
+## See Also
+
+- [azure-functions-validation — Architecture](https://github.com/yeongseon/azure-functions-validation) — Request/response validation pipeline
+- [azure-functions-openapi — Architecture](https://github.com/yeongseon/azure-functions-openapi) — OpenAPI spec generation
+- [azure-functions-doctor — Architecture](https://github.com/yeongseon/azure-functions-doctor) — Pre-deploy diagnostic CLI
+- [azure-functions-scaffold — Architecture](https://github.com/yeongseon/azure-functions-scaffold) — Project scaffolding CLI
+- [azure-functions-langgraph — Architecture](https://github.com/yeongseon/azure-functions-langgraph) — LangGraph agent deployment


### PR DESCRIPTION
## Summary

- Replace ASCII art in DESIGN.md with Mermaid flowchart (Startup + Per-Invocation subgraphs)
- Add sequenceDiagram (Context Enrichment Flow) and Module Boundaries flowchart to `docs/architecture.md`
- Add `_decorator.py` and `_filters.py` to High-Level Components
- Add `with_context`, `RedactionFilter`, `SamplingFilter`, `__version__` to Public API Boundary
- Clarify `setup_logging()` behavior: ContextFilter installed on root handlers AND root logger; StreamHandler only when no handlers exist; `functions_formatter` support documented
- Reorder sections: Module Boundaries before Related Documents
- Add Sources (4 MS Learn links) and See Also (5 cross-repo links) to both files

## Verification

- `make check-all` passes (116 tests, 97.48% coverage)
- Oracle design review ✅
- Oracle post-impl review ✅ (6 accuracy fixes applied)

Closes #38