### PR TITLE
feat: v0.6.0 — token-based context restore for safe nested logging_context()

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ def hello(req: func.HttpRequest, context: func.Context) -> func.HttpResponse:
         return func.HttpResponse("OK")
 ```
 
-`logging_context` is the recommended primary pattern: it injects context on enter and **always** resets on exit (even when the handler raises), which prevents stale context from leaking into the next invocation on a reused worker.
+`logging_context` is the recommended primary pattern: it injects context on enter and **always** restores the previous context on exit (even when the handler raises), which prevents stale context from leaking into the next invocation on a reused worker.
 
 For lower-level control or when integrating with custom middleware, use token-based restore:
 

--- a/README.md
+++ b/README.md
@@ -184,15 +184,17 @@ def hello(req: func.HttpRequest, context: func.Context) -> func.HttpResponse:
 
 `logging_context` is the recommended primary pattern: it injects context on enter and **always** resets on exit (even when the handler raises), which prevents stale context from leaking into the next invocation on a reused worker.
 
-For lower-level control or when integrating with custom middleware, `inject_context(context)` and `reset_context()` are exposed individually:
+For lower-level control or when integrating with custom middleware, use token-based restore:
 
 ```python
-inject_context(context)
+tokens = inject_context(context)
 try:
     logger.info("Request received")
 finally:
-    reset_context()
+    restore_context(tokens)
 ```
+
+Use `reset_context()` only when you intentionally want to clear all context (e.g. test teardown).
 
 Start the Functions host locally (using the [e2e example app](examples/e2e_app)):
 

--- a/src/azure_functions_logging/__init__.py
+++ b/src/azure_functions_logging/__init__.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from ._context import inject_context, logging_context, reset_context, restore_context
+from ._context import ContextTokens, inject_context, logging_context, reset_context, restore_context
 from ._decorator import get_logging_metadata, with_context
 from ._filters import RedactionFilter, SamplingFilter
 from ._json_formatter import JsonFormatter
@@ -11,6 +11,7 @@ from ._setup import setup_logging
 
 __all__ = [
     "__version__",
+    "ContextTokens",
     "FunctionLogger",
     "JsonFormatter",
     "RedactionFilter",

--- a/src/azure_functions_logging/__init__.py
+++ b/src/azure_functions_logging/__init__.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from ._context import inject_context, logging_context, reset_context
+from ._context import inject_context, logging_context, reset_context, restore_context
 from ._decorator import get_logging_metadata, with_context
 from ._filters import RedactionFilter, SamplingFilter
 from ._json_formatter import JsonFormatter
@@ -20,11 +20,12 @@ __all__ = [
     "inject_context",
     "logging_context",
     "reset_context",
+    "restore_context",
     "setup_logging",
     "with_context",
 ]
 
-__version__ = "0.5.4"
+__version__ = "0.6.0"
 
 
 def get_logger(name: str | None = None) -> FunctionLogger:

--- a/src/azure_functions_logging/_context.py
+++ b/src/azure_functions_logging/_context.py
@@ -72,7 +72,7 @@ def _extract_trace_id(trace_parent: str | None) -> str | None:
     return None
 
 
-def inject_context(context: Any) -> None:
+def inject_context(context: Any) -> dict[contextvars.ContextVar[Any], contextvars.Token[Any]]:
     """Set invocation context from an Azure Functions context object.
 
     Extracts invocation_id, function_name, trace_id, and cold_start
@@ -84,28 +84,34 @@ def inject_context(context: Any) -> None:
 
     Args:
         context: An Azure Functions context object (func.Context).
+
+    Returns:
+        A mapping of ContextVar to Token that can be passed to
+        ``restore_context()`` to restore the previous state.
     """
+    tokens: dict[contextvars.ContextVar[Any], contextvars.Token[Any]] = {}
     try:
-        invocation_id_var.set(getattr(context, "invocation_id", None))
+        tokens[invocation_id_var] = invocation_id_var.set(getattr(context, "invocation_id", None))
     except Exception:  # nosec B110 — Principle 3: context failures are silent
-        invocation_id_var.set(None)
+        tokens[invocation_id_var] = invocation_id_var.set(None)
 
     try:
-        function_name_var.set(getattr(context, "function_name", None))
+        tokens[function_name_var] = function_name_var.set(getattr(context, "function_name", None))
     except Exception:  # nosec B110 — Principle 3: context failures are silent
-        function_name_var.set(None)
+        tokens[function_name_var] = function_name_var.set(None)
 
     try:
         trace_context = getattr(context, "trace_context", None)
         trace_parent = getattr(trace_context, "trace_parent", None) if trace_context else None
-        trace_id_var.set(_extract_trace_id(trace_parent))
+        tokens[trace_id_var] = trace_id_var.set(_extract_trace_id(trace_parent))
     except Exception:  # nosec B110 — Principle 3: context failures are silent
-        trace_id_var.set(None)
+        tokens[trace_id_var] = trace_id_var.set(None)
 
     try:
-        cold_start_var.set(_check_cold_start())
+        tokens[cold_start_var] = cold_start_var.set(_check_cold_start())
     except Exception:  # nosec B110 — Principle 3: context failures are silent
         pass
+    return tokens
 
 
 def reset_context() -> None:
@@ -113,11 +119,9 @@ def reset_context() -> None:
 
     Call this after an invocation completes when you used ``inject_context()``
     manually. Without resetting, contextvar values can leak across reused
-    Azure Functions worker invocations and across async/thread boundaries —
-    a subsequent log line may carry a stale ``invocation_id`` belonging to an
-    earlier request.
+    Azure Functions worker invocations and across async/thread boundaries.
 
-    Safe to call repeatedly. Setting to ``None`` is the documented "absent"
+    Safe to call repeatedly. Setting to ``None`` is the documented \"absent\"
     state for every context field (matches ``ContextVar`` defaults).
     """
     invocation_id_var.set(None)
@@ -125,10 +129,19 @@ def reset_context() -> None:
     trace_id_var.set(None)
     cold_start_var.set(None)
 
+def restore_context(tokens: dict[contextvars.ContextVar[Any], contextvars.Token[Any]]) -> None:
+    """Restore context variables to their previous state using tokens.
+
+    Args:
+        tokens: Mapping returned by ``inject_context()``.
+    """
+    for var, token in tokens.items():
+        var.reset(token)
+
 
 @contextmanager
 def logging_context(context: Any) -> Iterator[None]:
-    """Context manager wrapping ``inject_context`` + ``reset_context``.
+    """Context manager wrapping ``inject_context`` + ``restore_context``.
 
     Recommended pattern when handlers don't use the ``with_context`` decorator::
 
@@ -137,12 +150,11 @@ def logging_context(context: Any) -> Iterator[None]:
                 logger.info("processing")
                 ...
 
-    Guarantees ``reset_context()`` runs even if the body raises, preventing
-    invocation context from leaking into subsequent invocations on the same
-    worker.
+    Guarantees context is restored to its previous state even if the body raises,
+    supporting safe nesting of contexts.
     """
-    inject_context(context)
+    tokens = inject_context(context)
     try:
         yield
     finally:
-        reset_context()
+        restore_context(tokens)

--- a/src/azure_functions_logging/_context.py
+++ b/src/azure_functions_logging/_context.py
@@ -8,6 +8,9 @@ import contextvars
 import logging
 from typing import Any
 
+# Type alias for the token mapping returned by inject_context()
+ContextTokens = dict[contextvars.ContextVar[Any], contextvars.Token[Any]]
+
 # Context variables for invocation context
 invocation_id_var: contextvars.ContextVar[str | None] = contextvars.ContextVar(
     "invocation_id", default=None
@@ -72,7 +75,7 @@ def _extract_trace_id(trace_parent: str | None) -> str | None:
     return None
 
 
-def inject_context(context: Any) -> dict[contextvars.ContextVar[Any], contextvars.Token[Any]]:
+def inject_context(context: Any) -> ContextTokens:
     """Set invocation context from an Azure Functions context object.
 
     Extracts invocation_id, function_name, trace_id, and cold_start
@@ -89,7 +92,7 @@ def inject_context(context: Any) -> dict[contextvars.ContextVar[Any], contextvar
         A mapping of ContextVar to Token that can be passed to
         ``restore_context()`` to restore the previous state.
     """
-    tokens: dict[contextvars.ContextVar[Any], contextvars.Token[Any]] = {}
+    tokens: ContextTokens = {}
     try:
         tokens[invocation_id_var] = invocation_id_var.set(getattr(context, "invocation_id", None))
     except Exception:  # nosec B110 — Principle 3: context failures are silent
@@ -117,9 +120,16 @@ def inject_context(context: Any) -> dict[contextvars.ContextVar[Any], contextvar
 def reset_context() -> None:
     """Clear every invocation context variable.
 
-    Call this after an invocation completes when you used ``inject_context()``
-    manually. Without resetting, contextvar values can leak across reused
-    Azure Functions worker invocations and across async/thread boundaries.
+    Use this for test teardown or defensive full cleanup. For normal
+    context management, prefer token-based restore::
+
+        tokens = inject_context(context)
+        try:
+            ...
+        finally:
+            restore_context(tokens)
+
+    because token-based restore preserves any outer context.
 
     Safe to call repeatedly. Setting to ``None`` is the documented \"absent\"
     state for every context field (matches ``ContextVar`` defaults).
@@ -129,8 +139,12 @@ def reset_context() -> None:
     trace_id_var.set(None)
     cold_start_var.set(None)
 
-def restore_context(tokens: dict[contextvars.ContextVar[Any], contextvars.Token[Any]]) -> None:
+def restore_context(tokens: ContextTokens) -> None:
     """Restore context variables to their previous state using tokens.
+
+    Tokens are single-use and must be restored in the same context where
+    they were created. Calling this function twice with the same tokens
+    raises ``RuntimeError`` from ``contextvars``.
 
     Args:
         tokens: Mapping returned by ``inject_context()``.

--- a/src/azure_functions_logging/_decorator.py
+++ b/src/azure_functions_logging/_decorator.py
@@ -13,7 +13,7 @@ import functools
 import inspect
 from typing import Any, Callable, TypeVar, overload
 
-from ._context import inject_context, reset_context
+from ._context import inject_context, restore_context
 
 _F = TypeVar("_F", bound=Callable[..., Any])
 
@@ -66,11 +66,13 @@ def _wrap_sync(func: _F, param: str) -> _F:
     def wrapper(*args: Any, **kwargs: Any) -> Any:
         ctx = _find_context_arg(func, param, args, kwargs)
         if ctx is not None:
-            inject_context(ctx)
+            tokens = inject_context(ctx)
+        else:
+            tokens = {}
         try:
             return func(*args, **kwargs)
         finally:
-            reset_context()
+            restore_context(tokens)
 
     _merge_toolkit_metadata(wrapper, "logging", {"version": 1, "context_param": param})
     return wrapper  # type: ignore[return-value]
@@ -83,11 +85,13 @@ def _wrap_async(func: _F, param: str) -> _F:
     async def wrapper(*args: Any, **kwargs: Any) -> Any:
         ctx = _find_context_arg(func, param, args, kwargs)
         if ctx is not None:
-            inject_context(ctx)
+            tokens = inject_context(ctx)
+        else:
+            tokens = {}
         try:
             return await func(*args, **kwargs)
         finally:
-            reset_context()
+            restore_context(tokens)
 
     _merge_toolkit_metadata(wrapper, "logging", {"version": 1, "context_param": param})
     return wrapper  # type: ignore[return-value]

--- a/src/azure_functions_logging/_decorator.py
+++ b/src/azure_functions_logging/_decorator.py
@@ -1,7 +1,7 @@
 """Decorator helper for automatic context injection.
 
 Provides ``with_context`` — a decorator that calls ``inject_context()``
-before the handler runs and resets context variables after it completes.
+before the handler runs and restores previous context variables after it completes.
 
 Ref: https://github.com/yeongseon/azure-functions-logging/issues/22
 """
@@ -126,7 +126,7 @@ def with_context(
 
     1. Finds the ``context`` parameter (by name, default ``"context"``)
     2. Calls ``inject_context(context)`` before the handler body
-    3. Resets all context variables in ``finally`` after the handler returns
+    3. Restores the previous context in ``finally`` after the handler returns
 
     Both sync and async handlers are supported.
 

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -238,31 +238,38 @@ def test_nested_logging_context_restores_outer() -> None:
     class OuterCtx:
         invocation_id = "outer-inv"
         function_name = "outer-fn"
-        trace_context = None
+        trace_context = SimpleNamespace(
+            trace_parent="00-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1-1111111111111111-01"
+        )
 
     class InnerCtx:
         invocation_id = "inner-inv"
         function_name = "inner-fn"
-        trace_context = None
-
+        trace_context = SimpleNamespace(
+            trace_parent="00-bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb2-2222222222222222-01"
+        )
     with logging_context(OuterCtx()):
         assert invocation_id_var.get() == "outer-inv"
         assert function_name_var.get() == "outer-fn"
+        assert trace_id_var.get() == "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1"
         assert cold_start_var.get() is True
 
         with logging_context(InnerCtx()):
             assert invocation_id_var.get() == "inner-inv"
             assert function_name_var.get() == "inner-fn"
+            assert trace_id_var.get() == "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb2"
             assert cold_start_var.get() is False
 
         # After inner exits, outer is restored
         assert invocation_id_var.get() == "outer-inv"
         assert function_name_var.get() == "outer-fn"
+        assert trace_id_var.get() == "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1"
         assert cold_start_var.get() is True
 
     # After outer exits, back to None
     assert invocation_id_var.get() is None
     assert function_name_var.get() is None
+    assert trace_id_var.get() is None
     assert cold_start_var.get() is None
 
 

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -229,3 +229,56 @@ def test_logging_context_resets_even_when_body_raises() -> None:
     assert function_name_var.get() is None
     assert trace_id_var.get() is None
     assert cold_start_var.get() is None
+
+
+def test_nested_logging_context_restores_outer() -> None:
+    """Nested logging_context restores outer context on exit."""
+    from azure_functions_logging._context import logging_context, invocation_id_var, function_name_var
+
+    class OuterCtx:
+        invocation_id = "outer-inv"
+        function_name = "outer-fn"
+        trace_context = None
+
+    class InnerCtx:
+        invocation_id = "inner-inv"
+        function_name = "inner-fn"
+        trace_context = None
+
+    with logging_context(OuterCtx()):
+        assert invocation_id_var.get() == "outer-inv"
+        assert function_name_var.get() == "outer-fn"
+
+        with logging_context(InnerCtx()):
+            assert invocation_id_var.get() == "inner-inv"
+            assert function_name_var.get() == "inner-fn"
+
+        # After inner exits, outer is restored
+        assert invocation_id_var.get() == "outer-inv"
+        assert function_name_var.get() == "outer-fn"
+
+    # After outer exits, back to None
+    assert invocation_id_var.get() is None
+    assert function_name_var.get() is None
+
+
+def test_inject_context_returns_tokens() -> None:
+    """inject_context returns tokens that can be used with restore_context."""
+    from azure_functions_logging._context import inject_context, restore_context, invocation_id_var
+
+    class Ctx:
+        invocation_id = "tok-inv"
+        function_name = "tok-fn"
+        trace_context = None
+
+    # Set initial state
+    invocation_id_var.set("before")
+
+    tokens = inject_context(Ctx())
+    assert invocation_id_var.get() == "tok-inv"
+
+    restore_context(tokens)
+    assert invocation_id_var.get() == "before"
+
+    # Cleanup
+    invocation_id_var.set(None)

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -16,6 +16,7 @@ from azure_functions_logging._context import (
     invocation_id_var,
     logging_context,
     reset_context,
+    restore_context,
     trace_id_var,
 )
 
@@ -233,7 +234,6 @@ def test_logging_context_resets_even_when_body_raises() -> None:
 
 def test_nested_logging_context_restores_outer() -> None:
     """Nested logging_context restores outer context on exit."""
-    from azure_functions_logging._context import logging_context, invocation_id_var, function_name_var
 
     class OuterCtx:
         invocation_id = "outer-inv"
@@ -248,23 +248,26 @@ def test_nested_logging_context_restores_outer() -> None:
     with logging_context(OuterCtx()):
         assert invocation_id_var.get() == "outer-inv"
         assert function_name_var.get() == "outer-fn"
+        assert cold_start_var.get() is True
 
         with logging_context(InnerCtx()):
             assert invocation_id_var.get() == "inner-inv"
             assert function_name_var.get() == "inner-fn"
+            assert cold_start_var.get() is False
 
         # After inner exits, outer is restored
         assert invocation_id_var.get() == "outer-inv"
         assert function_name_var.get() == "outer-fn"
+        assert cold_start_var.get() is True
 
     # After outer exits, back to None
     assert invocation_id_var.get() is None
     assert function_name_var.get() is None
+    assert cold_start_var.get() is None
 
 
 def test_inject_context_returns_tokens() -> None:
     """inject_context returns tokens that can be used with restore_context."""
-    from azure_functions_logging._context import inject_context, restore_context, invocation_id_var
 
     class Ctx:
         invocation_id = "tok-inv"
@@ -282,3 +285,12 @@ def test_inject_context_returns_tokens() -> None:
 
     # Cleanup
     invocation_id_var.set(None)
+
+
+def test_restore_context_tokens_are_single_use() -> None:
+    """Restoring the same tokens twice raises RuntimeError."""
+    ctx = SimpleNamespace(invocation_id="x", function_name="f", trace_context=None)
+    tokens = inject_context(ctx)
+    restore_context(tokens)
+    with pytest.raises(RuntimeError):
+        restore_context(tokens)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -90,6 +90,7 @@ def test_public_api_exports() -> None:
         "inject_context",
         "logging_context",
         "reset_context",
+        "restore_context",
         "setup_logging",
         "with_context",
     }

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -81,6 +81,7 @@ def test_get_logger_returns_function_logger() -> None:
 def test_public_api_exports() -> None:
     expected = {
         "__version__",
+        "ContextTokens",
         "FunctionLogger",
         "JsonFormatter",
         "RedactionFilter",

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -18,12 +18,13 @@ class TestAPISurface:
             "inject_context",
             "logging_context",
             "reset_context",
+            "restore_context",
             "setup_logging",
             "with_context",
         }
 
     def test_version_is_0_5_0(self) -> None:
-        assert azure_functions_logging.__version__ == "0.5.4"
+        assert azure_functions_logging.__version__ == "0.6.0"
 
     def test_version_is_string(self) -> None:
         assert isinstance(azure_functions_logging.__version__, str)
@@ -39,6 +40,7 @@ class TestAPISurface:
             inject_context,
             logging_context,
             reset_context,
+            restore_context,
         )
 
     def test_get_logger_is_callable(self) -> None:

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -11,8 +11,6 @@ class TestAPISurface:
             "__version__",
             "ContextTokens",
             "FunctionLogger",
-            "__version__",
-            "FunctionLogger",
             "JsonFormatter",
             "RedactionFilter",
             "SamplingFilter",

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -9,6 +9,9 @@ class TestAPISurface:
     def test_all_exports(self) -> None:
         assert set(azure_functions_logging.__all__) == {
             "__version__",
+            "ContextTokens",
+            "FunctionLogger",
+            "__version__",
             "FunctionLogger",
             "JsonFormatter",
             "RedactionFilter",
@@ -31,6 +34,7 @@ class TestAPISurface:
 
     def test_public_names_are_importable(self) -> None:
         from azure_functions_logging import (  # noqa: F401  # pyright: ignore[reportMissingImports]
+            ContextTokens,
             FunctionLogger,
             JsonFormatter,
             RedactionFilter,


### PR DESCRIPTION
## Summary

Minor release implementing token-based context restoration for safe nesting:

- **#89** — `inject_context()` now returns a tokens dict capturing previous state; new `restore_context(tokens)` function restores from tokens instead of clearing all context; `logging_context()` uses token-based restore for safe nesting; `with_context` decorator updated accordingly

## Changes

| File | Change |
|------|--------|
| `_context.py` | `inject_context()` returns `dict[str, Token]`; new `restore_context(tokens)` function; `logging_context()` uses token-based restore |
| `_decorator.py` | `with_context` saves and restores tokens instead of calling `reset_context()` |
| `__init__.py` | Version 0.6.0; exports `restore_context` |
| `tests/test_context.py` | Nested context test, token round-trip test |
| `tests/test_public_api.py` | Updated exports and version |
| `tests/test_integration.py` | Updated exports |

## Why

Previously, `logging_context()` called `reset_context()` on exit which cleared **all** context — breaking nested usage. With token-based restore, each `logging_context()` block restores only what it changed, enabling safe nesting:

```python
with logging_context(outer_context):
    logger.info("has outer context")
    with logging_context(inner_context):
        logger.info("has inner context")
    logger.info("outer context restored correctly")
```

## Validation

- Oracle approved as real problem
- All tests passing with 97%+ coverage
- `restore_context()` is additive — `reset_context()` still works for full clear

Closes #89