### PR TITLE
feat(host-config): make host.json discovery deterministic and bounded

### DIFF
--- a/README.md
+++ b/README.md
@@ -372,6 +372,23 @@ Recommended `host.json` baseline:
 }
 ```
 
+### Discovery order
+
+`host.json` is located by walking up from the current working directory:
+
+1. `cwd/host.json`
+2. Each parent directory, up to 5 levels deep.
+
+The first existing file wins. To bypass auto-discovery (e.g. in tests or
+non-standard layouts), pass an explicit path:
+
+```python
+from pathlib import Path
+from azure_functions_logging import setup_logging
+
+setup_logging(host_json_path=Path("/site/wwwroot/host.json"))
+```
+
 ## Noise Control
 
 Suppress chatty third-party loggers without removing them:

--- a/src/azure_functions_logging/_host_config.py
+++ b/src/azure_functions_logging/_host_config.py
@@ -17,6 +17,10 @@ _HOST_LEVEL_TO_LOGGING: dict[str, int] = {
     "warning": logging.WARNING,
 }
 
+# Maximum number of parent directories to walk when auto-discovering host.json.
+# Bounded to avoid scanning the entire filesystem on misconfigured environments.
+_HOST_JSON_DISCOVERY_MAX_DEPTH = 5
+
 
 def _resolve_host_level(value: object) -> int | None:
     if not isinstance(value, str):
@@ -24,7 +28,38 @@ def _resolve_host_level(value: object) -> int | None:
     return _HOST_LEVEL_TO_LOGGING.get(value.lower())
 
 
-def warn_host_json_level_conflict(configured_level: int) -> None:
+def discover_host_json(start: Path | None = None) -> Path | None:
+    """Locate ``host.json`` deterministically by walking ``start`` upward.
+
+    Discovery order:
+
+    1. ``start`` (defaults to :func:`Path.cwd`).
+    2. Each ancestor up to :data:`_HOST_JSON_DISCOVERY_MAX_DEPTH` levels.
+
+    Returns the first existing ``host.json`` path or ``None``. Never raises:
+    filesystem errors are swallowed so callers stay silent on broken setups.
+    """
+    try:
+        base = (start or Path.cwd()).resolve()
+    except Exception:
+        return None
+
+    candidates = [base, *list(base.parents)[:_HOST_JSON_DISCOVERY_MAX_DEPTH]]
+    for directory in candidates:
+        candidate = directory / "host.json"
+        try:
+            if candidate.is_file():
+                return candidate
+        except OSError:
+            continue
+    return None
+
+
+def warn_host_json_level_conflict(
+    configured_level: int,
+    *,
+    host_json_path: Path | str | None = None,
+) -> None:
     """Warn when any ``host.json`` ``logLevel`` entry suppresses logs below ``configured_level``.
 
     Azure Functions honors category-specific keys under ``logging.logLevel``
@@ -35,10 +70,25 @@ def warn_host_json_level_conflict(configured_level: int) -> None:
     user's logs.
 
     This helper iterates every category and warns once per offending entry.
+
+    Args:
+        configured_level: The numeric logging level configured by the app.
+        host_json_path: Optional explicit path to a ``host.json`` file. When
+            provided, auto-discovery is bypassed entirely. When ``None``,
+            :func:`discover_host_json` is used.
     """
-    host_path = Path.cwd() / "host.json"
-    if not host_path.exists():
-        return
+    if host_json_path is not None:
+        host_path = Path(host_json_path)
+        try:
+            if not host_path.is_file():
+                return
+        except OSError:
+            return
+    else:
+        discovered = discover_host_json()
+        if discovered is None:
+            return
+        host_path = discovered
 
     try:
         host_config = json.loads(host_path.read_text(encoding="utf-8"))

--- a/src/azure_functions_logging/_setup.py
+++ b/src/azure_functions_logging/_setup.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 import os
+from pathlib import Path
 import threading
 import warnings
 
@@ -33,6 +34,7 @@ def setup_logging(
     format: str = "color",
     logger_name: str | None = None,
     functions_formatter: logging.Formatter | None = None,
+    host_json_path: Path | str | None = None,
 ) -> None:
     """Configure logging for the current environment.
     Behavior depends on the detected environment:
@@ -60,6 +62,11 @@ def setup_logging(
             handlers when running inside Azure/Core Tools. Useful for
             injecting a custom JSON formatter or third-party formatter
             without losing ContextFilter integration.
+        host_json_path: Optional explicit path to a ``host.json`` file used by
+            the host-level conflict warning. When ``None`` (default),
+            ``host.json`` is auto-discovered by walking up from the current
+            working directory (bounded). Pass an explicit path to disable
+            auto-discovery in environments where it might pick the wrong file.
     """
     if format not in {"color", "json"}:
         msg = "format must be 'color' or 'json'"
@@ -104,6 +111,6 @@ def setup_logging(
                     handler.addFilter(context_filter)
 
         if is_functions_env:
-            warn_host_json_level_conflict(level)
+            warn_host_json_level_conflict(level, host_json_path=host_json_path)
 
         _configured_loggers.add(logger_name)

--- a/tests/test_host_config.py
+++ b/tests/test_host_config.py
@@ -7,7 +7,7 @@ import warnings
 
 import pytest
 
-from azure_functions_logging._host_config import warn_host_json_level_conflict
+from azure_functions_logging._host_config import discover_host_json, warn_host_json_level_conflict
 
 
 def _write_host_json(path: Path, content: dict[str, object]) -> None:
@@ -213,3 +213,112 @@ def test_no_warning_when_log_level_block_is_not_a_dict(
         warn_host_json_level_conflict(logging.INFO)
 
     assert len(warning_list) == 0
+
+
+# ---------------------------------------------------------------------------
+# Discovery + override tests (issue #102)
+# ---------------------------------------------------------------------------
+
+
+def test_discover_host_json_finds_in_cwd(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _write_host_json(tmp_path / "host.json", {"version": "2.0"})
+    monkeypatch.chdir(tmp_path)
+    found = discover_host_json()
+    assert found == (tmp_path / "host.json").resolve()
+
+
+def test_discover_host_json_walks_parents(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    nested = tmp_path / "a" / "b" / "c"
+    nested.mkdir(parents=True)
+    _write_host_json(tmp_path / "host.json", {"version": "2.0"})
+    monkeypatch.chdir(nested)
+    found = discover_host_json()
+    assert found == (tmp_path / "host.json").resolve()
+
+
+def test_discover_host_json_returns_none_when_missing(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    assert discover_host_json() is None
+
+
+def test_discover_host_json_respects_max_depth(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # 7 nested levels — host.json placed at the very top, beyond the bounded walk.
+    deep = tmp_path
+    for name in ("a", "b", "c", "d", "e", "f", "g"):
+        deep = deep / name
+    deep.mkdir(parents=True)
+    _write_host_json(tmp_path / "host.json", {"version": "2.0"})
+    monkeypatch.chdir(deep)
+    assert discover_host_json() is None
+
+
+def test_discover_host_json_picks_nearest(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    nested = tmp_path / "app"
+    nested.mkdir()
+    _write_host_json(tmp_path / "host.json", {"version": "2.0"})
+    _write_host_json(nested / "host.json", {"version": "4.0"})
+    monkeypatch.chdir(nested)
+    found = discover_host_json()
+    assert found == (nested / "host.json").resolve()
+
+
+def test_warn_uses_explicit_override_when_cwd_has_no_host_json(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    other = tmp_path / "elsewhere"
+    other.mkdir()
+    _write_host_json(
+        other / "host.json",
+        {"logging": {"logLevel": {"default": "Warning"}}},
+    )
+    # cwd has no host.json — discovery would yield nothing.
+    monkeypatch.chdir(tmp_path)
+    with pytest.warns(UserWarning, match="more restrictive"):
+        warn_host_json_level_conflict(
+            logging.INFO,
+            host_json_path=other / "host.json",
+        )
+
+
+def test_warn_override_missing_file_silently_skipped(
+    tmp_path: Path,
+) -> None:
+    with warnings.catch_warnings(record=True) as warning_list:
+        warnings.simplefilter("always")
+        warn_host_json_level_conflict(
+            logging.INFO,
+            host_json_path=tmp_path / "does-not-exist.json",
+        )
+    assert len(warning_list) == 0
+
+
+def test_warn_walks_parents_to_find_host_json(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Auto-discovery must reach host.json even when cwd is a subdirectory."""
+    nested = tmp_path / "src" / "functions"
+    nested.mkdir(parents=True)
+    _write_host_json(
+        tmp_path / "host.json",
+        {"logging": {"logLevel": {"default": "Warning"}}},
+    )
+    monkeypatch.chdir(nested)
+    with pytest.warns(UserWarning, match="more restrictive"):
+        warn_host_json_level_conflict(logging.INFO)


### PR DESCRIPTION
## Summary
Replaces cwd-only `host.json` lookup with a bounded parent walk and adds an explicit override path so the host-level conflict warning never silently disappears in non-standard layouts.

## Changes
- `discover_host_json()` walks from cwd up through ancestors (max 5 levels), returning the first hit.
- New `host_json_path` parameter on `warn_host_json_level_conflict()` and `setup_logging()` to bypass auto-discovery.
- Discovery is read-only and silent on errors (no exceptions propagate to setup).
- README documents the discovery order and override usage.
- 8 new tests covering cwd hit, parent walk, depth bound, nearest-wins, override used, override missing-file silent, walks-then-warns.

## Validation
- `make lint`, `make typecheck` — pass
- `make test` — 173 passed, 95.03% coverage
- `make build` — sdist + wheel built

Closes #102