### PR TITLE
fix(context): tighten W3C traceparent validation in _extract_trace_id

### DIFF
--- a/src/azure_functions_logging/_context.py
+++ b/src/azure_functions_logging/_context.py
@@ -66,20 +66,52 @@ class ContextFilter(logging.Filter):
         return True
 
 
-def _extract_trace_id(trace_parent: str | None) -> str | None:
-    """Extract trace_id from W3C traceparent header.
+_HEX_CHARS = frozenset("0123456789abcdefABCDEF")
 
-    Format: 00-<trace_id>-<parent_id>-<flags>
+
+def _is_hex(value: str, length: int) -> bool:
+    return len(value) == length and all(ch in _HEX_CHARS for ch in value)
+
+
+def _extract_trace_id(trace_parent: str | None) -> str | None:
+    """Extract a W3C trace-id from a ``traceparent`` header.
+
+    Format (W3C Trace Context Level 1):
+        ``<version>-<trace-id>-<parent-id>-<flags>``
+
+    Returns the trace-id only when the header is structurally valid:
+      * exactly 4 ``-``-separated parts,
+      * version: 2 hex chars (``ff`` is reserved — rejected),
+      * trace-id: 32 hex chars and not all-zero,
+      * parent/span-id: 16 hex chars and not all-zero,
+      * flags: 2 hex chars,
+      * version ``00`` enforces the strict 4-part shape; future versions are
+        accepted as long as the first 4 fields parse — trailing fields are
+        ignored to stay forward-compatible with later spec revisions.
+
+    Otherwise returns ``None`` so callers never log garbage trace IDs.
     """
     if not trace_parent:
         return None
     try:
         parts = trace_parent.split("-")
-        if len(parts) >= 3:
-            return parts[1]
+        if len(parts) < 4:
+            return None
+        version, trace_id, parent_id, flags = parts[0], parts[1], parts[2], parts[3]
+        if not _is_hex(version, 2) or version.lower() == "ff":
+            return None
+        # Version 00 must have exactly 4 fields; later versions may extend.
+        if version == "00" and len(parts) != 4:
+            return None
+        if not _is_hex(trace_id, 32) or trace_id == "0" * 32:
+            return None
+        if not _is_hex(parent_id, 16) or parent_id == "0" * 16:
+            return None
+        if not _is_hex(flags, 2):
+            return None
+        return trace_id
     except Exception:  # nosec B110 — Principle 3: context failures are silent
-        pass
-    return None
+        return None
 
 
 def inject_context(context: Any) -> ContextTokens:

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -428,3 +428,68 @@ def test_install_context_factory_with_logger_emit() -> None:
         cold_start_var.set(None)
         logger.handlers.clear()
         logger.propagate = True
+
+
+
+# ---------------------------------------------------------------------------
+# W3C traceparent strict validation (issue #104)
+# ---------------------------------------------------------------------------
+
+_VALID_TRACEPARENT = "00-1234567890abcdef1234567890abcdef-fedcba0987654321-01"
+_VALID_TRACE_ID = "1234567890abcdef1234567890abcdef"
+
+
+@pytest.mark.parametrize(
+    "header",
+    [
+        # version 00 with extra trailing field
+        "00-1234567890abcdef1234567890abcdef-fedcba0987654321-01-extra",
+        # bad version length
+        "0-1234567890abcdef1234567890abcdef-fedcba0987654321-01",
+        "000-1234567890abcdef1234567890abcdef-fedcba0987654321-01",
+        # reserved version ff
+        "ff-1234567890abcdef1234567890abcdef-fedcba0987654321-01",
+        # non-hex in version
+        "zz-1234567890abcdef1234567890abcdef-fedcba0987654321-01",
+        # short trace-id
+        "00-1234567890abcdef1234567890abcde-fedcba0987654321-01",
+        # long trace-id
+        "00-1234567890abcdef1234567890abcdef0-fedcba0987654321-01",
+        # non-hex trace-id
+        "00-zzzz567890abcdef1234567890abcdef-fedcba0987654321-01",
+        # all-zero trace-id
+        "00-00000000000000000000000000000000-fedcba0987654321-01",
+        # short span-id
+        "00-1234567890abcdef1234567890abcdef-fedcba098765432-01",
+        # long span-id
+        "00-1234567890abcdef1234567890abcdef-fedcba09876543210-01",
+        # all-zero span-id
+        "00-1234567890abcdef1234567890abcdef-0000000000000000-01",
+        # non-hex span-id
+        "00-1234567890abcdef1234567890abcdef-zzzzzzzzzzzzzzzz-01",
+        # bad flags length
+        "00-1234567890abcdef1234567890abcdef-fedcba0987654321-1",
+        "00-1234567890abcdef1234567890abcdef-fedcba0987654321-001",
+        # non-hex flags
+        "00-1234567890abcdef1234567890abcdef-fedcba0987654321-zz",
+        # too few fields
+        "00-1234567890abcdef1234567890abcdef-fedcba0987654321",
+    ],
+)
+def test_extract_trace_id_rejects_malformed_headers(header: str) -> None:
+    assert _extract_trace_id(header) is None
+
+
+def test_extract_trace_id_accepts_valid_uppercase_hex() -> None:
+    upper = "00-1234567890ABCDEF1234567890ABCDEF-FEDCBA0987654321-01"
+    assert _extract_trace_id(upper) == "1234567890ABCDEF1234567890ABCDEF"
+
+
+def test_extract_trace_id_forward_compatible_future_version() -> None:
+    """Versions other than 00 may have trailing fields — still parsed."""
+    future = "01-1234567890abcdef1234567890abcdef-fedcba0987654321-01-future"
+    assert _extract_trace_id(future) == _VALID_TRACE_ID
+
+
+def test_extract_trace_id_baseline_valid_still_works() -> None:
+    assert _extract_trace_id(_VALID_TRACEPARENT) == _VALID_TRACE_ID


### PR DESCRIPTION
## Summary
Replaces the lenient ``parts >= 3`` check with strict W3C Trace Context Level 1 validation so malformed `traceparent` headers no longer produce garbage `trace_id` values in logs.

## Validation rules added
- 4 hyphen-separated parts (version `00` rejects trailing fields)
- version: 2 hex chars, `ff` rejected (reserved)
- trace-id: 32 hex chars, all-zero rejected
- parent/span-id: 16 hex chars, all-zero rejected
- flags: 2 hex chars
- Future versions (`!= 00`) accepted with optional trailing fields — forward-compatible

## Tests
- 16 parametrized rejection cases covering every validation rule
- Uppercase hex acceptance test
- Forward-compat future-version test
- Baseline happy-path regression

## Validation
- `make lint`, `make typecheck` — pass
- `make test` — 199 passed, 95.25% coverage

Closes #104