### PR TITLE
docs: clarify Application Insights ingestion, cold_start semantics, and KQL shapes

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ Azure Functions Python logging has specific failure modes that generic logging l
 - **Noise control** — `SamplingFilter` rate-limits chatty third-party loggers
 - **PII protection** — `RedactionFilter` masks sensitive fields before they reach log aggregation
 
+> **Scope disclaimer.** This package writes structured JSON to Python `logging` / stdout. How those fields appear in Application Insights depends on the Azure Functions host, worker, logging configuration, and ingestion pipeline. The library does not own ingestion or schema mapping — both `customDimensions`-parsed and raw-`message` shapes are valid in production.
+
 ## Before / After
 
 **Without** `azure-functions-logging` — plain `print()` output, no context, no structure:
@@ -102,11 +104,11 @@ Production output (NDJSON for Application Insights):
 
 > Every log carries `invocation_id` and `cold_start`. Queryable in Application Insights. Zero `print()` statements.
 
-> **Note:** The exact Application Insights schema depends on your ingestion pipeline. The queries below assume structured JSON fields appear in `customDimensions`.
+> **Note:** The exact Application Insights schema depends on your ingestion pipeline. In some deployments JSON fields are parsed into `customDimensions`; in others the JSON stays inside the `message` column. Examples for both shapes are below.
 
 ### Query in Application Insights
 
-Once your logs flow as structured JSON, query them in Application Insights:
+#### When JSON fields are parsed into `customDimensions`
 
 ```kql
 traces
@@ -120,6 +122,26 @@ Find all cold starts in the last hour:
 ```kql
 traces
 | where customDimensions.cold_start == "true"
+| where timestamp > ago(1h)
+| summarize count() by bin(timestamp, 5m)
+```
+
+#### When JSON remains in the `message` column
+
+```kql
+traces
+| extend payload = parse_json(message)
+| where tostring(payload.invocation_id) == "abc-123-def"
+| project timestamp, tostring(payload.message), tostring(payload.cold_start), tostring(payload.function_name)
+| order by timestamp asc
+```
+
+Find all cold starts in the last hour:
+
+```kql
+traces
+| extend payload = parse_json(message)
+| where tostring(payload.cold_start) == "true"
 | where timestamp > ago(1h)
 | summarize count() by bin(timestamp, 5m)
 ```
@@ -210,6 +232,8 @@ curl -s "https://<your-app>.azurewebsites.net/api/logme?correlation_id=demo-123"
 - `function_name` — the Azure Functions function name
 - `trace_id` — trace context from the platform
 - `cold_start` — `True` on first invocation of this worker process
+
+> **`cold_start` semantics.** `cold_start=True` means *the first invocation observed by this Python worker process after module load*. It is **not** a platform-level cold start metric and does not correspond to App Service plan / instance allocation cold starts reported by Azure Functions metrics. Subsequent invocations on the same worker emit `cold_start=False` until the worker is recycled.
 
 ```python
 def my_function(req, context):

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -173,6 +173,9 @@ Behavior:
 
 No manual state tracking needed.
 
+!!! note "What `cold_start` actually measures"
+    `cold_start=True` means *the first invocation observed by this Python worker process after module load*. It is **not** a platform-level cold start metric and does not correspond to App Service plan / instance allocation cold starts reported by Azure Functions metrics. The flag is process-global and flips back to `False` after the first `inject_context()` call on the worker.
+
 ### Example with Duration
 
 ```python


### PR DESCRIPTION
Closes #79

## Summary

P2 documentation accuracy fixes from the external review. Pure docs change — no source modifications.

### 1. Application Insights scope disclaimer (early in README)

Added a `Scope disclaimer` callout immediately after the **What it does** bullet list, before any KQL example. The previous "Application Insights-ready" framing was technically accurate but implicit — the disclaimer existed only midway through the README, after readers had already seen examples assuming `customDimensions` parsing.

The new disclaimer states plainly: this package writes structured JSON to Python `logging` / stdout. How those fields appear in Application Insights depends on the Azure Functions host, worker, logging configuration, and ingestion pipeline. The library does not own ingestion or schema mapping. Both `customDimensions`-parsed and raw-`message` shapes are valid in production.

### 2. `cold_start` semantics documented precisely

Added a callout in both **README** (`Invocation Context` section) and **docs/usage.md** (`Cold Start Detection` section):

> `cold_start=True` means *the first invocation observed by this Python worker process after module load*. It is **not** a platform-level cold start metric and does not correspond to App Service plan / instance allocation cold starts reported by Azure Functions metrics.

This matches the actual implementation: `_cold_start` is a process-global flag flipped on the first `inject_context()` call after module import. It is informational for log correlation, not a substitute for Azure metrics.

### 3. KQL examples split into both ingestion shapes

The README **Query in Application Insights** section now has two clearly labeled subsections:

- **When JSON fields are parsed into `customDimensions`** — the original queries.
- **When JSON remains in the `message` column** — same queries rewritten with `parse_json(message)` and `tostring(payload.<field>)`.

Both shapes occur in real Azure Functions deployments depending on the worker, host configuration, and Application Insights connection mode. Documenting only the parsed shape misled users whose payloads land as raw text.

## Validation

- `make lint` — clean (no source files touched, but README/docs changes verified through pre-commit hooks)
- `make test` — 142 passed, 3 skipped, 97.05% coverage
- No source changes; no behavior changes; no public API changes.

## Acceptance checklist (from #79)

- [x] README "Application Insights-ready" disclaimer added near the top
- [x] `cold_start` semantics documented in README and `docs/usage.md`
- [x] KQL examples split into both ingestion shapes
- [x] No code changes; pure docs PR