### PR TITLE
docs: enable Mermaid diagram rendering on GitHub Pages

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,7 @@
 site_name: Azure Functions Logging
 site_description: Developer-friendly logging helpers for Azure Functions Python
 site_author: Yeongseon Choe
+site_url: https://yeongseon.github.io/azure-functions-logging/
 repo_url: https://github.com/yeongseon/azure-functions-logging
 edit_uri: edit/main/docs/
 
@@ -46,7 +47,11 @@ markdown_extensions:
       permalink: true
       toc_depth: 3
   - tables
-  - pymdownx.superfences
+  - pymdownx.superfences:
+      custom_fences:
+        - name: mermaid
+          class: mermaid
+          format: !!python/name:pymdownx.superfences.fence_code_format
   - pymdownx.highlight:
       anchor_linenums: true
   - pymdownx.tabbed:
@@ -73,3 +78,6 @@ extra:
       link: https://github.com/yeongseon/azure-functions-logging
   copyright: |
     © 2026 Yeongseon Choe – MIT Licensed
+
+extra_javascript:
+  - https://unpkg.com/mermaid@11.14.0/dist/mermaid.min.js


### PR DESCRIPTION
## Summary

- Add `custom_fences` Mermaid configuration to `pymdownx.superfences` in `mkdocs.yml`
- Add `extra_javascript` with pinned Mermaid JS v11.14.0 CDN
- Add `site_url` for canonical URLs and sitemap generation
- Mermaid diagrams in `docs/architecture.md` will now render as visual diagrams instead of plain text code blocks

## Root Cause

`pymdownx.superfences` was configured as a bare extension without the `custom_fences` block needed to recognize ` ```mermaid ` code blocks. The Mermaid JS library was also not loaded via `extra_javascript`.

## Changes

**`mkdocs.yml`**: 
- `pymdownx.superfences` → `pymdownx.superfences` with `custom_fences` for mermaid
- Added `extra_javascript` section with `https://unpkg.com/mermaid@11.14.0/dist/mermaid.min.js`
- Added `site_url: https://yeongseon.github.io/azure-functions-logging/`

## Validation

- `make check-all` passes

Fixes #43