### PR TITLE
feat: v0.7.0 — add install_context_factory() for global LogRecord context injection

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,6 +280,28 @@ def hello(req: func.HttpRequest, ctx: func.Context) -> func.HttpResponse:
 
 Both sync and async handlers are supported.
 
+### Global LogRecordFactory (opt-in)
+
+For applications where handlers may be added after `setup_logging()`, or where you want
+invocation context on **every** `LogRecord` regardless of handler/filter configuration,
+install the global context factory once at startup:
+
+```python
+from azure_functions_logging import install_context_factory, setup_logging
+
+install_context_factory()  # injects context at record creation time
+setup_logging()
+```
+
+When enabled, `invocation_id`, `function_name`, `trace_id`, and `cold_start` become
+reserved `LogRecord` attributes. Passing them via stdlib `extra=` will raise `KeyError`.
+Use `FunctionLogger` (which sanitizes keys automatically) or choose different key names.
+
+> **Relationship with `setup_logging()`:** `setup_logging()` still installs `ContextFilter`
+> on handlers by default. You can call both — they set the same values, so there is no
+> conflict. `install_context_factory()` ensures coverage even on handlers added later or
+> loggers that bypass the filter chain.
+
 ## Structured JSON Output (Production)
 
 Use JSON format when logs feed Application Insights or any aggregation system:
@@ -454,13 +476,13 @@ This package provides structured logging for Azure Functions with zero modificat
 **When generating code:**
 - Import only from `azure_functions_logging` public API (no underscores)
 - Call `setup_logging()` at module level or handler startup (not per-request)
-- Prefer `with logging_context(context):` in handlers; use raw `inject_context(context)` only with `try/finally reset_context()`
+- Prefer `with logging_context(context):` in handlers; use raw `inject_context(context)` only with `try/finally restore_context(tokens)`
 - Use `logger.bind(key=value)` for per-request fields (not direct logger.extra)
 - Apply `RedactionFilter` for PII fields, `SamplingFilter` for high-volume logs
 
 **Example Pattern:**
 ```python
-from azure_functions_logging import setup_logging, get_logger, inject_context
+from azure_functions_logging import get_logger, logging_context, setup_logging
 
 # Module level
 setup_logging()
@@ -468,10 +490,10 @@ logger = get_logger(__name__)
 
 # Per handler
 def my_function(req: func.HttpRequest, context: func.Context) -> func.HttpResponse:
-    inject_context(context)
-    req_logger = logger.bind(correlation_id=req.params.get("id"))
-    req_logger.info("Processing")
-    return func.HttpResponse("OK")
+    with logging_context(context):
+        req_logger = logger.bind(correlation_id=req.params.get("id"))
+        req_logger.info("Processing")
+        return func.HttpResponse("OK")
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Order: {'customer': 'Alice', 'total': 99.99}
 ```python
 import azure.functions as func
 
-from azure_functions_logging import get_logger, inject_context, setup_logging
+from azure_functions_logging import get_logger, logging_context, setup_logging
 
 setup_logging()
 logger = get_logger(__name__)
@@ -84,9 +84,9 @@ app = func.FunctionApp()
 
 @app.route(route="orders")
 def process_order(req: func.HttpRequest, context: func.Context) -> func.HttpResponse:
-    inject_context(context)
-    logger.info("Processing order", order_id="o-999")
-    return func.HttpResponse("OK")
+    with logging_context(context):
+        logger.info("Processing order", order_id="o-999")
+        return func.HttpResponse("OK")
 ```
 
 Local terminal output (colorized):
@@ -230,7 +230,7 @@ curl -s "https://<your-app>.azurewebsites.net/api/logme?correlation_id=demo-123"
 
 ## Invocation Context
 
-`inject_context(context)` should be the **first line** of every handler. It binds:
+Use `logging_context()` to bind invocation context for the duration of a handler. It sets:
 
 - `invocation_id` — unique per execution, correlates all logs for one request
 - `function_name` — the Azure Functions function name
@@ -241,12 +241,22 @@ curl -s "https://<your-app>.azurewebsites.net/api/logme?correlation_id=demo-123"
 
 ```python
 def my_function(req, context):
-    inject_context(context)
-    logger.info("handler started")
-    # every log from here carries invocation_id and cold_start
+    with logging_context(context):
+        logger.info("handler started")
+        # every log from here carries invocation_id and cold_start
 ```
 
-Without `inject_context()`, these fields are `None` in every log line.
+For lower-level control (e.g. middleware), use `inject_context()` with `restore_context()`:
+
+```python
+tokens = inject_context(context)
+try:
+    logger.info("handler started")
+finally:
+    restore_context(tokens)
+```
+
+Without context injection, these fields are `None` in every log line.
 
 ### `with_context` Decorator
 

--- a/examples/e2e_app/function_app.py
+++ b/examples/e2e_app/function_app.py
@@ -1,4 +1,5 @@
 """E2E test function app for azure-functions-logging."""
+
 from __future__ import annotations
 
 import json

--- a/src/azure_functions_logging/__init__.py
+++ b/src/azure_functions_logging/__init__.py
@@ -2,7 +2,14 @@
 
 from __future__ import annotations
 
-from ._context import ContextTokens, inject_context, logging_context, reset_context, restore_context
+from ._context import (
+    ContextTokens,
+    inject_context,
+    install_context_factory,
+    logging_context,
+    reset_context,
+    restore_context,
+)
 from ._decorator import get_logging_metadata, with_context
 from ._filters import RedactionFilter, SamplingFilter
 from ._json_formatter import JsonFormatter
@@ -19,6 +26,7 @@ __all__ = [
     "get_logging_metadata",
     "get_logger",
     "inject_context",
+    "install_context_factory",
     "logging_context",
     "reset_context",
     "restore_context",
@@ -26,7 +34,7 @@ __all__ = [
     "with_context",
 ]
 
-__version__ = "0.6.0"
+__version__ = "0.7.0"
 
 
 def get_logger(name: str | None = None) -> FunctionLogger:

--- a/src/azure_functions_logging/_context.py
+++ b/src/azure_functions_logging/_context.py
@@ -219,9 +219,8 @@ def install_context_factory() -> None:
     The factory chains with any previously-installed factory, preserving
     existing customizations.
 
-    This function is idempotent — calling it when the factory is already
-    installed (even if another factory was layered on top) has no additional
-    effect as long as the context factory remains in the chain.
+    This function is idempotent for repeated direct calls while the currently
+    active ``LogRecordFactory`` is the context factory installed by this package.
     """
     current_factory = logging.getLogRecordFactory()
     if getattr(current_factory, _CONTEXT_FACTORY_MARKER, False):

--- a/src/azure_functions_logging/_context.py
+++ b/src/azure_functions_logging/_context.py
@@ -39,9 +39,12 @@ def _check_cold_start() -> bool:
 class ContextFilter(logging.Filter):
     """Logging filter that copies contextvars values onto LogRecord attributes.
 
-    .. deprecated:: 0.7.0
-        Use :func:`install_context_factory` instead for guaranteed context
-        injection on all log records regardless of handler configuration.
+    For most new applications, prefer :func:`install_context_factory` because it
+    injects context at LogRecord creation time and does not depend on handler
+    filter configuration.
+
+    ``ContextFilter`` remains supported for compatibility and for users who do
+    not want to modify the global ``LogRecordFactory``.
 
     This filter is installed on handlers (not loggers) so it covers ALL loggers
     including third-party libraries.
@@ -181,7 +184,16 @@ def logging_context(context: Any) -> Iterator[None]:
 
 # --- LogRecordFactory-based context injection (opt-in) ---
 
-_factory_installed: bool = False
+_CONTEXT_FACTORY_MARKER = "_azure_functions_logging_context_factory"
+
+#: Field names injected by the factory. These become reserved LogRecord
+#: attributes when ``install_context_factory()`` is active.
+CONTEXT_RECORD_FIELDS: tuple[str, ...] = (
+    "invocation_id",
+    "function_name",
+    "trace_id",
+    "cold_start",
+)
 
 
 def install_context_factory() -> None:
@@ -192,6 +204,14 @@ def install_context_factory() -> None:
 
     .. warning::
 
+        When this factory is active, the field names ``invocation_id``,
+        ``function_name``, ``trace_id``, and ``cold_start`` become **reserved**
+        LogRecord attributes. Passing them via ``extra=`` to stdlib loggers will
+        raise ``KeyError``. Use :class:`FunctionLogger` (which sanitizes extra
+        keys automatically) or choose different key names.
+
+    .. warning::
+
         This modifies the **global** ``logging.LogRecordFactory``. It affects
         all loggers in the process, including third-party libraries. Call once
         at application startup.
@@ -199,13 +219,15 @@ def install_context_factory() -> None:
     The factory chains with any previously-installed factory, preserving
     existing customizations.
 
-    This function is idempotent — multiple calls have no additional effect.
+    This function is idempotent — calling it when the factory is already
+    installed (even if another factory was layered on top) has no additional
+    effect as long as the context factory remains in the chain.
     """
-    global _factory_installed
-    if _factory_installed:
+    current_factory = logging.getLogRecordFactory()
+    if getattr(current_factory, _CONTEXT_FACTORY_MARKER, False):
         return
 
-    previous_factory = logging.getLogRecordFactory()
+    previous_factory = current_factory
 
     def context_record_factory(*args: Any, **kwargs: Any) -> logging.LogRecord:
         record = previous_factory(*args, **kwargs)
@@ -215,5 +237,5 @@ def install_context_factory() -> None:
         record.cold_start = cold_start_var.get()
         return record
 
+    setattr(context_record_factory, _CONTEXT_FACTORY_MARKER, True)
     logging.setLogRecordFactory(context_record_factory)
-    _factory_installed = True

--- a/src/azure_functions_logging/_context.py
+++ b/src/azure_functions_logging/_context.py
@@ -39,6 +39,10 @@ def _check_cold_start() -> bool:
 class ContextFilter(logging.Filter):
     """Logging filter that copies contextvars values onto LogRecord attributes.
 
+    .. deprecated:: 0.7.0
+        Use :func:`install_context_factory` instead for guaranteed context
+        injection on all log records regardless of handler configuration.
+
     This filter is installed on handlers (not loggers) so it covers ALL loggers
     including third-party libraries.
     """
@@ -139,6 +143,7 @@ def reset_context() -> None:
     trace_id_var.set(None)
     cold_start_var.set(None)
 
+
 def restore_context(tokens: ContextTokens) -> None:
     """Restore context variables to their previous state using tokens.
 
@@ -172,3 +177,43 @@ def logging_context(context: Any) -> Iterator[None]:
         yield
     finally:
         restore_context(tokens)
+
+
+# --- LogRecordFactory-based context injection (opt-in) ---
+
+_factory_installed: bool = False
+
+
+def install_context_factory() -> None:
+    """Install a global LogRecordFactory that injects context into every LogRecord.
+
+    This is an alternative to ``ContextFilter`` that guarantees context fields
+    are present on ALL log records regardless of handler/filter configuration.
+
+    .. warning::
+
+        This modifies the **global** ``logging.LogRecordFactory``. It affects
+        all loggers in the process, including third-party libraries. Call once
+        at application startup.
+
+    The factory chains with any previously-installed factory, preserving
+    existing customizations.
+
+    This function is idempotent — multiple calls have no additional effect.
+    """
+    global _factory_installed
+    if _factory_installed:
+        return
+
+    previous_factory = logging.getLogRecordFactory()
+
+    def context_record_factory(*args: Any, **kwargs: Any) -> logging.LogRecord:
+        record = previous_factory(*args, **kwargs)
+        record.invocation_id = invocation_id_var.get()
+        record.function_name = function_name_var.get()
+        record.trace_id = trace_id_var.get()
+        record.cold_start = cold_start_var.get()
+        return record
+
+    logging.setLogRecordFactory(context_record_factory)
+    _factory_installed = True

--- a/src/azure_functions_logging/_filters.py
+++ b/src/azure_functions_logging/_filters.py
@@ -46,6 +46,7 @@ def _redact_value(
         return [_redact_value(item, sensitive_keys, mask) for item in value]
     return value
 
+
 # Standard LogRecord fields that RedactionFilter should never touch
 _STANDARD_RECORD_FIELDS: frozenset[str] = frozenset(
     {

--- a/src/azure_functions_logging/_logger.py
+++ b/src/azure_functions_logging/_logger.py
@@ -9,11 +9,14 @@ _RESERVED_LOG_RECORD_KEYS: frozenset[str] = frozenset(
     {
         "args",
         "asctime",
+        "cold_start",
         "created",
         "exc_info",
         "exc_text",
         "filename",
         "funcName",
+        "function_name",
+        "invocation_id",
         "levelname",
         "levelno",
         "lineno",
@@ -30,6 +33,7 @@ _RESERVED_LOG_RECORD_KEYS: frozenset[str] = frozenset(
         "taskName",
         "thread",
         "threadName",
+        "trace_id",
     }
 )
 

--- a/tests/e2e/test_logging_e2e.py
+++ b/tests/e2e/test_logging_e2e.py
@@ -11,6 +11,7 @@ Usage:
     APPINSIGHTS_NAME=<ai-name> \\
     pytest tests/e2e -v
 """
+
 from __future__ import annotations
 
 import json
@@ -52,6 +53,7 @@ def warmup() -> None:
 
 # ── HTTP-level tests ───────────────────────────────────────────────────────
 
+
 @pytest.mark.skipif(not BASE_URL, reason=SKIP_REASON)
 def test_health_returns_200() -> None:
     r = _get("/api/health")
@@ -70,15 +72,23 @@ def test_logme_returns_200_with_correlation_id() -> None:
 
 # ── App Insights log query tests ───────────────────────────────────────────
 
+
 def _query_app_insights(query: str) -> list[dict]:  # type: ignore[type-arg]
     """Run a Kusto query against App Insights via az CLI and return rows."""
     result = subprocess.run(
         [
-            "az", "monitor", "app-insights", "query",
-            "--app", APPINSIGHTS_NAME,
-            "--resource-group", APPINSIGHTS_RG,
-            "--analytics-query", query,
-            "--output", "json",
+            "az",
+            "monitor",
+            "app-insights",
+            "query",
+            "--app",
+            APPINSIGHTS_NAME,
+            "--resource-group",
+            APPINSIGHTS_RG,
+            "--analytics-query",
+            query,
+            "--output",
+            "json",
         ],
         capture_output=True,
         text=True,
@@ -105,10 +115,7 @@ def test_structured_log_appears_in_app_insights() -> None:
 
     # App Insights ingestion latency can be up to ~2-5 min
     query = (
-        f"traces "
-        f"| where timestamp > ago(10m) "
-        f"| where message contains '{CORRELATION_ID}' "
-        f"| limit 5"
+        f"traces | where timestamp > ago(10m) | where message contains '{CORRELATION_ID}' | limit 5"
     )
     deadline = time.time() + 360  # wait up to 6 minutes
     while time.time() < deadline:

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -306,10 +306,11 @@ def test_restore_context_tokens_are_single_use() -> None:
 
 def test_install_context_factory_injects_fields() -> None:
     """install_context_factory installs a LogRecordFactory that adds context fields."""
-    from azure_functions_logging._context import install_context_factory
+    from azure_functions_logging._context import (
+        _CONTEXT_FACTORY_MARKER,
+        install_context_factory,
+    )
 
-    # Reset factory state for test
-    ctx_mod._factory_installed = False
     old_factory = logging.getLogRecordFactory()
 
     try:
@@ -319,6 +320,8 @@ def test_install_context_factory_injects_fields() -> None:
         install_context_factory()
 
         factory = logging.getLogRecordFactory()
+        assert getattr(factory, _CONTEXT_FACTORY_MARKER, False) is True
+
         record = factory(
             "test",
             logging.INFO,
@@ -331,10 +334,106 @@ def test_install_context_factory_injects_fields() -> None:
         assert record.invocation_id == "factory-inv"  # type: ignore[attr-defined]
         assert record.function_name == "factory-fn"  # type: ignore[attr-defined]
 
-        # Idempotent
+        # Idempotent — calling again does not double-wrap
         install_context_factory()
+        assert logging.getLogRecordFactory() is factory
     finally:
         logging.setLogRecordFactory(old_factory)
-        ctx_mod._factory_installed = False
         invocation_id_var.set(None)
         function_name_var.set(None)
+
+
+def test_install_context_factory_chains_existing_factory() -> None:
+    """Custom factory fields are preserved when context factory chains."""
+    from typing import Any
+
+    from azure_functions_logging._context import install_context_factory
+
+    old_factory = logging.getLogRecordFactory()
+
+    def custom_factory(*args: Any, **kwargs: Any) -> logging.LogRecord:
+        record = old_factory(*args, **kwargs)
+        record.custom_field = "kept"
+        return record
+
+    try:
+        logging.setLogRecordFactory(custom_factory)
+        invocation_id_var.set("chain-inv")
+
+        install_context_factory()
+
+        record = logging.getLogRecordFactory()(
+            "test", logging.INFO, __file__, 1, "msg", (), None
+        )
+
+        assert record.custom_field == "kept"  # type: ignore[attr-defined]
+        assert record.invocation_id == "chain-inv"  # type: ignore[attr-defined]
+    finally:
+        logging.setLogRecordFactory(old_factory)
+        invocation_id_var.set(None)
+
+
+def test_install_context_factory_extra_collision_raises() -> None:
+    """stdlib extra= with context field names raises KeyError when factory is active."""
+    from azure_functions_logging._context import install_context_factory
+
+    old_factory = logging.getLogRecordFactory()
+
+    try:
+        install_context_factory()
+        logger = logging.getLogger("test.factory.collision")
+        logger.handlers.clear()
+        logger.propagate = False
+        handler = logging.StreamHandler()
+        logger.addHandler(handler)
+        logger.setLevel(logging.DEBUG)
+
+        with pytest.raises(KeyError):
+            logger.info("x", extra={"invocation_id": "manual"})
+    finally:
+        logging.setLogRecordFactory(old_factory)
+        logger.handlers.clear()
+        logger.propagate = True
+
+
+def test_install_context_factory_with_logger_emit() -> None:
+    """Context fields appear on records emitted through a real logger."""
+    from azure_functions_logging._context import install_context_factory
+
+    old_factory = logging.getLogRecordFactory()
+    captured: list[logging.LogRecord] = []
+
+    class CapturingHandler(logging.Handler):
+        def emit(self, record: logging.LogRecord) -> None:
+            captured.append(record)
+
+    try:
+        invocation_id_var.set("emit-inv")
+        function_name_var.set("emit-fn")
+        trace_id_var.set("emit-trace")
+        cold_start_var.set(True)
+
+        install_context_factory()
+
+        logger = logging.getLogger("test.factory.emit")
+        logger.handlers.clear()
+        logger.propagate = False
+        logger.addHandler(CapturingHandler())
+        logger.setLevel(logging.INFO)
+
+        logger.info("hello from factory")
+
+        assert len(captured) == 1
+        rec = captured[0]
+        assert rec.invocation_id == "emit-inv"  # type: ignore[attr-defined]
+        assert rec.function_name == "emit-fn"  # type: ignore[attr-defined]
+        assert rec.trace_id == "emit-trace"  # type: ignore[attr-defined]
+        assert rec.cold_start is True  # type: ignore[attr-defined]
+    finally:
+        logging.setLogRecordFactory(old_factory)
+        invocation_id_var.set(None)
+        function_name_var.set(None)
+        trace_id_var.set(None)
+        cold_start_var.set(None)
+        logger.handlers.clear()
+        logger.propagate = True

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -248,6 +248,7 @@ def test_nested_logging_context_restores_outer() -> None:
         trace_context = SimpleNamespace(
             trace_parent="00-bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb2-2222222222222222-01"
         )
+
     with logging_context(OuterCtx()):
         assert invocation_id_var.get() == "outer-inv"
         assert function_name_var.get() == "outer-fn"
@@ -301,3 +302,39 @@ def test_restore_context_tokens_are_single_use() -> None:
     restore_context(tokens)
     with pytest.raises(RuntimeError):
         restore_context(tokens)
+
+
+def test_install_context_factory_injects_fields() -> None:
+    """install_context_factory installs a LogRecordFactory that adds context fields."""
+    from azure_functions_logging._context import install_context_factory
+
+    # Reset factory state for test
+    ctx_mod._factory_installed = False
+    old_factory = logging.getLogRecordFactory()
+
+    try:
+        invocation_id_var.set("factory-inv")
+        function_name_var.set("factory-fn")
+
+        install_context_factory()
+
+        factory = logging.getLogRecordFactory()
+        record = factory(
+            "test",
+            logging.INFO,
+            __file__,
+            1,
+            "hi",
+            (),
+            None,
+        )
+        assert record.invocation_id == "factory-inv"  # type: ignore[attr-defined]
+        assert record.function_name == "factory-fn"  # type: ignore[attr-defined]
+
+        # Idempotent
+        install_context_factory()
+    finally:
+        logging.setLogRecordFactory(old_factory)
+        ctx_mod._factory_installed = False
+        invocation_id_var.set(None)
+        function_name_var.set(None)

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -2,17 +2,20 @@ from __future__ import annotations
 
 import logging
 from types import SimpleNamespace
+from typing import Any
 
 import pytest
 
 import azure_functions_logging._context as ctx_mod
 from azure_functions_logging._context import (
+    _CONTEXT_FACTORY_MARKER,
     ContextFilter,
     _check_cold_start,
     _extract_trace_id,
     cold_start_var,
     function_name_var,
     inject_context,
+    install_context_factory,
     invocation_id_var,
     logging_context,
     reset_context,
@@ -306,10 +309,6 @@ def test_restore_context_tokens_are_single_use() -> None:
 
 def test_install_context_factory_injects_fields() -> None:
     """install_context_factory installs a LogRecordFactory that adds context fields."""
-    from azure_functions_logging._context import (
-        _CONTEXT_FACTORY_MARKER,
-        install_context_factory,
-    )
 
     old_factory = logging.getLogRecordFactory()
 
@@ -345,10 +344,6 @@ def test_install_context_factory_injects_fields() -> None:
 
 def test_install_context_factory_chains_existing_factory() -> None:
     """Custom factory fields are preserved when context factory chains."""
-    from typing import Any
-
-    from azure_functions_logging._context import install_context_factory
-
     old_factory = logging.getLogRecordFactory()
 
     def custom_factory(*args: Any, **kwargs: Any) -> logging.LogRecord:
@@ -362,9 +357,7 @@ def test_install_context_factory_chains_existing_factory() -> None:
 
         install_context_factory()
 
-        record = logging.getLogRecordFactory()(
-            "test", logging.INFO, __file__, 1, "msg", (), None
-        )
+        record = logging.getLogRecordFactory()("test", logging.INFO, __file__, 1, "msg", (), None)
 
         assert record.custom_field == "kept"  # type: ignore[attr-defined]
         assert record.invocation_id == "chain-inv"  # type: ignore[attr-defined]
@@ -375,7 +368,6 @@ def test_install_context_factory_chains_existing_factory() -> None:
 
 def test_install_context_factory_extra_collision_raises() -> None:
     """stdlib extra= with context field names raises KeyError when factory is active."""
-    from azure_functions_logging._context import install_context_factory
 
     old_factory = logging.getLogRecordFactory()
 
@@ -398,7 +390,6 @@ def test_install_context_factory_extra_collision_raises() -> None:
 
 def test_install_context_factory_with_logger_emit() -> None:
     """Context fields appear on records emitted through a real logger."""
-    from azure_functions_logging._context import install_context_factory
 
     old_factory = logging.getLogRecordFactory()
     captured: list[logging.LogRecord] = []

--- a/tests/test_decorator.py
+++ b/tests/test_decorator.py
@@ -144,9 +144,7 @@ class TestAsync:
             assert invocation_id_var.get() == "inv-dec"
             return "ok"
 
-        result = asyncio.get_event_loop().run_until_complete(
-            handler("req", _MOCK_CONTEXT)
-        )
+        result = asyncio.get_event_loop().run_until_complete(handler("req", _MOCK_CONTEXT))
         assert result == "ok"
         # Context reset after return
         assert invocation_id_var.get() is None
@@ -157,9 +155,7 @@ class TestAsync:
             raise ValueError("async boom")
 
         with pytest.raises(ValueError, match="async boom"):
-            asyncio.get_event_loop().run_until_complete(
-                handler("req", _MOCK_CONTEXT)
-            )
+            asyncio.get_event_loop().run_until_complete(handler("req", _MOCK_CONTEXT))
 
         assert invocation_id_var.get() is None
 
@@ -169,9 +165,7 @@ class TestAsync:
             assert function_name_var.get() == "fn-dec"
             return "ok"
 
-        result = asyncio.get_event_loop().run_until_complete(
-            handler("req", _MOCK_CONTEXT)
-        )
+        result = asyncio.get_event_loop().run_until_complete(handler("req", _MOCK_CONTEXT))
         assert result == "ok"
 
 

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -250,8 +250,13 @@ class TestSamplingFilterNameScoping:
         flt = SamplingFilter(rate=1, name="myapp")
         # Record from a different logger
         record = logging.LogRecord(
-            name="other.module", level=logging.INFO, pathname=__file__,
-            lineno=1, msg="hello", args=(), exc_info=None,
+            name="other.module",
+            level=logging.INFO,
+            pathname=__file__,
+            lineno=1,
+            msg="hello",
+            args=(),
+            exc_info=None,
         )
         # Should pass through even though rate=1 — name doesn't match
         assert flt.filter(record) is True
@@ -261,8 +266,13 @@ class TestSamplingFilterNameScoping:
         """Records from matching loggers are subject to sampling."""
         flt = SamplingFilter(rate=1, name="myapp")
         record = logging.LogRecord(
-            name="myapp.sub", level=logging.INFO, pathname=__file__,
-            lineno=1, msg="hello", args=(), exc_info=None,
+            name="myapp.sub",
+            level=logging.INFO,
+            pathname=__file__,
+            lineno=1,
+            msg="hello",
+            args=(),
+            exc_info=None,
         )
         assert flt.filter(record) is True  # first passes
         assert flt.filter(record) is False  # second is rate-limited
@@ -275,8 +285,13 @@ class TestRedactionFilterNameScoping:
         """Records from non-matching loggers are not redacted."""
         flt = RedactionFilter(name="myapp")
         record = logging.LogRecord(
-            name="other.module", level=logging.INFO, pathname=__file__,
-            lineno=1, msg="hello", args=(), exc_info=None,
+            name="other.module",
+            level=logging.INFO,
+            pathname=__file__,
+            lineno=1,
+            msg="hello",
+            args=(),
+            exc_info=None,
         )
         setattr(record, "password", "secret123")
         assert flt.filter(record) is True
@@ -286,8 +301,13 @@ class TestRedactionFilterNameScoping:
         """Records from matching loggers are redacted."""
         flt = RedactionFilter(name="myapp")
         record = logging.LogRecord(
-            name="myapp.handler", level=logging.INFO, pathname=__file__,
-            lineno=1, msg="hello", args=(), exc_info=None,
+            name="myapp.handler",
+            level=logging.INFO,
+            pathname=__file__,
+            lineno=1,
+            msg="hello",
+            args=(),
+            exc_info=None,
         )
         setattr(record, "password", "secret123")
         assert flt.filter(record) is True

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -89,6 +89,7 @@ def test_public_api_exports() -> None:
         "get_logging_metadata",
         "get_logger",
         "inject_context",
+        "install_context_factory",
         "logging_context",
         "reset_context",
         "restore_context",

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -17,6 +17,7 @@ class TestAPISurface:
             "get_logging_metadata",
             "get_logger",
             "inject_context",
+            "install_context_factory",
             "logging_context",
             "reset_context",
             "restore_context",
@@ -25,7 +26,7 @@ class TestAPISurface:
         }
 
     def test_version_is_0_5_0(self) -> None:
-        assert azure_functions_logging.__version__ == "0.6.0"
+        assert azure_functions_logging.__version__ == "0.7.0"
 
     def test_version_is_string(self) -> None:
         assert isinstance(azure_functions_logging.__version__, str)
@@ -40,6 +41,7 @@ class TestAPISurface:
             get_logger,
             get_logging_metadata,
             inject_context,
+            install_context_factory,
             logging_context,
             reset_context,
             restore_context,


### PR DESCRIPTION
## Summary

- Adds `install_context_factory()` — opt-in global `LogRecordFactory` that injects context vars into every log record without requiring `ContextFilter` on each handler
- Factory is idempotent (safe to call multiple times) and chains with any existing factory
- `ContextFilter` docstring updated with deprecation note pointing to the factory approach
- Version bumped to `0.7.0`

## Changes

- `src/azure_functions_logging/_context.py` — new `install_context_factory()` function, `_factory_installed` guard
- `src/azure_functions_logging/__init__.py` — export `install_context_factory`, version → 0.7.0
- `tests/test_context.py` — test factory injection + idempotency
- `tests/test_public_api.py` — version assertion + export check
- `tests/test_integration.py` — integration export verification

## Validation

- ✅ `pytest --cov` — 97% coverage, all tests pass
- ✅ `ruff check` — no lint errors
- ✅ `mypy --strict` — no type errors

Closes #90