### PR TITLE
docs: add Azure deployment verification note to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ curl -s "https://<your-app>.azurewebsites.net/api/logme?correlation_id=demo-123"
 {"logged": true, "correlation_id": "demo-123"}
 ```
 
-> Response captured from a deployed Azure Function; URL anonymized.
+> Verified against a temporary Azure Functions deployment in koreacentral (Python 3.12, Consumption plan). Response captured and URL anonymized.
 
 ## Invocation Context
 


### PR DESCRIPTION
## Summary

- Update verification note with real Azure deployment details

## Details

Deployed the `e2e_app` example to a temporary Azure Function (Consumption plan, Python 3.12, koreacentral) and verified:

```
GET /api/logme?correlation_id=demo-123
→ {"logged": true, "correlation_id": "demo-123"} HTTP 200 ✅
```

Response matches README content exactly. Resources deleted immediately after verification.