### PR TITLE
fix(json): make JsonFormatter fully fail-safe in format()

### DIFF
--- a/src/azure_functions_logging/_json_formatter.py
+++ b/src/azure_functions_logging/_json_formatter.py
@@ -69,13 +69,20 @@ class JsonFormatter(logging.Formatter):
         super().__init__()
 
     def format(self, record: logging.LogRecord) -> str:
-        """Format a log record as one NDJSON object."""
-        message = record.getMessage()
-        timestamp = datetime.fromtimestamp(record.created, tz=timezone.utc).isoformat()
+        """Format a log record as one NDJSON object.
+
+        Fully fail-safe: every step (message rendering, exception formatting,
+        timestamp, JSON serialization) is wrapped so that a hostile
+        ``__str__`` / ``__repr__``, a malformed ``exc_info`` triple, or a
+        cyclic ``extra`` payload never raises out of ``format()``. Worst-case
+        we still emit a single valid JSON object with sentinel values.
+        """
+        message = _safe_get_message(record)
+        timestamp = _safe_timestamp(record)
 
         exception: str | None = None
         if record.exc_info:
-            exception = self.formatException(record.exc_info)
+            exception = _safe_format_exception(self, record.exc_info)
 
         excluded_fields = _STANDARD_RECORD_FIELDS | _CONTEXT_FIELDS
         extra = {key: value for key, value in record.__dict__.items() if key not in excluded_fields}
@@ -93,4 +100,60 @@ class JsonFormatter(logging.Formatter):
             "extra": extra,
         }
 
-        return json.dumps(payload, ensure_ascii=False, default=_json_default)
+        try:
+            return json.dumps(payload, ensure_ascii=False, default=_json_default)
+        except Exception:
+            # Last-resort fallback: drop ``extra`` (the most likely culprit
+            # for cyclic / unserializable payloads) and re-attempt. If even
+            # that fails, emit a minimal hand-built JSON object so the
+            # logging pipeline never breaks.
+            payload["extra"] = {"__serialization_error__": True}
+            try:
+                return json.dumps(payload, ensure_ascii=False, default=_json_default)
+            except Exception:
+                return _emergency_payload(record)
+
+
+def _safe_get_message(record: logging.LogRecord) -> str:
+    """Render ``record.getMessage()`` without ever raising."""
+    try:
+        return record.getMessage()
+    except Exception as exc:
+        return f"<unrenderable message: {type(exc).__name__}>"
+
+
+def _safe_timestamp(record: logging.LogRecord) -> str:
+    """Format the record timestamp without ever raising."""
+    try:
+        return datetime.fromtimestamp(record.created, tz=timezone.utc).isoformat()
+    except Exception:
+        return "1970-01-01T00:00:00+00:00"
+
+
+def _safe_format_exception(formatter: logging.Formatter, exc_info: Any) -> str:
+    """Format ``exc_info`` without ever raising."""
+    try:
+        return formatter.formatException(exc_info)
+    except Exception as exc:
+        return f"<unformattable exception: {type(exc).__name__}>"
+
+
+def _emergency_payload(record: logging.LogRecord) -> str:
+    """Build a minimal valid JSON line when every other path failed."""
+    level = getattr(record, "levelname", "UNKNOWN")
+    name = getattr(record, "name", "unknown")
+    return json.dumps(
+        {
+            "timestamp": "1970-01-01T00:00:00+00:00",
+            "level": str(level),
+            "logger": str(name),
+            "message": "<emergency fallback: formatter failed>",
+            "invocation_id": None,
+            "function_name": None,
+            "trace_id": None,
+            "cold_start": None,
+            "exception": None,
+            "extra": {"__serialization_error__": True},
+        },
+        ensure_ascii=False,
+    )

--- a/tests/test_json_formatter.py
+++ b/tests/test_json_formatter.py
@@ -8,6 +8,8 @@ import logging
 import sys
 import uuid
 
+import pytest
+
 from azure_functions_logging._json_formatter import JsonFormatter
 
 
@@ -158,3 +160,100 @@ def test_unserializable_extra_where_str_raises_returns_sentinel() -> None:
     payload = json.loads(formatter.format(record))
 
     assert payload["extra"]["bad"] == "<unserializable:Hostile>"
+
+
+
+# ---- Fail-safe tests (#101) ---------------------------------------------
+
+
+class _HostileStr:
+    """Object whose __str__ raises — used to break message rendering."""
+
+    def __str__(self) -> str:  # noqa: D401
+        raise RuntimeError("boom in __str__")
+
+    def __repr__(self) -> str:  # noqa: D401
+        raise RuntimeError("boom in __repr__")
+
+
+def test_format_survives_hostile_message_str() -> None:
+    formatter = JsonFormatter()
+    # Use %-format with a single %s arg whose __str__ raises
+    record = logging.LogRecord(
+        name="test.logger",
+        level=logging.INFO,
+        pathname=__file__,
+        lineno=1,
+        msg="value=%s",
+        args=(_HostileStr(),),
+        exc_info=None,
+    )
+
+    output = formatter.format(record)
+    payload = json.loads(output)  # must be valid JSON
+    assert payload["level"] == "INFO"
+    assert "<unrenderable message:" in payload["message"]
+
+
+def test_format_survives_malformed_exc_info() -> None:
+    formatter = JsonFormatter()
+    record = _make_record(logging.ERROR, "boom")
+    # Invalid exc_info triple: missing traceback object causes formatException to fail
+    record.exc_info = (RuntimeError, RuntimeError("x"), "not a traceback")  # type: ignore[assignment]
+
+    output = formatter.format(record)
+    payload = json.loads(output)
+    assert payload["level"] == "ERROR"
+    assert payload["exception"] is not None
+    assert "<unformattable exception:" in payload["exception"]
+
+
+def test_format_survives_cyclic_extra_payload() -> None:
+    formatter = JsonFormatter()
+    record = _make_record(logging.INFO, "cyclic")
+    cycle: dict[str, object] = {}
+    cycle["self"] = cycle  # self-referential — json.dumps would normally raise
+    record.cyclic = cycle
+
+    output = formatter.format(record)
+    payload = json.loads(output)  # must still be valid JSON
+    # Either the default coerced it to a string, or last-resort fallback fired
+    assert payload["level"] == "INFO"
+    assert "extra" in payload
+
+
+def test_format_emergency_fallback_when_payload_dict_unserializable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """If even the second json.dumps attempt fails, emergency payload is emitted."""
+    formatter = JsonFormatter()
+    record = _make_record(logging.WARNING, "force emergency")
+
+
+
+    call_count = {"n": 0}
+    real_dumps = json.dumps
+
+    def always_raise(*args, **kwargs):  # type: ignore[no-untyped-def]
+        call_count["n"] += 1
+        if call_count["n"] <= 2:
+            raise TypeError("forced failure")
+        return real_dumps(*args, **kwargs)
+
+    monkeypatch.setattr("azure_functions_logging._json_formatter.json.dumps", always_raise)
+
+    output = formatter.format(record)
+    payload = json.loads(output)  # emergency payload must be valid JSON
+    assert payload["message"] == "<emergency fallback: formatter failed>"
+    assert payload["extra"] == {"__serialization_error__": True}
+    assert payload["level"] == "WARNING"
+
+
+def test_format_handles_invalid_timestamp() -> None:
+    formatter = JsonFormatter()
+    record = _make_record(logging.INFO, "bad ts")
+    record.created = float("nan")  # fromtimestamp will raise
+
+    output = formatter.format(record)
+    payload = json.loads(output)
+    assert payload["timestamp"] == "1970-01-01T00:00:00+00:00"


### PR DESCRIPTION
## Summary
Hardens `JsonFormatter.format()` so it can never raise out of the logging hot path, regardless of malformed `LogRecord` state.

## Changes
- New defensive helpers: `_safe_get_message`, `_safe_timestamp`, `_safe_format_exception`, `_emergency_payload`.
- Two-tier `json.dumps` fallback: on `TypeError`/`ValueError`, drop `extra` and retry; if that still fails, emit a last-resort emergency payload that is guaranteed to serialize.
- 5 new regression tests covering hostile `__str__`, malformed `exc_info`, cyclic extras, double-failure emergency path, and invalid `created` timestamp.

## Validation
- `make lint` — pass
- `make typecheck` — pass
- `make test` — 165 passed, 3 skipped, **95.78% coverage**
- `make build` — sdist + wheel built

Closes #101