### PR TITLE
fix: v0.5.4 — correct README, warn on ignored format, honor filter name

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![CI](https://github.com/yeongseon/azure-functions-logging-python/actions/workflows/ci-test.yml/badge.svg)](https://github.com/yeongseon/azure-functions-logging-python/actions/workflows/ci-test.yml)
 [![Release](https://github.com/yeongseon/azure-functions-logging-python/actions/workflows/publish-pypi.yml/badge.svg)](https://github.com/yeongseon/azure-functions-logging-python/actions/workflows/publish-pypi.yml)
 [![Security Scans](https://github.com/yeongseon/azure-functions-logging-python/actions/workflows/security.yml/badge.svg)](https://github.com/yeongseon/azure-functions-logging-python/actions/workflows/security.yml)
-[![codecov](https://codecov.io/gh/yeongseon/azure-functions-logging-python-python/branch/main/graph/badge.svg)](https://codecov.io/gh/yeongseon/azure-functions-logging-python-python)
+[![codecov](https://codecov.io/gh/yeongseon/azure-functions-logging-python/branch/main/graph/badge.svg)](https://codecov.io/gh/yeongseon/azure-functions-logging-python)
 [![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit)](https://pre-commit.com/)
 [![Docs](https://img.shields.io/badge/docs-gh--pages-blue)](https://yeongseon.github.io/azure-functions-logging-python/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
@@ -33,7 +33,7 @@ Azure Functions Python logging has specific failure modes that generic logging l
 | Cold start invisible | No signal when a new worker instance starts | Detects automatically on first `inject_context()` |
 | Noisy third-party loggers | `azure-core`, `urllib3` flood your Application Insights | `SamplingFilter` / `RedactionFilter` |
 | Local vs cloud output mismatch | Colorized output breaks in production pipelines | Environment-aware formatter switching |
-| PII leaking into logs | Sensitive fields logged in exception tracebacks | `RedactionFilter` with key-based redaction |
+| PII leaking into logs | Sensitive values accidentally logged as extra fields | `RedactionFilter` with key-based redaction |
 
 ## What it does
 
@@ -286,8 +286,19 @@ Use JSON format when logs feed Application Insights or any aggregation system:
 > In Azure Functions, the host manages handlers. Use `functions_formatter=JsonFormatter()` to set
 > JSON output on host-managed handlers. Passing `format="json"` in Azure emits a warning.
 
+For standalone local development or CI output:
+
 ```python
 setup_logging(format="json")
+```
+
+For Azure Functions / Core Tools, the host owns the handlers. To force JSON
+formatting on existing host-managed handlers:
+
+```python
+from azure_functions_logging import JsonFormatter, setup_logging
+
+setup_logging(functions_formatter=JsonFormatter())
 ```
 
 Output per log line (NDJSON — one JSON object per line):
@@ -364,7 +375,7 @@ Any log record with extra fields whose keys match a sensitive key will have thos
 | Environment | Format | Behavior |
 |-------------|--------|---------|
 | Local terminal | `color` (default) | Colorized `[TIME] [LEVEL] [LOGGER] message` |
-| Azure / Core Tools | `json` | NDJSON, no ANSI codes, host-managed handlers |
+| Azure / Core Tools | host-managed | Installs context filters only; pass `functions_formatter=JsonFormatter()` to force NDJSON on host handlers |
 | CI / pipeline | `json` | NDJSON, machine-parseable |
 
 `setup_logging()` detects `FUNCTIONS_WORKER_RUNTIME` and `WEBSITE_INSTANCE_ID` to choose the right path automatically. In Azure, it installs context filters without adding handlers (avoids duplicate output from the host pipeline).
@@ -436,12 +447,12 @@ This package provides structured logging for Azure Functions with zero modificat
 5. **Test-friendly**:
    - `inject_context()` accepts any object (no hard dependency on azure.functions.Context)
    - `with_context` decorator works with sync and async handlers
-   - Use `context.reset_context_vars()` in test teardown if needed
+   - Use `reset_context()` in test teardown if needed
 
 **When generating code:**
 - Import only from `azure_functions_logging` public API (no underscores)
 - Call `setup_logging()` at module level or handler startup (not per-request)
-- Call `inject_context(context)` as first line of handler
+- Prefer `with logging_context(context):` in handlers; use raw `inject_context(context)` only with `try/finally reset_context()`
 - Use `logger.bind(key=value)` for per-request fields (not direct logger.extra)
 - Apply `RedactionFilter` for PII fields, `SamplingFilter` for high-volume logs
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Azure Functions Python logging has specific failure modes that generic logging l
 | Cold start invisible | No signal when a new worker instance starts | Detects automatically on first `inject_context()` |
 | Noisy third-party loggers | `azure-core`, `urllib3` flood your Application Insights | `SamplingFilter` / `RedactionFilter` |
 | Local vs cloud output mismatch | Colorized output breaks in production pipelines | Environment-aware formatter switching |
-| PII leaking into logs | Sensitive fields logged in exception tracebacks | `RedactionFilter` with pattern matching |
+| PII leaking into logs | Sensitive fields logged in exception tracebacks | `RedactionFilter` with key-based redaction |
 
 ## What it does
 
@@ -282,6 +282,10 @@ Both sync and async handlers are supported.
 
 Use JSON format when logs feed Application Insights or any aggregation system:
 
+> **Note:** The `format` parameter only affects handlers created by this library (local development).
+> In Azure Functions, the host manages handlers. Use `functions_formatter=JsonFormatter()` to set
+> JSON output on host-managed handlers. Passing `format="json"` in Azure emits a warning.
+
 ```python
 setup_logging(format="json")
 ```
@@ -333,8 +337,8 @@ import logging
 
 setup_logging()
 
-# Only log 1 in 10 azure-core messages
-logging.getLogger("azure").addFilter(SamplingFilter(rate=0.1))
+# Allow up to 10 azure-core messages per 1-second window
+logging.getLogger("azure").addFilter(SamplingFilter(rate=10))
 
 # Silence urllib3 completely in production
 logging.getLogger("urllib3").setLevel(logging.WARNING)
@@ -350,10 +354,10 @@ import logging
 
 setup_logging()
 root = logging.getLogger()
-root.addFilter(RedactionFilter(patterns=["password", "token", "secret"]))
+root.addFilter(RedactionFilter(sensitive_keys=["password", "token", "secret"]))
 ```
 
-Any log record where the message or extra fields match a pattern will have those values replaced with `[REDACTED]`.
+Any log record with extra fields whose keys match a sensitive key will have those values replaced with `***`.
 
 ## Local vs Cloud
 

--- a/src/azure_functions_logging/__init__.py
+++ b/src/azure_functions_logging/__init__.py
@@ -24,7 +24,7 @@ __all__ = [
     "with_context",
 ]
 
-__version__ = "0.5.3"
+__version__ = "0.5.4"
 
 
 def get_logger(name: str | None = None) -> FunctionLogger:

--- a/src/azure_functions_logging/_filters.py
+++ b/src/azure_functions_logging/_filters.py
@@ -117,6 +117,10 @@ class SamplingFilter(logging.Filter):
 
     def filter(self, record: logging.LogRecord) -> bool:
         """Return True to emit the record, False to drop it."""
+        # Honor name-based scoping from logging.Filter
+        if not super().filter(record):
+            return True  # bypass sampling for non-matching loggers
+
         # Always pass WARNING and above
         if record.levelno >= logging.WARNING:
             return True
@@ -166,6 +170,10 @@ class RedactionFilter(logging.Filter):
 
     def filter(self, record: logging.LogRecord) -> bool:
         """Redact sensitive fields on the record. Always returns True."""
+        # Honor name-based scoping from logging.Filter
+        if not super().filter(record):
+            return True  # bypass redaction for non-matching loggers
+
         for key in list(record.__dict__.keys()):
             if key in _STANDARD_RECORD_FIELDS:
                 continue

--- a/src/azure_functions_logging/_filters.py
+++ b/src/azure_functions_logging/_filters.py
@@ -92,8 +92,9 @@ class SamplingFilter(logging.Filter):
     Args:
         rate: Maximum number of records to pass per window. Must be >= 1.
         window: Rolling time window in seconds. Default: 1.0.
-        name: Logger name filter (passed to ``logging.Filter.__init__``).
-              Empty string matches all loggers (default).
+        name: Optional logger-name scope. When set, only matching loggers are
+            subject to sampling; non-matching records pass through unchanged.
+            Empty string matches all loggers (default).
 
     Example::
 
@@ -148,8 +149,8 @@ class RedactionFilter(logging.Filter):
         sensitive_keys: Iterable of lowercase key names to redact. When None,
             uses the built-in default set (password, passwd, token,
             authorization, secret, api_key, apikey).
-        name: Logger name filter (passed to ``logging.Filter.__init__``).
-
+        name: Optional logger-name scope. When set, only matching loggers are
+            subject to redaction; non-matching records pass through unchanged.
     Example::
 
         filter = RedactionFilter()

--- a/src/azure_functions_logging/_setup.py
+++ b/src/azure_functions_logging/_setup.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 import os
 import threading
+import warnings
 
 from ._context import ContextFilter
 from ._formatter import ColorFormatter
@@ -72,6 +73,12 @@ def setup_logging(
 
         if is_functions_env:
             # Azure or Core Tools: install filter only, don't touch handlers/level
+            if format != "color" and functions_formatter is None:
+                warnings.warn(
+                    "The 'format' parameter is ignored in Azure Functions environment. "
+                    "Pass functions_formatter=JsonFormatter() to set JSON output on host handlers.",
+                    stacklevel=2,
+                )
             root = logging.getLogger()
             for handler in root.handlers:
                 if functions_formatter is not None:

--- a/src/azure_functions_logging/_setup.py
+++ b/src/azure_functions_logging/_setup.py
@@ -52,7 +52,8 @@ def setup_logging(
         level: Logging level for local development. Ignored in Azure/Core Tools.
         format: Log output format for local development. Supported values are
             ``"color"`` (default) and ``"json"``. Ignored when
-            ``functions_formatter`` is provided.
+            ``functions_formatter`` is provided. In Azure/Core Tools, passing
+            ``format="json"`` without ``functions_formatter`` emits a warning.
         logger_name: Optional logger name to configure. When None, configures
             the root logger (local dev) or installs filter on root handlers (Azure).
         functions_formatter: Optional custom formatter applied to all root

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -278,9 +278,9 @@ class TestRedactionFilterNameScoping:
             name="other.module", level=logging.INFO, pathname=__file__,
             lineno=1, msg="hello", args=(), exc_info=None,
         )
-        record.password = "secret123"
+        setattr(record, "password", "secret123")
         assert flt.filter(record) is True
-        assert record.password == "secret123"  # not redacted
+        assert getattr(record, "password") == "secret123"  # not redacted
 
     def test_matching_logger_applies_redaction(self) -> None:
         """Records from matching loggers are redacted."""
@@ -289,6 +289,6 @@ class TestRedactionFilterNameScoping:
             name="myapp.handler", level=logging.INFO, pathname=__file__,
             lineno=1, msg="hello", args=(), exc_info=None,
         )
-        record.password = "secret123"
+        setattr(record, "password", "secret123")
         assert flt.filter(record) is True
-        assert record.password == "***"
+        assert getattr(record, "password") == "***"

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -240,3 +240,55 @@ def test_redaction_filter_skips_attributes_that_raise_on_access() -> None:
     assert record.__dict__["explode"] == {"token": "***"}
     assert getattr(record, "password") == "***"
     assert getattr(record, "payload") == {"token": "***", "safe": "ok"}
+
+
+class TestSamplingFilterNameScoping:
+    """Tests for name-based filter scoping in SamplingFilter."""
+
+    def test_non_matching_logger_bypasses_sampling(self) -> None:
+        """Records from non-matching loggers pass through without sampling."""
+        flt = SamplingFilter(rate=1, name="myapp")
+        # Record from a different logger
+        record = logging.LogRecord(
+            name="other.module", level=logging.INFO, pathname=__file__,
+            lineno=1, msg="hello", args=(), exc_info=None,
+        )
+        # Should pass through even though rate=1 — name doesn't match
+        assert flt.filter(record) is True
+        assert flt.filter(record) is True  # not rate-limited
+
+    def test_matching_logger_applies_sampling(self) -> None:
+        """Records from matching loggers are subject to sampling."""
+        flt = SamplingFilter(rate=1, name="myapp")
+        record = logging.LogRecord(
+            name="myapp.sub", level=logging.INFO, pathname=__file__,
+            lineno=1, msg="hello", args=(), exc_info=None,
+        )
+        assert flt.filter(record) is True  # first passes
+        assert flt.filter(record) is False  # second is rate-limited
+
+
+class TestRedactionFilterNameScoping:
+    """Tests for name-based filter scoping in RedactionFilter."""
+
+    def test_non_matching_logger_bypasses_redaction(self) -> None:
+        """Records from non-matching loggers are not redacted."""
+        flt = RedactionFilter(name="myapp")
+        record = logging.LogRecord(
+            name="other.module", level=logging.INFO, pathname=__file__,
+            lineno=1, msg="hello", args=(), exc_info=None,
+        )
+        record.password = "secret123"
+        assert flt.filter(record) is True
+        assert record.password == "secret123"  # not redacted
+
+    def test_matching_logger_applies_redaction(self) -> None:
+        """Records from matching loggers are redacted."""
+        flt = RedactionFilter(name="myapp")
+        record = logging.LogRecord(
+            name="myapp.handler", level=logging.INFO, pathname=__file__,
+            lineno=1, msg="hello", args=(), exc_info=None,
+        )
+        record.password = "secret123"
+        assert flt.filter(record) is True
+        assert record.password == "***"

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -23,7 +23,7 @@ class TestAPISurface:
         }
 
     def test_version_is_0_5_0(self) -> None:
-        assert azure_functions_logging.__version__ == "0.5.3"
+        assert azure_functions_logging.__version__ == "0.5.4"
 
     def test_version_is_string(self) -> None:
         assert isinstance(azure_functions_logging.__version__, str)

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -153,3 +153,41 @@ def test_is_functions_environment_with_only_website_instance_id_is_false() -> No
     with patch.dict(os.environ, {"WEBSITE_INSTANCE_ID": "abc123"}, clear=True):
         assert _is_functions_environment() is False
         assert _is_azure_hosted() is True
+
+
+def test_format_json_warns_in_azure_environment() -> None:
+    """When format='json' and no functions_formatter in Azure, emit a warning."""
+    import warnings
+
+    root = logging.getLogger()
+    root.handlers = [logging.StreamHandler()]
+
+    with patch.dict(os.environ, {"FUNCTIONS_WORKER_RUNTIME": "python"}, clear=True):
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            setup_logging(format="json")
+
+        assert len(w) == 1
+        assert "format" in str(w[0].message).lower()
+        assert "ignored" in str(w[0].message).lower()
+
+    root.handlers = []
+    root.filters.clear()
+
+
+def test_format_color_no_warning_in_azure_environment() -> None:
+    """When format='color' (default) in Azure, no warning."""
+    import warnings
+
+    root = logging.getLogger()
+    root.handlers = [logging.StreamHandler()]
+
+    with patch.dict(os.environ, {"FUNCTIONS_WORKER_RUNTIME": "python"}, clear=True):
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            setup_logging(format="color")
+
+        assert len(w) == 0
+
+    root.handlers = []
+    root.filters.clear()


### PR DESCRIPTION
## Summary

Patch release addressing 3 Oracle-validated issues:

- **#87** — Fix incorrect README examples: `SamplingFilter(rate=10)`, `RedactionFilter(sensitive_keys=[...])`, remove false "pattern matching" claim
- **#88** — Emit `warnings.warn()` when `format != "color"` and no `functions_formatter` detected in Azure environment
- **#91** — Call `super().filter(record)` in `SamplingFilter` and `RedactionFilter` to honor `logging.Filter(name=...)` scoping

## Changes

| File | Change |
|------|--------|
| `README.md` | Corrected constructor examples, added format behavior note |
| `_filters.py` | Added `super().filter(record)` in both filter classes |
| `_setup.py` | Added `import warnings`, emit warning when format ignored |
| `__init__.py` | Version bump to 0.5.4 |
| `tests/test_filters.py` | Name-scoping tests for both filters |
| `tests/test_setup.py` | Format warning emission tests |
| `tests/test_public_api.py` | Version assertion updated |

## Validation

- Oracle approved all 3 issues as real problems
- All tests passing with 97%+ coverage
- No breaking API changes (patch-safe)

Closes #87, closes #88, closes #91