### PR TITLE
chore: add CODE_OF_CONDUCT.md and SUPPORT.md for DX Toolkit consistency

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,56 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity and
+orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior:
+
+* The use of sexualized language or imagery and unwelcome sexual attention
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information without explicit permission
+* Other conduct which could reasonably be considered inappropriate
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+yeongseon.choe@gmail.com.
+
+All complaints will be reviewed and investigated promptly and fairly.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.0, available at
+https://www.contributor-covenant.org/version/2/0/code_of_conduct.html.
+
+[homepage]: https://www.contributor-covenant.org

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,46 @@
+# Support Policy
+
+## Supported Environment
+
+* Python: 3.10 and above
+* Runtime: Azure Functions (Python)
+
+## Support Scope
+
+This project is maintained by a single developer and support is provided on a
+best-effort basis.
+
+Supported requests:
+
+* Bug reports with clear reproduction steps
+* Feature requests aligned with the project scope
+* Usage questions related to the package itself
+
+Out of scope:
+
+* Custom feature development
+* Environment-specific debugging
+* General Azure infrastructure consulting
+
+## Support Channels
+
+Preferred channels:
+
+* GitHub Issues for bugs and feature requests
+* GitHub Discussions for usage questions
+* GitHub Security Advisories for security reports
+
+Response targets:
+
+* Initial response: within 3 business days on a best-effort basis
+* Follow-up updates: weekly for active issues when applicable
+
+## Deprecation Policy
+
+* Deprecated behavior will be documented before removal
+* Deprecations are announced at least one minor release in advance
+* Removals happen in a later release when practical
+
+## Security Issues
+
+Report security issues privately when possible. See `SECURITY.md` for details.


### PR DESCRIPTION
## Summary

Add the two missing governance files to align with all other DX Toolkit sibling repos.

- **CODE_OF_CONDUCT.md** — Contributor Covenant v2.0 (identical to openapi, validation, db, etc.)
- **SUPPORT.md** — Support scope, channels, and deprecation policy

### Governance file audit (after this PR)

| File | openapi | validation | db | logging | knowledge | langgraph | durable-graph | doctor | scaffold | cookbook |
|------|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
| LICENSE | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
| CODE_OF_CONDUCT | ✅ | ✅ | ✅ | ✅→ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
| SECURITY | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
| SUPPORT | ✅ | ✅ | ✅ | ✅→ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
| CONTRIBUTING | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |

> `✅→` = added in this PR