### PR TITLE
docs: sync multilingual README, llms.txt, and docs with v0.7.x API

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -1,125 +1,524 @@
 # Azure Functions Logging
 
+> **Azure Functions Python DX Toolkit** の一部 — [azure-functions-cookbook-python](https://github.com/yeongseon/azure-functions-cookbook-python) によりドッグフーディング検証済み。
+
 [![PyPI](https://img.shields.io/pypi/v/azure-functions-logging.svg)](https://pypi.org/project/azure-functions-logging/)
 [![Python Version](https://img.shields.io/badge/python-3.10%20%7C%203.11%20%7C%203.12%20%7C%203.13%20%7C%203.14-blue)](https://pypi.org/project/azure-functions-logging/)
 [![CI](https://github.com/yeongseon/azure-functions-logging-python/actions/workflows/ci-test.yml/badge.svg)](https://github.com/yeongseon/azure-functions-logging-python/actions/workflows/ci-test.yml)
-[![Release](https://github.com/yeongseon/azure-functions-logging-python/actions/workflows/release.yml/badge.svg)](https://github.com/yeongseon/azure-functions-logging-python/actions/workflows/release.yml)
+[![Release](https://github.com/yeongseon/azure-functions-logging-python/actions/workflows/publish-pypi.yml/badge.svg)](https://github.com/yeongseon/azure-functions-logging-python/actions/workflows/publish-pypi.yml)
 [![Security Scans](https://github.com/yeongseon/azure-functions-logging-python/actions/workflows/security.yml/badge.svg)](https://github.com/yeongseon/azure-functions-logging-python/actions/workflows/security.yml)
 [![codecov](https://codecov.io/gh/yeongseon/azure-functions-logging-python/branch/main/graph/badge.svg)](https://codecov.io/gh/yeongseon/azure-functions-logging-python)
 [![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit)](https://pre-commit.com/)
 [![Docs](https://img.shields.io/badge/docs-gh--pages-blue)](https://yeongseon.github.io/azure-functions-logging-python/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
-他の言語: [English](README.md) | [한국어](README.ko.md) | [简体中文](README.zh-CN.md)
+他の言語で読む: [English](README.md) | [한국어](README.ko.md) | [简体中文](README.zh-CN.md)
 
-**Azure Functions Python v2 プログラミングモデル**向けの、開発者に優しい logging ヘルパーです。
+**Azure Functions Python v2 のための、呼び出し（invocation）認識可能なオブザーバビリティ。**
+`invocation_id` を表面化し、コールドスタートを検出し、`host.json` の設定不備を警告し、Application Insights にすぐに使える構造化ログを出力します — Python 標準の `logging` を置き換えることなく。
 
-## Why Use It
+---
 
-Azure Functions Python ハンドラーには、共通の logging の課題があります。
+**Azure Functions Python DX Toolkit** の一部
+→ FastAPI のような開発体験を Azure Functions にもたらします。
 
-- ログ出力が視覚的に密集しており、スキャンが困難
-- エラーが INFO レベルのノイズに埋もれて目立たない
-- デフォルトのフォーマットが人間にとって読みやすく最適化されていない
+## なぜ存在するのか
 
-`azure-functions-logging` は、最小限のセットアップで色分けされ、きれいにフォーマットされたログ出力を提供します。Python の標準 `logging` モジュールと互換性があります。
+Azure Functions Python のロギングには、汎用的なロギングライブラリでは扱えない固有の失敗モードがあります:
 
-## Scope
+| 問題 | 何が起こるか | このライブラリ |
+|------|-------------|---------------|
+| `host.json` のログレベル衝突 | `INFO` ログが Azure で静かに消える | 起動時に検出して警告 |
+| ログに `invocation_id` がない | 特定の実行とログを関連付けられない | `context` オブジェクトから自動注入 |
+| コールドスタートが見えない | 新しい worker インスタンス起動時にシグナルなし | 最初の `inject_context()` で自動検出 |
+| サードパーティロガーがうるさい | `azure-core`, `urllib3` が Application Insights を埋め尽くす | `SamplingFilter` / `RedactionFilter` |
+| ローカルとクラウドの出力不一致 | 色付き出力が本番パイプラインを壊す | 環境認識フォーマッタ自動切替 |
+| PII がログに漏洩 | extra フィールド経由で機密値が誤って記録される | キーベースの redaction を行う `RedactionFilter` |
 
-- Azure Functions Python **v2 プログラミングモデル**
-- Python 標準の `logging` モジュール
-- 色付けおよび JSON 形式のログ出力
-- 呼び出しコンテキストの注入 (Invocation context injection) とコールドスタートの検出
+## 何をするのか
 
-このパッケージは、分散トレーシング、ログ集約、または OpenTelemetry との統合を目的としていません。
+- **呼び出しコンテキスト** — すべてのログに `invocation_id`, `function_name`, `cold_start` を自動注入
+- **構造化 JSON 出力** — Application Insights にそのまま使える NDJSON フォーマット
+- **ノイズ制御** — `SamplingFilter` がうるさいサードパーティロガーをレート制限
+- **PII 保護** — `RedactionFilter` が機密フィールドをログ集約に到達する前にマスキング
 
-## Features
+> **スコープ免責事項。** このパッケージは Python `logging` / stdout に構造化 JSON を書き込みます。これらのフィールドが Application Insights にどう現れるかは、Azure Functions host、worker、ロギング設定、および ingestion パイプラインに依存します。ライブラリは ingestion やスキーマ マッピングを所有しません — `customDimensions` にパースされる形式と、生の `message` 内に残る形式の両方が本番環境で有効です。
 
-- ログレベルの色分け (DEBUG はグレー、INFO は青、WARNING は黄色、ERROR は赤、CRITICAL は太字の赤)
-- 本番環境および CI 環境向けの JSON 構造化ログ出力
-- すっきりとした `[TIME] [LEVEL] [LOGGER] message` フォーマット
-- `setup_logging()` による一行での設定
-- 便利な logger 作成のための `get_logger(__name__)` ヘルパー
-- 呼び出しコンテキスト (invocation_id, function_name, trace_id) の自動注入
-- 手動のインストルメンテーションなしでのコールドスタート検出
-- `logger.bind(user_id="abc")` によるコンテキストのバインド
-- `host.json` のログレベル競合に関する警告
-- 読みやすいスタックトレースを含む例外出力
-- Python 標準の `logging` モジュールと互換
+## Before / After
 
-## Installation
+`azure-functions-logging` を **使わない場合** — 単純な `print()` 出力、コンテキストなし、構造なし:
+
+```python
+import azure.functions as func
+
+app = func.FunctionApp()
+
+
+@app.route(route="orders")
+def process_order(req: func.HttpRequest) -> func.HttpResponse:
+    print("Processing order")        # invocation_id なし、構造なし
+    print(f"Order: {req.get_json()}")  # PII 漏洩可能、ログレベルなし
+    return func.HttpResponse("OK")
+```
+
+ターミナル出力:
+
+```
+Processing order
+Order: {'customer': 'Alice', 'total': 99.99}
+```
+
+> Invocation ID なし。ログレベルなし。Application Insights での相関が困難。
+
+`azure-functions-logging` を **使う場合** — 構造化され、クエリ可能、本番環境対応:
+
+```python
+import azure.functions as func
+
+from azure_functions_logging import get_logger, logging_context, setup_logging
+
+setup_logging()
+logger = get_logger(__name__)
+app = func.FunctionApp()
+
+
+@app.route(route="orders")
+def process_order(req: func.HttpRequest, context: func.Context) -> func.HttpResponse:
+    with logging_context(context):
+        logger.info("Processing order", order_id="o-999")
+        return func.HttpResponse("OK")
+```
+
+ローカルターミナル出力 (色付き):
+
+```
+10:30:00 INFO     function_app  Processing order  [invocation_id=abc-123-def, function_name=process_order, cold_start=true]
+```
+
+本番出力 (Application Insights 用 NDJSON):
+
+```json
+{"timestamp": "2024-01-15T10:30:00+00:00", "level": "INFO", "logger": "function_app",
+ "message": "Processing order", "invocation_id": "abc-123-def",
+ "function_name": "process_order", "trace_id": null, "cold_start": true,
+ "exception": null, "extra": {"order_id": "o-999"}}
+```
+
+> すべてのログに `invocation_id` と `cold_start` が含まれます。Application Insights でクエリ可能。`print()` 文ゼロ。
+
+> **注:** 正確な Application Insights スキーマは ingestion パイプラインに依存します。一部の配置では JSON フィールドが `customDimensions` にパースされ、他の配置では JSON が `message` カラム内に残ります。両方の形式の例を以下に示します。
+
+### Application Insights でのクエリ
+
+#### JSON フィールドが `customDimensions` にパースされる場合
+
+```kql
+traces
+| where customDimensions.invocation_id == "abc-123-def"
+| project timestamp, message, customDimensions.cold_start, customDimensions.function_name
+| order by timestamp asc
+```
+
+過去 1 時間のすべてのコールドスタートを検索:
+
+```kql
+traces
+| where customDimensions.cold_start == "true"
+| where timestamp > ago(1h)
+| summarize count() by bin(timestamp, 5m)
+```
+
+#### JSON が `message` カラムに残る場合
+
+```kql
+traces
+| extend payload = parse_json(message)
+| where tostring(payload.invocation_id) == "abc-123-def"
+| project timestamp, tostring(payload.message), tostring(payload.cold_start), tostring(payload.function_name)
+| order by timestamp asc
+```
+
+過去 1 時間のすべてのコールドスタートを検索:
+
+```kql
+traces
+| extend payload = parse_json(message)
+| where tostring(payload.cold_start) == "true"
+| where timestamp > ago(1h)
+| summarize count() by bin(timestamp, 5m)
+```
+
+## このパッケージがしないこと
+
+このパッケージは以下を所有しません:
+
+- **stdlib logging の置き換え** — Python 標準の `logging` をラップして強化するだけで、決して置き換えません
+- **分散トレーシング** — エンドツーエンドのトレース相関には OpenTelemetry または Application Insights SDK を使用してください
+- **API ドキュメント** — API ドキュメントと spec 生成には [`azure-functions-openapi`](https://github.com/yeongseon/azure-functions-openapi-python) を使用してください
+
+## インストール
 
 ```bash
 pip install azure-functions-logging
 ```
 
-ローカル開発用:
-
-```bash
-git clone https://github.com/yeongseon/azure-functions-logging-python.git
-cd azure-functions-logging-python
-pip install -e .[dev]
-```
-
 ## Quick Start
 
 ```python
-from azure_functions_logging import get_logger, setup_logging
+import azure.functions as func
+from azure_functions_logging import get_logger, logging_context, setup_logging
 
 setup_logging()
-
 logger = get_logger(__name__)
-logger.info("Processing request")
+
+app = func.FunctionApp()
+
+@app.route(route="hello")
+def hello(req: func.HttpRequest, context: func.Context) -> func.HttpResponse:
+    with logging_context(context):  # invocation_id, function_name, cold_start をバインド、終了時にリセット
+        logger.info("Request received")
+        # {"level": "INFO", "invocation_id": "abc-123", "cold_start": true, ...}
+
+        return func.HttpResponse("OK")
 ```
 
-### JSON Output
+`logging_context` は推奨される主要パターンです。エンター時にコンテキストを注入し、（ハンドラが例外を発生させても）終了時に **常に** 前のコンテキストを復元するため、再利用された worker で古いコンテキストが次の呼び出しに漏れることを防ぎます。
+
+低レベル制御またはカスタムミドルウェアと統合する場合は、トークンベース復元を使用してください:
+
+```python
+tokens = inject_context(context)
+try:
+    logger.info("Request received")
+finally:
+    restore_context(tokens)
+```
+
+`reset_context()` は意図的にすべてのコンテキストをクリアしたい場合 (例: テストの teardown) のみ使用してください。
+
+ローカルで Functions host を起動 ([e2e サンプルアプリ](examples/e2e_app) 使用):
+
+```bash
+func start
+```
+
+### ローカルおよび Azure での検証
+
+デプロイ後 ([docs/deployment.md](docs/deployment.md) 参照)、同じリクエストは両環境で同じレスポンスを生成します。
+
+#### ローカル
+
+```bash
+curl -s http://localhost:7071/api/logme?correlation_id=demo-123
+```
+
+```json
+{"logged": true, "correlation_id": "demo-123"}
+```
+
+#### Azure
+
+```bash
+curl -s "https://<your-app>.azurewebsites.net/api/logme?correlation_id=demo-123"
+```
+
+```json
+{"logged": true, "correlation_id": "demo-123"}
+```
+
+> koreacentral リージョンの一時的な Azure Functions デプロイで検証 (Python 3.12, Consumption plan)。レスポンスをキャプチャし、URL は匿名化されています。
+
+## 呼び出しコンテキスト (Invocation Context)
+
+ハンドラの実行期間中に呼び出しコンテキストをバインドするには `logging_context()` を使用します。以下を設定します:
+
+- `invocation_id` — 実行ごとに一意、1 リクエストのすべてのログを相関させる
+- `function_name` — Azure Functions の関数名
+- `trace_id` — プラットフォームからのトレースコンテキスト
+- `cold_start` — この worker プロセスの最初の呼び出しで `True`
+
+> **`cold_start` のセマンティクス。** `cold_start=True` は *モジュールロード後にこの Python worker プロセスで観測された最初の呼び出し* を意味します。**プラットフォームレベル** のコールドスタートメトリックではなく、Azure Functions メトリクスが報告する App Service plan / instance 割当のコールドスタートには対応しません。同じ worker での後続の呼び出しは、worker がリサイクルされるまで `cold_start=False` を発行します。
+
+```python
+def my_function(req, context):
+    with logging_context(context):
+        logger.info("handler started")
+        # ここから先のすべてのログに invocation_id と cold_start が含まれる
+```
+
+低レベル制御 (例: ミドルウェア) には、`inject_context()` と `restore_context()` を使用します:
+
+```python
+tokens = inject_context(context)
+try:
+    logger.info("handler started")
+finally:
+    restore_context(tokens)
+```
+
+コンテキスト注入なしでは、これらのフィールドはすべてのログ行で `None` です。
+
+### `with_context` デコレータ
+
+ボイラープレートを減らすには、`inject_context()` を手動で呼び出す代わりに `with_context` デコレータを使用します:
+
+```python
+import azure.functions as func
+from azure_functions_logging import get_logger, setup_logging, with_context
+
+setup_logging()
+logger = get_logger(__name__)
+
+app = func.FunctionApp()
+
+@app.route(route="hello")
+@with_context
+def hello(req: func.HttpRequest, context: func.Context) -> func.HttpResponse:
+    logger.info("Request received")
+    return func.HttpResponse("OK")
+```
+
+デコレータは名前で `context` パラメータを見つけ、ハンドラ実行前に `inject_context()` を呼び出し、戻った後 `finally` でコンテキスト変数をリセットします。
+
+カスタムパラメータ名:
+
+```python
+@with_context(param="ctx")
+def hello(req: func.HttpRequest, ctx: func.Context) -> func.HttpResponse:
+    ...
+```
+
+同期および非同期ハンドラの両方がサポートされます。
+
+### グローバル LogRecordFactory (オプトイン)
+
+`setup_logging()` の後にハンドラが追加される可能性がある、またはハンドラ/フィルタ設定に関係なく **すべての** `LogRecord` に呼び出しコンテキストを乗せたいアプリケーションでは、起動時にグローバルコンテキストファクトリを一度インストールしてください:
+
+```python
+from azure_functions_logging import install_context_factory, setup_logging
+
+install_context_factory()  # レコード生成時にコンテキストを注入
+setup_logging()
+```
+
+有効化されると、`invocation_id`, `function_name`, `trace_id`, `cold_start` は予約された `LogRecord` 属性となります。stdlib `extra=` 経由で渡すと `KeyError` が発生します。キーを自動的にサニタイズする `FunctionLogger` を使用するか、別のキー名を選択してください。
+
+> **`setup_logging()` との関係:** `setup_logging()` は引き続きデフォルトでハンドラに `ContextFilter` をインストールします。両方を呼び出しても問題ありません — 同じ値を設定するため衝突しません。`install_context_factory()` は、後で追加されたハンドラやフィルタチェーンをバイパスするロガーでもカバレッジを保証します。
+
+## 構造化 JSON 出力 (本番)
+
+ログが Application Insights や任意の集約システムに流れる場合は JSON フォーマットを使用してください:
+
+> **注:** `format` パラメータは、このライブラリが作成したハンドラ (ローカル開発) にのみ影響します。
+> Azure Functions では host がハンドラを管理します。host が管理するハンドラに JSON 出力を設定するには
+> `functions_formatter=JsonFormatter()` を使用してください。Azure で `format="json"` を渡すと警告が発生します。
+
+スタンドアロンのローカル開発または CI 出力の場合:
 
 ```python
 setup_logging(format="json")
+```
 
+Azure Functions / Core Tools では host がハンドラを所有します。既存の host 管理ハンドラに JSON フォーマットを強制するには:
+
+```python
+from azure_functions_logging import JsonFormatter, setup_logging
+
+setup_logging(functions_formatter=JsonFormatter())
+```
+
+ログ行ごとの出力 (NDJSON — 1 行 1 JSON オブジェクト):
+
+```json
+{"timestamp": "2024-01-15T10:30:00+00:00", "level": "INFO", "logger": "my_module",
+ "message": "order accepted", "invocation_id": "abc-123", "function_name": "OrderHandler",
+ "cold_start": false, "trace_id": "00-abc...", "exception": null,
+ "extra": {"order_id": "o-999"}}
+```
+
+追加フィールドは `extra` に表示され、Application Insights でインデックス可能です:
+
+```python
+logger.info("order accepted", order_id="o-999", tenant_id="t-1")
+```
+
+## host.json 衝突検出
+
+`host.json` がアプリが発行するログレベルを抑制する場合、起動時にこの警告が表示されます:
+
+```
+WARNING: host.json logLevel.default is 'Warning'. Logs below WARNING will be suppressed in Azure.
+```
+
+推奨される `host.json` ベースライン:
+
+```json
+{
+  "version": "2.0",
+  "logging": {
+    "logLevel": {
+      "default": "Information",
+      "Function": "Information"
+    }
+  }
+}
+```
+
+### 探索順序
+
+`host.json` は現在の作業ディレクトリから上に向かって探索されます:
+
+1. `cwd/host.json`
+2. 各親ディレクトリ、最大 5 階層まで。
+
+最初に存在するファイルが採用されます。自動探索をバイパスするには (テストや非標準レイアウトなど)、明示的なパスを渡してください:
+
+```python
+from pathlib import Path
+from azure_functions_logging import setup_logging
+
+setup_logging(host_json_path=Path("/site/wwwroot/host.json"))
+```
+
+## ノイズ制御
+
+うるさいサードパーティロガーを削除せずに抑制します:
+
+```python
+from azure_functions_logging import SamplingFilter, setup_logging
+import logging
+
+setup_logging()
+
+# 1 秒ウィンドウあたり azure-core メッセージを最大 10 個まで許可
+logging.getLogger("azure").addFilter(SamplingFilter(rate=10))
+
+# 本番で urllib3 を完全に沈黙
+logging.getLogger("urllib3").setLevel(logging.WARNING)
+```
+
+## PII Redaction
+
+機密フィールドが Application Insights に到達する前に削除します:
+
+```python
+from azure_functions_logging import RedactionFilter, setup_logging
+import logging
+
+setup_logging()
+root = logging.getLogger()
+root.addFilter(RedactionFilter(sensitive_keys=["password", "token", "secret"]))
+```
+
+extra フィールドのキーが sensitive キーと一致するすべてのログレコードは、その値が `***` で置き換えられます。
+
+## ローカル vs クラウド
+
+| 環境 | フォーマット | 動作 |
+|------|------------|------|
+| ローカルターミナル | `color` (デフォルト) | 色付き `[TIME] [LEVEL] [LOGGER] message` |
+| Azure / Core Tools | host-managed | コンテキストフィルタのみインストール; host ハンドラに NDJSON を強制するには `functions_formatter=JsonFormatter()` を渡す |
+| CI / パイプライン | `json` | NDJSON、機械パース可能 |
+
+`setup_logging()` は `FUNCTIONS_WORKER_RUNTIME` と `WEBSITE_INSTANCE_ID` を検出し、自動的に正しいパスを選択します。Azure では、ハンドラを追加せずにコンテキストフィルタをインストールします (host パイプラインからの重複出力を回避)。
+
+## コンテキストバインディング
+
+リクエストスコープのメタデータを各呼び出しに渡すことなく、すべてのログにアタッチします:
+
+```python
+def process_order(order_id: str) -> None:
+    order_logger = logger.bind(order_id=order_id, region="eastus")
+    order_logger.info("processing started")   # order_id + region を含む
+    order_logger.info("processing complete")  # 同じメタデータ、新しいメッセージ
+```
+
+呼び出しごとにバインドされたロガーを作成してください。モジュールレベルでキャッシュしないでください。
+
+## いつ使うか
+
+- Application Insights で構造化されクエリ可能なログが必要なとき
+- 単一リクエストのすべてのログにわたる `invocation_id` 相関が必要なとき
+- カスタム instrumentation なしでコールドスタート検出が必要なとき
+- サードパーティロガーに対して PII redaction やノイズ制御が必要なとき
+- `host.json` 設定が静かにログを抑制し、その理由がわからないとき
+
+## ドキュメント
+
+- 完全なドキュメント: [yeongseon.github.io/azure-functions-logging-python](https://yeongseon.github.io/azure-functions-logging-python/)
+- [Configuration reference](https://yeongseon.github.io/azure-functions-logging-python/configuration/)
+- [Troubleshooting guide](https://yeongseon.github.io/azure-functions-logging-python/troubleshooting/)
+- [API reference](https://yeongseon.github.io/azure-functions-logging-python/api/)
+
+## エコシステム
+
+このパッケージは **Azure Functions Python DX Toolkit** の一部です。
+
+**設計原則:** `azure-functions-logging` は構造化ロギングと呼び出し認識オブザーバビリティを所有します。Python 標準の `logging` を強化します — 置き換えません。隣接する関心事は [`azure-functions-openapi`](https://github.com/yeongseon/azure-functions-openapi-python) (API ドキュメントと spec 生成)、[`azure-functions-validation`](https://github.com/yeongseon/azure-functions-validation-python) (リクエスト/レスポンス検証とシリアライゼーション)、[`azure-functions-langgraph`](https://github.com/yeongseon/azure-functions-langgraph-python) (LangGraph ランタイム公開) に属します。
+
+| パッケージ | 役割 |
+|----------|------|
+| [azure-functions-openapi-python](https://github.com/yeongseon/azure-functions-openapi-python) | OpenAPI spec 生成と Swagger UI |
+| [azure-functions-validation-python](https://github.com/yeongseon/azure-functions-validation-python) | リクエスト/レスポンス検証とシリアライゼーション |
+| [azure-functions-db-python](https://github.com/yeongseon/azure-functions-db-python) | SQL, PostgreSQL, MySQL, SQLite, Cosmos DB のデータベースバインディング |
+| [azure-functions-langgraph-python](https://github.com/yeongseon/azure-functions-langgraph-python) | Azure Functions 向け LangGraph デプロイアダプタ |
+| [azure-functions-scaffold-python](https://github.com/yeongseon/azure-functions-scaffold-python) | プロジェクトスキャフォールディング CLI |
+| **azure-functions-logging-python** | 構造化ロギングとオブザーバビリティ |
+| [azure-functions-doctor-python](https://github.com/yeongseon/azure-functions-doctor-python) | デプロイ前診断 CLI |
+| [azure-functions-durable-graph-python](https://github.com/yeongseon/azure-functions-durable-graph-python) | Durable Functions ベースのマニフェストファーストグラフランタイム *(experimental)* |
+| [azure-functions-knowledge-python](https://github.com/yeongseon/azure-functions-knowledge-python) | 知識検索 (RAG) デコレータ |
+| [azure-functions-cookbook-python](https://github.com/yeongseon/azure-functions-cookbook-python) | ドッグフード例 — toolkit 全体を実行する実行可能なレシピ |
+
+
+## AI コーディングアシスタント向け
+
+このパッケージは stdlib logging に変更を加えずに Azure Functions に構造化ロギングを提供します。
+
+**LLM フレンドリーなリソース:**
+- `llms.txt` — 簡潔な API リファレンスと quick start (リポジトリルート)
+- `llms-full.txt` — 完全な API シグネチャ、パターン、設計原則 (リポジトリルート)
+
+**コード生成のための主要な実装詳細:**
+
+1. **ルートロガーを変更しない** — ハンドラにのみフィルタ/フォーマッタをインストール
+2. **コンテキスト注入は contextvar ベース** — thread-local ではなく、asyncio で動作
+3. **冪等な setup** — `setup_logging()` を複数回呼び出しても安全
+4. **2 つの環境、2 つの動作**:
+   - Azure/Core Tools: 既存の root ハンドラにフィルタのみインストール (host.json を尊重)
+   - ローカル開発: 指定されたロガーに ColorFormatter または JsonFormatter ハンドラを追加
+5. **テストフレンドリー**:
+   - `inject_context()` は任意のオブジェクトを受け入れる (azure.functions.Context への強い依存なし)
+   - `with_context` デコレータは同期および非同期ハンドラで動作
+   - 必要に応じてテスト teardown で `reset_context()` を使用
+
+**コード生成時:**
+- `azure_functions_logging` の公開 API からのみインポート (アンダースコアなし)
+- `setup_logging()` をモジュールレベルまたはハンドラ起動時に呼び出す (リクエストごとではない)
+- ハンドラでは `with logging_context(context):` を優先; 生の `inject_context(context)` は `try/finally restore_context(tokens)` とのみ併用
+- リクエストごとのフィールドには `logger.bind(key=value)` を使用 (logger.extra への直接アクセスではない)
+- PII フィールドには `RedactionFilter`、大量ログには `SamplingFilter` を適用
+
+**例パターン:**
+```python
+from azure_functions_logging import get_logger, logging_context, setup_logging
+
+# モジュールレベル
+setup_logging()
 logger = get_logger(__name__)
-logger.info("Processing request")
-# {"timestamp": "...", "level": "INFO", "logger": "...", "message": "Processing request", ...}
+
+# ハンドラごと
+def my_function(req: func.HttpRequest, context: func.Context) -> func.HttpResponse:
+    with logging_context(context):
+        req_logger = logger.bind(correlation_id=req.params.get("id"))
+        req_logger.info("Processing")
+        return func.HttpResponse("OK")
 ```
 
-### Context Injection
 
-```python
-from azure_functions_logging import inject_context
-
-def my_function(req, context):
-    inject_context(context)
-    logger.info("Handling request")  # includes invocation_id, function_name, trace_id
-```
-
-### Context Binding
-
-```python
-bound = logger.bind(user_id="abc", operation="checkout")
-bound.info("Processing")  # includes user_id + operation in every log line
-```
-
-## Documentation
-
-- 全ドキュメント: [yeongseon.github.io/azure-functions-logging-python](https://yeongseon.github.io/azure-functions-logging-python/)
-- 製品要件: `PRD.md`
-
-## Ecosystem
-
-- [azure-functions-validation](https://github.com/yeongseon/azure-functions-validation) — リクエストとレスポンスのバリデーション
-- [azure-functions-openapi](https://github.com/yeongseon/azure-functions-openapi) — OpenAPI と Swagger UI
-- [azure-functions-langgraph](https://github.com/yeongseon/azure-functions-langgraph) — LangGraph デプロイアダプター
-- [azure-functions-doctor](https://github.com/yeongseon/azure-functions-doctor) — 診断 CLI
-- [azure-functions-scaffold](https://github.com/yeongseon/azure-functions-scaffold) — プロジェクトスキャフォールディング
-- [azure-functions-durable-graph](https://github.com/yeongseon/azure-functions-durable-graph) — Durable Functions ベースのグラフランタイム *(計画中)*
-- [azure-functions-python-cookbook](https://github.com/yeongseon/azure-functions-python-cookbook) — レシピとサンプル
-
-## Disclaimer
-
-このプロジェクトは独立したコミュニティプロジェクトであり、Microsoft と提携・承認・保守関係にはありません。
+このプロジェクトは独立したコミュニティプロジェクトであり、Microsoft と提携、承認、保守関係にはありません。
 
 Azure および Azure Functions は Microsoft Corporation の商標です。
 
-## License
+## ライセンス
 
 MIT

--- a/README.ko.md
+++ b/README.ko.md
@@ -1,125 +1,524 @@
 # Azure Functions Logging
 
+> **Azure Functions Python DX Toolkit**의 일부 — [azure-functions-cookbook-python](https://github.com/yeongseon/azure-functions-cookbook-python)에서 도그푸딩(dogfooding)으로 검증되었습니다.
+
 [![PyPI](https://img.shields.io/pypi/v/azure-functions-logging.svg)](https://pypi.org/project/azure-functions-logging/)
 [![Python Version](https://img.shields.io/badge/python-3.10%20%7C%203.11%20%7C%203.12%20%7C%203.13%20%7C%203.14-blue)](https://pypi.org/project/azure-functions-logging/)
 [![CI](https://github.com/yeongseon/azure-functions-logging-python/actions/workflows/ci-test.yml/badge.svg)](https://github.com/yeongseon/azure-functions-logging-python/actions/workflows/ci-test.yml)
-[![Release](https://github.com/yeongseon/azure-functions-logging-python/actions/workflows/release.yml/badge.svg)](https://github.com/yeongseon/azure-functions-logging-python/actions/workflows/release.yml)
+[![Release](https://github.com/yeongseon/azure-functions-logging-python/actions/workflows/publish-pypi.yml/badge.svg)](https://github.com/yeongseon/azure-functions-logging-python/actions/workflows/publish-pypi.yml)
 [![Security Scans](https://github.com/yeongseon/azure-functions-logging-python/actions/workflows/security.yml/badge.svg)](https://github.com/yeongseon/azure-functions-logging-python/actions/workflows/security.yml)
 [![codecov](https://codecov.io/gh/yeongseon/azure-functions-logging-python/branch/main/graph/badge.svg)](https://codecov.io/gh/yeongseon/azure-functions-logging-python)
 [![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit)](https://pre-commit.com/)
 [![Docs](https://img.shields.io/badge/docs-gh--pages-blue)](https://yeongseon.github.io/azure-functions-logging-python/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
-다른 언어: [English](README.md) | [日本語](README.ja.md) | [简体中文](README.zh-CN.md)
+다른 언어로 보기: [English](README.md) | [日本語](README.ja.md) | [简体中文](README.zh-CN.md)
 
-**Azure Functions Python v2 프로그래밍 모델**을 위한 개발자 친화적인 logging 헬퍼입니다.
+**Azure Functions Python v2를 위한 호출(invocation) 인지 가능한 관측성(observability).**
+`invocation_id`를 노출하고, cold start를 감지하며, `host.json` 설정 오류를 경고하고, Application Insights에 바로 사용 가능한 구조화된 로그를 출력합니다 — Python 표준 `logging`을 대체하지 않습니다.
 
-## Why Use It
+---
 
-Azure Functions Python 핸들러는 다음과 같은 logging 관련 불편함이 있습니다:
+**Azure Functions Python DX Toolkit**의 일부
+→ FastAPI와 같은 개발자 경험을 Azure Functions에 제공합니다.
 
-- 로그 출력이 시각적으로 조밀하여 훑어보기 어려움
-- 에러가 일반 info 레벨 로그 사이에서 잘 눈에 띄지 않음
-- 기본 포맷이 사람이 읽기에 최적화되어 있지 않음
+## 왜 필요한가
 
-`azure-functions-logging`은 Python의 표준 `logging` 모듈과 호환되며, 최소한의 설정으로 색상이 적용되고 깔끔하게 포맷된 로그 출력을 제공합니다.
+Azure Functions Python의 logging에는 일반 logging 라이브러리가 다루지 않는 고유의 실패 모드가 있습니다:
 
-## Scope
+| 문제 | 발생 현상 | 이 라이브러리의 해결책 |
+|------|-----------|------------------------|
+| `host.json` 로그 레벨 충돌 | `INFO` 로그가 Azure에서 조용히 사라짐 | 시작 시점에 감지하여 경고 |
+| 로그에 `invocation_id` 부재 | 특정 실행과 로그를 연결할 수 없음 | `context` 객체에서 자동 주입 |
+| Cold start가 보이지 않음 | 새 worker 인스턴스 시작 시 신호 없음 | 첫 `inject_context()` 호출 시 자동 감지 |
+| 시끄러운 서드파티 로거 | `azure-core`, `urllib3` 등이 Application Insights를 채움 | `SamplingFilter` / `RedactionFilter` |
+| 로컬과 클라우드 출력 불일치 | 색상 출력이 프로덕션 파이프라인을 깨뜨림 | 환경 인지 포매터 자동 전환 |
+| PII가 로그에 유출 | extra 필드를 통해 민감 값이 우발적으로 기록 | 키 기반 redaction을 수행하는 `RedactionFilter` |
 
-- Azure Functions Python **v2 프로그래밍 모델**
-- Python 표준 `logging` 모듈
-- 색상 적용 및 JSON 로그 출력
-- Invocation context 주입 및 cold start 감지
+## 무엇을 하는가
 
-이 패키지는 분산 트레이싱, 로그 수집 또는 OpenTelemetry 통합을 대상으로 하지 않습니다.
+- **호출 컨텍스트** — 모든 로그에 `invocation_id`, `function_name`, `cold_start`를 자동 주입
+- **구조화된 JSON 출력** — Application Insights에 바로 적합한 NDJSON 포맷
+- **노이즈 제어** — `SamplingFilter`로 시끄러운 서드파티 로거의 비율을 제한
+- **PII 보호** — `RedactionFilter`로 민감 필드를 로그 집계에 도달하기 전에 마스킹
 
-## Features
+> **범위 면책.** 이 패키지는 Python `logging` / stdout으로 구조화된 JSON을 씁니다. Application Insights에서 어떻게 표시되는지는 Azure Functions host, worker, logging 구성, ingestion 파이프라인에 따라 달라집니다. 라이브러리는 ingestion이나 schema mapping을 책임지지 않습니다 — `customDimensions`로 파싱되는 형태와 raw `message`에 들어가는 형태 모두 프로덕션에서 유효합니다.
 
-- 로그 레벨별 색상 적용 (DEBUG 회색, INFO 파란색, WARNING 노란색, ERROR 빨간색, CRITICAL 굵은 빨간색)
-- 프로덕션 및 CI 환경을 위한 JSON 구조화된 로그 출력
-- 깔끔한 `[TIME] [LEVEL] [LOGGER] message` 포맷
-- 한 줄의 코드로 설정 가능한 `setup_logging()`
-- 편리한 logger 생성을 위한 `get_logger(__name__)` 헬퍼
-- invocation_id, function_name, trace_id 등 호출 context 자동 주입
-- 별도의 코드 삽입 없이 cold start 감지
-- `logger.bind(user_id="abc")`를 통한 context 바인딩
-- `host.json` 로그 레벨 충돌 경고
-- 가독성 좋은 스택 트레이스를 포함한 예외 출력
-- Python 표준 `logging` 모듈과 호환
+## Before / After
 
-## Installation
+`azure-functions-logging` **사용 전** — 단순 `print()` 출력, 컨텍스트 없음, 구조 없음:
+
+```python
+import azure.functions as func
+
+app = func.FunctionApp()
+
+
+@app.route(route="orders")
+def process_order(req: func.HttpRequest) -> func.HttpResponse:
+    print("Processing order")        # invocation_id 없음, 구조 없음
+    print(f"Order: {req.get_json()}")  # PII 유출 가능, 로그 레벨 없음
+    return func.HttpResponse("OK")
+```
+
+터미널 출력:
+
+```
+Processing order
+Order: {'customer': 'Alice', 'total': 99.99}
+```
+
+> Invocation ID 없음. 로그 레벨 없음. Application Insights에서 상관(correlate)하기 어려움.
+
+`azure-functions-logging` **사용 후** — 구조화되고, 쿼리 가능하며, 프로덕션 준비 완료:
+
+```python
+import azure.functions as func
+
+from azure_functions_logging import get_logger, logging_context, setup_logging
+
+setup_logging()
+logger = get_logger(__name__)
+app = func.FunctionApp()
+
+
+@app.route(route="orders")
+def process_order(req: func.HttpRequest, context: func.Context) -> func.HttpResponse:
+    with logging_context(context):
+        logger.info("Processing order", order_id="o-999")
+        return func.HttpResponse("OK")
+```
+
+로컬 터미널 출력 (색상 적용):
+
+```
+10:30:00 INFO     function_app  Processing order  [invocation_id=abc-123-def, function_name=process_order, cold_start=true]
+```
+
+프로덕션 출력 (Application Insights용 NDJSON):
+
+```json
+{"timestamp": "2024-01-15T10:30:00+00:00", "level": "INFO", "logger": "function_app",
+ "message": "Processing order", "invocation_id": "abc-123-def",
+ "function_name": "process_order", "trace_id": null, "cold_start": true,
+ "exception": null, "extra": {"order_id": "o-999"}}
+```
+
+> 모든 로그에 `invocation_id`와 `cold_start`가 포함됩니다. Application Insights에서 쿼리 가능. `print()` 문 없음.
+
+> **참고:** 정확한 Application Insights 스키마는 ingestion 파이프라인에 따라 다릅니다. 일부 배포에서는 JSON 필드가 `customDimensions`로 파싱되고, 다른 곳에서는 JSON이 `message` 컬럼 내부에 그대로 남습니다. 두 형태 모두에 대한 예시가 아래에 있습니다.
+
+### Application Insights에서 쿼리
+
+#### JSON 필드가 `customDimensions`로 파싱되는 경우
+
+```kql
+traces
+| where customDimensions.invocation_id == "abc-123-def"
+| project timestamp, message, customDimensions.cold_start, customDimensions.function_name
+| order by timestamp asc
+```
+
+지난 1시간의 모든 cold start 찾기:
+
+```kql
+traces
+| where customDimensions.cold_start == "true"
+| where timestamp > ago(1h)
+| summarize count() by bin(timestamp, 5m)
+```
+
+#### JSON이 `message` 컬럼에 그대로 남는 경우
+
+```kql
+traces
+| extend payload = parse_json(message)
+| where tostring(payload.invocation_id) == "abc-123-def"
+| project timestamp, tostring(payload.message), tostring(payload.cold_start), tostring(payload.function_name)
+| order by timestamp asc
+```
+
+지난 1시간의 모든 cold start 찾기:
+
+```kql
+traces
+| extend payload = parse_json(message)
+| where tostring(payload.cold_start) == "true"
+| where timestamp > ago(1h)
+| summarize count() by bin(timestamp, 5m)
+```
+
+## 이 패키지가 하지 않는 일
+
+이 패키지는 다음을 책임지지 않습니다:
+
+- **stdlib logging 대체** — Python 표준 `logging`을 감싸고 보강할 뿐, 절대 대체하지 않습니다
+- **분산 트레이싱** — end-to-end trace 상관에는 OpenTelemetry나 Application Insights SDK를 사용하세요
+- **API 문서** — API 문서 및 spec 생성에는 [`azure-functions-openapi`](https://github.com/yeongseon/azure-functions-openapi-python)를 사용하세요
+
+## 설치
 
 ```bash
 pip install azure-functions-logging
 ```
 
-로컬 개발용:
-
-```bash
-git clone https://github.com/yeongseon/azure-functions-logging-python.git
-cd azure-functions-logging-python
-pip install -e .[dev]
-```
-
 ## Quick Start
 
 ```python
-from azure_functions_logging import get_logger, setup_logging
+import azure.functions as func
+from azure_functions_logging import get_logger, logging_context, setup_logging
 
 setup_logging()
-
 logger = get_logger(__name__)
-logger.info("Processing request")
+
+app = func.FunctionApp()
+
+@app.route(route="hello")
+def hello(req: func.HttpRequest, context: func.Context) -> func.HttpResponse:
+    with logging_context(context):  # invocation_id, function_name, cold_start 바인딩 후, 종료 시 복원
+        logger.info("Request received")
+        # {"level": "INFO", "invocation_id": "abc-123", "cold_start": true, ...}
+
+        return func.HttpResponse("OK")
 ```
 
-### JSON Output
+`logging_context`는 권장되는 기본 패턴입니다. 진입 시 컨텍스트를 주입하고, **항상** 종료 시 (핸들러가 예외를 발생시키더라도) 이전 컨텍스트를 복원하므로, 재사용되는 worker에서 stale 컨텍스트가 다음 호출로 누출되는 것을 방지합니다.
+
+저수준 제어가 필요하거나 커스텀 미들웨어와 통합할 때는 토큰 기반 복원을 사용하세요:
+
+```python
+tokens = inject_context(context)
+try:
+    logger.info("Request received")
+finally:
+    restore_context(tokens)
+```
+
+`reset_context()`는 의도적으로 모든 컨텍스트를 지우려는 경우(예: 테스트 teardown)에만 사용하세요.
+
+Functions host를 로컬에서 실행 ([e2e 예제 앱](examples/e2e_app) 사용):
+
+```bash
+func start
+```
+
+### 로컬 및 Azure에서 검증
+
+배포 후 ([docs/deployment.md](docs/deployment.md) 참고), 동일한 요청은 두 환경에서 동일한 응답을 생성합니다.
+
+#### 로컬
+
+```bash
+curl -s http://localhost:7071/api/logme?correlation_id=demo-123
+```
+
+```json
+{"logged": true, "correlation_id": "demo-123"}
+```
+
+#### Azure
+
+```bash
+curl -s "https://<your-app>.azurewebsites.net/api/logme?correlation_id=demo-123"
+```
+
+```json
+{"logged": true, "correlation_id": "demo-123"}
+```
+
+> koreacentral 리전의 임시 Azure Functions 배포로 검증되었습니다 (Python 3.12, Consumption plan). 응답은 캡처되었으며 URL은 익명화되었습니다.
+
+## 호출 컨텍스트 (Invocation Context)
+
+핸들러가 실행되는 동안 호출 컨텍스트를 바인딩하려면 `logging_context()`를 사용하세요. 다음을 설정합니다:
+
+- `invocation_id` — 실행마다 고유, 한 요청의 모든 로그를 상관시킴
+- `function_name` — Azure Functions 함수 이름
+- `trace_id` — 플랫폼의 trace 컨텍스트
+- `cold_start` — 이 worker 프로세스의 첫 호출일 때 `True`
+
+> **`cold_start` 의미.** `cold_start=True`는 *모듈 로드 후 이 Python worker 프로세스에서 관측된 첫 호출*을 의미합니다. **플랫폼 레벨**의 cold start 메트릭이 아니며, Azure Functions 메트릭이 보고하는 App Service plan / instance 할당 cold start와는 일치하지 않습니다. 같은 worker의 후속 호출은 worker가 재활용될 때까지 `cold_start=False`를 발행합니다.
+
+```python
+def my_function(req, context):
+    with logging_context(context):
+        logger.info("handler started")
+        # 이 시점부터의 모든 로그에 invocation_id와 cold_start 포함
+```
+
+저수준 제어 (예: 미들웨어)에는 `inject_context()`와 `restore_context()`를 사용하세요:
+
+```python
+tokens = inject_context(context)
+try:
+    logger.info("handler started")
+finally:
+    restore_context(tokens)
+```
+
+컨텍스트 주입이 없으면 모든 로그 라인에서 이 필드들은 `None`입니다.
+
+### `with_context` 데코레이터
+
+보일러플레이트를 줄이려면, `inject_context()`를 수동으로 호출하는 대신 `with_context` 데코레이터를 사용하세요:
+
+```python
+import azure.functions as func
+from azure_functions_logging import get_logger, setup_logging, with_context
+
+setup_logging()
+logger = get_logger(__name__)
+
+app = func.FunctionApp()
+
+@app.route(route="hello")
+@with_context
+def hello(req: func.HttpRequest, context: func.Context) -> func.HttpResponse:
+    logger.info("Request received")
+    return func.HttpResponse("OK")
+```
+
+데코레이터는 이름으로 `context` 매개변수를 찾고, 핸들러 실행 전 `inject_context()`를 호출하며, 반환 후 `finally`에서 컨텍스트 변수를 리셋합니다.
+
+커스텀 매개변수 이름:
+
+```python
+@with_context(param="ctx")
+def hello(req: func.HttpRequest, ctx: func.Context) -> func.HttpResponse:
+    ...
+```
+
+동기 및 비동기 핸들러가 모두 지원됩니다.
+
+### 글로벌 LogRecordFactory (opt-in)
+
+`setup_logging()` 이후에 핸들러가 추가될 수 있거나, 핸들러/필터 구성과 무관하게 **모든** `LogRecord`에 호출 컨텍스트를 적용하고 싶은 애플리케이션에서는, 시작 시 글로벌 컨텍스트 팩토리를 한 번 설치하세요:
+
+```python
+from azure_functions_logging import install_context_factory, setup_logging
+
+install_context_factory()  # record 생성 시점에 컨텍스트 주입
+setup_logging()
+```
+
+활성화되면 `invocation_id`, `function_name`, `trace_id`, `cold_start`는 예약된 `LogRecord` 속성이 됩니다. stdlib `extra=`를 통해 이들을 전달하면 `KeyError`가 발생합니다. 키를 자동으로 정제하는 `FunctionLogger`를 사용하거나 다른 키 이름을 선택하세요.
+
+> **`setup_logging()`과의 관계:** `setup_logging()`은 기본적으로 핸들러에 `ContextFilter`를 설치합니다. 둘 다 호출해도 됩니다 — 동일한 값을 설정하므로 충돌이 없습니다. `install_context_factory()`는 나중에 추가되는 핸들러나 필터 체인을 우회하는 로거에서도 적용됨을 보장합니다.
+
+## 구조화된 JSON 출력 (프로덕션)
+
+로그가 Application Insights나 어떤 집계 시스템으로 흘러갈 때는 JSON 포맷을 사용하세요:
+
+> **참고:** `format` 매개변수는 이 라이브러리가 생성한 핸들러 (로컬 개발)에만 영향을 줍니다.
+> Azure Functions에서는 host가 핸들러를 관리합니다. host가 관리하는 핸들러에 JSON 출력을 설정하려면
+> `functions_formatter=JsonFormatter()`를 사용하세요. Azure에서 `format="json"`을 전달하면 경고가 발생합니다.
+
+독립 실행형 로컬 개발 또는 CI 출력의 경우:
 
 ```python
 setup_logging(format="json")
-
-logger = get_logger(__name__)
-logger.info("Processing request")
-# {"timestamp": "...", "level": "INFO", "logger": "...", "message": "Processing request", ...}
 ```
 
-### Context Injection
+Azure Functions / Core Tools에서는 host가 핸들러를 소유합니다. 기존의 host 관리 핸들러에 JSON 포맷을 강제하려면:
 
 ```python
-from azure_functions_logging import inject_context
+from azure_functions_logging import JsonFormatter, setup_logging
 
-def my_function(req, context):
-    inject_context(context)
-    logger.info("Handling request")  # includes invocation_id, function_name, trace_id
+setup_logging(functions_formatter=JsonFormatter())
 ```
 
-### Context Binding
+로그 라인당 출력 (NDJSON — 한 줄에 한 JSON 객체):
+
+```json
+{"timestamp": "2024-01-15T10:30:00+00:00", "level": "INFO", "logger": "my_module",
+ "message": "order accepted", "invocation_id": "abc-123", "function_name": "OrderHandler",
+ "cold_start": false, "trace_id": "00-abc...", "exception": null,
+ "extra": {"order_id": "o-999"}}
+```
+
+추가 필드는 `extra`에 표시되며 Application Insights에서 인덱싱 가능합니다:
 
 ```python
-bound = logger.bind(user_id="abc", operation="checkout")
-bound.info("Processing")  # includes user_id + operation in every log line
+logger.info("order accepted", order_id="o-999", tenant_id="t-1")
 ```
 
-## Documentation
+## host.json 충돌 감지
+
+`host.json`이 앱이 발행하는 로그 레벨을 억제하면 시작 시 다음과 같은 경고가 표시됩니다:
+
+```
+WARNING: host.json logLevel.default is 'Warning'. Logs below WARNING will be suppressed in Azure.
+```
+
+권장 `host.json` 기본값:
+
+```json
+{
+  "version": "2.0",
+  "logging": {
+    "logLevel": {
+      "default": "Information",
+      "Function": "Information"
+    }
+  }
+}
+```
+
+### 발견 순서
+
+`host.json`은 현재 작업 디렉토리에서 위로 올라가며 탐색됩니다:
+
+1. `cwd/host.json`
+2. 각 상위 디렉토리, 최대 5단계 깊이까지.
+
+먼저 발견된 파일이 사용됩니다. 자동 발견을 우회하려면 (예: 테스트 또는 비표준 레이아웃에서) 명시적 경로를 전달하세요:
+
+```python
+from pathlib import Path
+from azure_functions_logging import setup_logging
+
+setup_logging(host_json_path=Path("/site/wwwroot/host.json"))
+```
+
+## 노이즈 제어
+
+시끄러운 서드파티 로거를 제거하지 않고 억제하세요:
+
+```python
+from azure_functions_logging import SamplingFilter, setup_logging
+import logging
+
+setup_logging()
+
+# 1초 윈도우당 azure-core 메시지를 최대 10개까지 허용
+logging.getLogger("azure").addFilter(SamplingFilter(rate=10))
+
+# 프로덕션에서 urllib3를 완전히 침묵
+logging.getLogger("urllib3").setLevel(logging.WARNING)
+```
+
+## PII Redaction
+
+민감 필드가 Application Insights에 도달하기 전에 제거하세요:
+
+```python
+from azure_functions_logging import RedactionFilter, setup_logging
+import logging
+
+setup_logging()
+root = logging.getLogger()
+root.addFilter(RedactionFilter(sensitive_keys=["password", "token", "secret"]))
+```
+
+extra 필드의 키가 sensitive 키와 일치하는 모든 로그 레코드는 해당 값이 `***`로 대체됩니다.
+
+## 로컬 vs 클라우드
+
+| 환경 | 포맷 | 동작 |
+|------|------|------|
+| 로컬 터미널 | `color` (기본) | 색상 적용된 `[TIME] [LEVEL] [LOGGER] message` |
+| Azure / Core Tools | host-managed | 컨텍스트 필터만 설치; host 핸들러에 NDJSON을 강제하려면 `functions_formatter=JsonFormatter()`를 전달 |
+| CI / 파이프라인 | `json` | NDJSON, 머신 파싱 가능 |
+
+`setup_logging()`은 `FUNCTIONS_WORKER_RUNTIME`과 `WEBSITE_INSTANCE_ID`를 감지하여 자동으로 올바른 경로를 선택합니다. Azure에서는 핸들러를 추가하지 않고 컨텍스트 필터를 설치합니다 (host 파이프라인의 중복 출력을 피함).
+
+## 컨텍스트 바인딩
+
+요청 범위 메타데이터를 모든 로그에 첨부하되, 모든 호출에 전달하지 않아도 됩니다:
+
+```python
+def process_order(order_id: str) -> None:
+    order_logger = logger.bind(order_id=order_id, region="eastus")
+    order_logger.info("processing started")   # order_id + region 포함
+    order_logger.info("processing complete")  # 동일한 메타데이터, 새 메시지
+```
+
+호출당 바운드 로거를 생성하세요. 모듈 레벨에서 캐싱하지 마세요.
+
+## 언제 사용하는가
+
+- Application Insights에서 구조화되고 쿼리 가능한 로그가 필요할 때
+- 한 요청의 모든 로그에 대해 `invocation_id` 상관관계를 원할 때
+- 커스텀 instrumentation 없이 cold start 감지가 필요할 때
+- 서드파티 로거에 대해 PII redaction이나 노이즈 제어를 원할 때
+- `host.json` 구성이 조용히 로그를 억제하는데 이유를 모를 때
+
+## 문서
 
 - 전체 문서: [yeongseon.github.io/azure-functions-logging-python](https://yeongseon.github.io/azure-functions-logging-python/)
-- 제품 요구 사항: `PRD.md`
+- [Configuration reference](https://yeongseon.github.io/azure-functions-logging-python/configuration/)
+- [Troubleshooting guide](https://yeongseon.github.io/azure-functions-logging-python/troubleshooting/)
+- [API reference](https://yeongseon.github.io/azure-functions-logging-python/api/)
 
-## Ecosystem
+## 생태계 (Ecosystem)
 
-- [azure-functions-validation](https://github.com/yeongseon/azure-functions-validation) — 요청 및 응답 검증
-- [azure-functions-openapi](https://github.com/yeongseon/azure-functions-openapi) — OpenAPI 및 Swagger UI
-- [azure-functions-langgraph](https://github.com/yeongseon/azure-functions-langgraph) — LangGraph 배포 어댑터
-- [azure-functions-doctor](https://github.com/yeongseon/azure-functions-doctor) — 진단 CLI
-- [azure-functions-scaffold](https://github.com/yeongseon/azure-functions-scaffold) — 프로젝트 스캐폴딩
-- [azure-functions-durable-graph](https://github.com/yeongseon/azure-functions-durable-graph) — Durable Functions 기반 그래프 런타임 *(계획)*
-- [azure-functions-python-cookbook](https://github.com/yeongseon/azure-functions-python-cookbook) — 레시피 및 예제
+이 패키지는 **Azure Functions Python DX Toolkit**의 일부입니다.
 
-## Disclaimer
+**디자인 원칙:** `azure-functions-logging`은 구조화된 logging과 호출 인지 관측성을 책임집니다. Python의 표준 `logging`을 보강할 뿐, 대체하지 않습니다. 인접 관심사는 [`azure-functions-openapi`](https://github.com/yeongseon/azure-functions-openapi-python) (API 문서 및 spec 생성), [`azure-functions-validation`](https://github.com/yeongseon/azure-functions-validation-python) (요청/응답 검증 및 직렬화), [`azure-functions-langgraph`](https://github.com/yeongseon/azure-functions-langgraph-python) (LangGraph 런타임 노출)이 담당합니다.
 
-이 프로젝트는 독립적인 커뮤니티 프로젝트이며 Microsoft와 제휴되어 있지 않고, Microsoft의 후원이나 유지보수를 받지 않습니다.
+| 패키지 | 역할 |
+|--------|------|
+| [azure-functions-openapi-python](https://github.com/yeongseon/azure-functions-openapi-python) | OpenAPI spec 생성 및 Swagger UI |
+| [azure-functions-validation-python](https://github.com/yeongseon/azure-functions-validation-python) | 요청/응답 검증 및 직렬화 |
+| [azure-functions-db-python](https://github.com/yeongseon/azure-functions-db-python) | SQL, PostgreSQL, MySQL, SQLite, Cosmos DB 데이터베이스 바인딩 |
+| [azure-functions-langgraph-python](https://github.com/yeongseon/azure-functions-langgraph-python) | Azure Functions용 LangGraph 배포 어댑터 |
+| [azure-functions-scaffold-python](https://github.com/yeongseon/azure-functions-scaffold-python) | 프로젝트 스캐폴딩 CLI |
+| **azure-functions-logging-python** | 구조화된 logging 및 관측성 |
+| [azure-functions-doctor-python](https://github.com/yeongseon/azure-functions-doctor-python) | 사전 배포 진단 CLI |
+| [azure-functions-durable-graph-python](https://github.com/yeongseon/azure-functions-durable-graph-python) | Durable Functions 기반 manifest-first 그래프 런타임 *(experimental)* |
+| [azure-functions-knowledge-python](https://github.com/yeongseon/azure-functions-knowledge-python) | 지식 검색 (RAG) 데코레이터 |
+| [azure-functions-cookbook-python](https://github.com/yeongseon/azure-functions-cookbook-python) | 도그푸딩 예제 — 전체 toolkit을 실행하는 실행 가능한 레시피 |
+
+
+## AI 코딩 어시스턴트를 위한 안내
+
+이 패키지는 stdlib logging을 수정하지 않고 Azure Functions를 위한 구조화된 logging을 제공합니다.
+
+**LLM 친화적 리소스:**
+- `llms.txt` — 간결한 API 레퍼런스와 quick start (저장소 루트)
+- `llms-full.txt` — 완전한 API 시그니처, 패턴, 디자인 원칙 (저장소 루트)
+
+**코드 생성을 위한 핵심 구현 세부사항:**
+
+1. **루트 로거를 절대 수정하지 않음** — 핸들러에만 필터/포매터 설치
+2. **컨텍스트 주입은 contextvar 기반** — thread-local이 아니므로 asyncio와 호환
+3. **멱등성 보장 setup** — `setup_logging()`을 여러 번 호출해도 안전
+4. **두 환경, 두 동작**:
+   - Azure/Core Tools: 기존 root 핸들러에 필터만 설치 (host.json 존중)
+   - 로컬 개발: 지정된 로거에 ColorFormatter 또는 JsonFormatter 핸들러 추가
+5. **테스트 친화적**:
+   - `inject_context()`는 어떤 객체든 받음 (azure.functions.Context에 강한 의존성 없음)
+   - `with_context` 데코레이터는 동기 및 비동기 핸들러에서 동작
+   - 필요하다면 테스트 teardown에서 `reset_context()` 사용
+
+**코드 생성 시:**
+- `azure_functions_logging` 공개 API에서만 import (밑줄 없음)
+- `setup_logging()`은 모듈 레벨이나 핸들러 시작 시 호출 (요청당 호출 X)
+- 핸들러에서는 `with logging_context(context):`를 우선 사용; raw `inject_context(context)`는 반드시 `try/finally restore_context(tokens)`와 함께 사용
+- 요청당 필드에는 `logger.bind(key=value)` 사용 (logger.extra 직접 X)
+- PII 필드에는 `RedactionFilter`, 대량 로그에는 `SamplingFilter` 적용
+
+**예시 패턴:**
+```python
+from azure_functions_logging import get_logger, logging_context, setup_logging
+
+# 모듈 레벨
+setup_logging()
+logger = get_logger(__name__)
+
+# 핸들러별
+def my_function(req: func.HttpRequest, context: func.Context) -> func.HttpResponse:
+    with logging_context(context):
+        req_logger = logger.bind(correlation_id=req.params.get("id"))
+        req_logger.info("Processing")
+        return func.HttpResponse("OK")
+```
+
+
+이 프로젝트는 독립적인 커뮤니티 프로젝트이며 Microsoft와 제휴, 후원, 유지보수 관계가 없습니다.
 
 Azure 및 Azure Functions는 Microsoft Corporation의 상표입니다.
 
-## License
+## 라이선스
 
 MIT

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,125 +1,524 @@
 # Azure Functions Logging
 
+> **Azure Functions Python DX Toolkit** 的一部分 — 由 [azure-functions-cookbook-python](https://github.com/yeongseon/azure-functions-cookbook-python) 通过自食其狗粮（dogfooding）方式验证。
+
 [![PyPI](https://img.shields.io/pypi/v/azure-functions-logging.svg)](https://pypi.org/project/azure-functions-logging/)
 [![Python Version](https://img.shields.io/badge/python-3.10%20%7C%203.11%20%7C%203.12%20%7C%203.13%20%7C%203.14-blue)](https://pypi.org/project/azure-functions-logging/)
 [![CI](https://github.com/yeongseon/azure-functions-logging-python/actions/workflows/ci-test.yml/badge.svg)](https://github.com/yeongseon/azure-functions-logging-python/actions/workflows/ci-test.yml)
-[![Release](https://github.com/yeongseon/azure-functions-logging-python/actions/workflows/release.yml/badge.svg)](https://github.com/yeongseon/azure-functions-logging-python/actions/workflows/release.yml)
+[![Release](https://github.com/yeongseon/azure-functions-logging-python/actions/workflows/publish-pypi.yml/badge.svg)](https://github.com/yeongseon/azure-functions-logging-python/actions/workflows/publish-pypi.yml)
 [![Security Scans](https://github.com/yeongseon/azure-functions-logging-python/actions/workflows/security.yml/badge.svg)](https://github.com/yeongseon/azure-functions-logging-python/actions/workflows/security.yml)
 [![codecov](https://codecov.io/gh/yeongseon/azure-functions-logging-python/branch/main/graph/badge.svg)](https://codecov.io/gh/yeongseon/azure-functions-logging-python)
 [![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit)](https://pre-commit.com/)
 [![Docs](https://img.shields.io/badge/docs-gh--pages-blue)](https://yeongseon.github.io/azure-functions-logging-python/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
-其他语言: [English](README.md) | [한국어](README.ko.md) | [日本語](README.ja.md)
+阅读其他语言版本: [English](README.md) | [한국어](README.ko.md) | [日本語](README.ja.md)
 
-专为 **Azure Functions Python v2 编程模型** 设计的开发者友好型 logging 助手。
+**面向 Azure Functions Python v2 的、感知调用（invocation-aware）的可观测性。**
+暴露 `invocation_id`，检测冷启动，对 `host.json` 错误配置发出警告，并输出可直接用于 Application Insights 的结构化日志 — 不替换 Python 标准 `logging`。
 
-## Why Use It
+---
 
-Azure Functions Python 处理程序通常面临以下 logging 痛点：
+**Azure Functions Python DX Toolkit** 的一部分
+→ 为 Azure Functions 带来类似 FastAPI 的开发者体验。
 
-- 日志输出过于密集，难以快速浏览
-- 错误信息淹没在 INFO 级别的日志中，不够醒目
-- 默认格式未针对人类阅读进行优化
+## 为什么存在
 
-`azure-functions-logging` 提供彩色且格式整洁的日志输出，兼容 Python 标准 `logging` 模块，且只需极简配置。
+Azure Functions Python 的日志记录有一些通用日志库无法处理的特定失败模式:
 
-## Scope
+| 问题 | 发生现象 | 本库的解决方案 |
+|------|---------|--------------|
+| `host.json` 日志级别冲突 | `INFO` 日志在 Azure 中静默消失 | 在启动时检测并发出警告 |
+| 日志中无 `invocation_id` | 无法将日志与特定执行关联 | 从 `context` 对象自动注入 |
+| 冷启动不可见 | 新 worker 实例启动时无信号 | 在首次 `inject_context()` 时自动检测 |
+| 嘈杂的第三方日志 | `azure-core`、`urllib3` 充斥 Application Insights | `SamplingFilter` / `RedactionFilter` |
+| 本地与云端输出不匹配 | 彩色输出在生产管道中崩溃 | 环境感知的格式化器自动切换 |
+| PII 泄露到日志 | 敏感值通过 extra 字段被意外记录 | 基于键的脱敏 `RedactionFilter` |
 
-- Azure Functions Python **v2 编程模型**
-- Python 标准 `logging` 模块
-- 彩色及 JSON 格式日志输出
-- 调用上下文注入 (Invocation context injection) 及冷启动检测
+## 它做什么
 
-本项目 **不** 涉及分布式追踪、日志聚合或 OpenTelemetry 集成。
+- **调用上下文** — 自动将 `invocation_id`、`function_name`、`cold_start` 注入每条日志
+- **结构化 JSON 输出** — 适用于 Application Insights 的 NDJSON 格式
+- **噪声控制** — `SamplingFilter` 限制嘈杂第三方日志的速率
+- **PII 保护** — `RedactionFilter` 在敏感字段到达日志聚合之前进行脱敏
 
-## Features
+> **范围免责声明。** 本包将结构化 JSON 写入 Python `logging` / stdout。这些字段在 Application Insights 中如何呈现取决于 Azure Functions host、worker、日志配置和 ingestion 管道。本库不拥有 ingestion 或 schema 映射 — `customDimensions` 解析形式和原始 `message` 形式在生产中都是有效的。
 
-- 彩色日志级别（DEBUG 灰色，INFO 蓝色，WARNING 黄色，ERROR 红色，CRITICAL 粗体红色）
-- 适用于生产和 CI 环境的 JSON 结构化日志输出
-- 整洁的 `[TIME] [LEVEL] [LOGGER] message` 格式
-- `setup_logging()` 一行式配置
-- 便于创建 logger 的 `get_logger(__name__)` 助手
-- 自动注入调用上下文 (invocation_id, function_name, trace_id)
-- 无需手动埋点的冷启动检测
-- 通过 `logger.bind(user_id="abc")` 进行上下文绑定
-- `host.json` 日志级别冲突警告
-- 友好且易读的异常堆栈轨迹输出
-- 兼容 Python 标准 `logging` 模块
+## Before / After
 
-## Installation
+**未使用** `azure-functions-logging` — 简单的 `print()` 输出，无上下文，无结构:
+
+```python
+import azure.functions as func
+
+app = func.FunctionApp()
+
+
+@app.route(route="orders")
+def process_order(req: func.HttpRequest) -> func.HttpResponse:
+    print("Processing order")        # 无 invocation_id, 无结构
+    print(f"Order: {req.get_json()}")  # PII 可能泄露, 无日志级别
+    return func.HttpResponse("OK")
+```
+
+终端输出:
+
+```
+Processing order
+Order: {'customer': 'Alice', 'total': 99.99}
+```
+
+> 无 invocation ID。无日志级别。在 Application Insights 中难以关联。
+
+**使用** `azure-functions-logging` — 结构化、可查询、生产就绪:
+
+```python
+import azure.functions as func
+
+from azure_functions_logging import get_logger, logging_context, setup_logging
+
+setup_logging()
+logger = get_logger(__name__)
+app = func.FunctionApp()
+
+
+@app.route(route="orders")
+def process_order(req: func.HttpRequest, context: func.Context) -> func.HttpResponse:
+    with logging_context(context):
+        logger.info("Processing order", order_id="o-999")
+        return func.HttpResponse("OK")
+```
+
+本地终端输出 (彩色):
+
+```
+10:30:00 INFO     function_app  Processing order  [invocation_id=abc-123-def, function_name=process_order, cold_start=true]
+```
+
+生产输出 (用于 Application Insights 的 NDJSON):
+
+```json
+{"timestamp": "2024-01-15T10:30:00+00:00", "level": "INFO", "logger": "function_app",
+ "message": "Processing order", "invocation_id": "abc-123-def",
+ "function_name": "process_order", "trace_id": null, "cold_start": true,
+ "exception": null, "extra": {"order_id": "o-999"}}
+```
+
+> 每条日志都带有 `invocation_id` 和 `cold_start`。可在 Application Insights 中查询。零 `print()` 语句。
+
+> **注意:** 确切的 Application Insights schema 取决于您的 ingestion 管道。在某些部署中，JSON 字段被解析为 `customDimensions`；在其他部署中，JSON 保留在 `message` 列中。下面提供了两种形式的示例。
+
+### 在 Application Insights 中查询
+
+#### 当 JSON 字段被解析为 `customDimensions` 时
+
+```kql
+traces
+| where customDimensions.invocation_id == "abc-123-def"
+| project timestamp, message, customDimensions.cold_start, customDimensions.function_name
+| order by timestamp asc
+```
+
+查找过去 1 小时内的所有冷启动:
+
+```kql
+traces
+| where customDimensions.cold_start == "true"
+| where timestamp > ago(1h)
+| summarize count() by bin(timestamp, 5m)
+```
+
+#### 当 JSON 保留在 `message` 列中时
+
+```kql
+traces
+| extend payload = parse_json(message)
+| where tostring(payload.invocation_id) == "abc-123-def"
+| project timestamp, tostring(payload.message), tostring(payload.cold_start), tostring(payload.function_name)
+| order by timestamp asc
+```
+
+查找过去 1 小时内的所有冷启动:
+
+```kql
+traces
+| extend payload = parse_json(message)
+| where tostring(payload.cold_start) == "true"
+| where timestamp > ago(1h)
+| summarize count() by bin(timestamp, 5m)
+```
+
+## 本包不做什么
+
+本包不拥有:
+
+- **替换 stdlib logging** — 它包装并丰富 Python 标准 `logging`，从不替换它
+- **分布式追踪** — 端到端追踪关联请使用 OpenTelemetry 或 Application Insights SDK
+- **API 文档** — API 文档和 spec 生成请使用 [`azure-functions-openapi`](https://github.com/yeongseon/azure-functions-openapi-python)
+
+## 安装
 
 ```bash
 pip install azure-functions-logging
 ```
 
-本地开发用:
-
-```bash
-git clone https://github.com/yeongseon/azure-functions-logging-python.git
-cd azure-functions-logging-python
-pip install -e .[dev]
-```
-
 ## Quick Start
 
 ```python
-from azure_functions_logging import get_logger, setup_logging
+import azure.functions as func
+from azure_functions_logging import get_logger, logging_context, setup_logging
 
 setup_logging()
-
 logger = get_logger(__name__)
-logger.info("Processing request")
+
+app = func.FunctionApp()
+
+@app.route(route="hello")
+def hello(req: func.HttpRequest, context: func.Context) -> func.HttpResponse:
+    with logging_context(context):  # 绑定 invocation_id, function_name, cold_start; 退出时重置
+        logger.info("Request received")
+        # {"level": "INFO", "invocation_id": "abc-123", "cold_start": true, ...}
+
+        return func.HttpResponse("OK")
 ```
 
-### JSON Output
+`logging_context` 是推荐的主要模式: 在进入时注入上下文，并在退出时 **始终** 恢复先前的上下文 (即使处理程序抛出异常)，这可以防止陈旧的上下文在重用 worker 时泄漏到下一次调用。
+
+如需较低级别的控制或与自定义中间件集成，请使用基于令牌 (token) 的恢复:
+
+```python
+tokens = inject_context(context)
+try:
+    logger.info("Request received")
+finally:
+    restore_context(tokens)
+```
+
+仅当您有意清除所有上下文时 (例如测试 teardown)，才使用 `reset_context()`。
+
+在本地启动 Functions host (使用 [e2e 示例应用](examples/e2e_app)):
+
+```bash
+func start
+```
+
+### 在本地与 Azure 上验证
+
+部署后 (参见 [docs/deployment.md](docs/deployment.md))，相同的请求在两个环境中产生相同的响应。
+
+#### 本地
+
+```bash
+curl -s http://localhost:7071/api/logme?correlation_id=demo-123
+```
+
+```json
+{"logged": true, "correlation_id": "demo-123"}
+```
+
+#### Azure
+
+```bash
+curl -s "https://<your-app>.azurewebsites.net/api/logme?correlation_id=demo-123"
+```
+
+```json
+{"logged": true, "correlation_id": "demo-123"}
+```
+
+> 已在 koreacentral 区域的临时 Azure Functions 部署上验证 (Python 3.12, Consumption plan)。已捕获响应，并对 URL 进行匿名化。
+
+## 调用上下文 (Invocation Context)
+
+使用 `logging_context()` 在处理程序运行期间绑定调用上下文。它会设置:
+
+- `invocation_id` — 每次执行唯一，关联一个请求的所有日志
+- `function_name` — Azure Functions 函数名
+- `trace_id` — 来自平台的 trace 上下文
+- `cold_start` — 此 worker 进程的首次调用时为 `True`
+
+> **`cold_start` 语义。** `cold_start=True` 表示 *模块加载后此 Python worker 进程观察到的首次调用*。它**不是**平台级别的冷启动指标，与 Azure Functions 指标报告的 App Service plan / instance 分配冷启动不对应。在同一 worker 上的后续调用，在 worker 被回收之前会发出 `cold_start=False`。
+
+```python
+def my_function(req, context):
+    with logging_context(context):
+        logger.info("handler started")
+        # 从此处开始的每条日志都带有 invocation_id 和 cold_start
+```
+
+如需较低级别的控制 (例如中间件)，请使用 `inject_context()` 配合 `restore_context()`:
+
+```python
+tokens = inject_context(context)
+try:
+    logger.info("handler started")
+finally:
+    restore_context(tokens)
+```
+
+不进行上下文注入时，每条日志中这些字段都为 `None`。
+
+### `with_context` 装饰器
+
+为减少样板代码，可使用 `with_context` 装饰器代替手动调用 `inject_context()`:
+
+```python
+import azure.functions as func
+from azure_functions_logging import get_logger, setup_logging, with_context
+
+setup_logging()
+logger = get_logger(__name__)
+
+app = func.FunctionApp()
+
+@app.route(route="hello")
+@with_context
+def hello(req: func.HttpRequest, context: func.Context) -> func.HttpResponse:
+    logger.info("Request received")
+    return func.HttpResponse("OK")
+```
+
+装饰器按名称查找 `context` 参数，在处理程序运行前调用 `inject_context()`，并在返回后的 `finally` 中重置上下文变量。
+
+自定义参数名:
+
+```python
+@with_context(param="ctx")
+def hello(req: func.HttpRequest, ctx: func.Context) -> func.HttpResponse:
+    ...
+```
+
+支持同步与异步处理程序。
+
+### 全局 LogRecordFactory (opt-in)
+
+对于在 `setup_logging()` 之后可能添加处理程序的应用，或希望无论处理程序/过滤器如何配置都让 **每个** `LogRecord` 都带有调用上下文的应用，请在启动时安装一次全局上下文工厂:
+
+```python
+from azure_functions_logging import install_context_factory, setup_logging
+
+install_context_factory()  # 在记录创建时注入上下文
+setup_logging()
+```
+
+启用后，`invocation_id`、`function_name`、`trace_id` 和 `cold_start` 将成为保留的 `LogRecord` 属性。通过 stdlib `extra=` 传递它们将引发 `KeyError`。请使用 `FunctionLogger` (它会自动清理键名) 或选择不同的键名。
+
+> **与 `setup_logging()` 的关系:** `setup_logging()` 默认仍然在处理程序上安装 `ContextFilter`。两者可以同时调用 — 它们设置相同的值，因此不会冲突。`install_context_factory()` 确保在稍后添加的处理程序或绕过过滤器链的 logger 上也能覆盖。
+
+## 结构化 JSON 输出 (生产)
+
+当日志流向 Application Insights 或任何聚合系统时，请使用 JSON 格式:
+
+> **注意:** `format` 参数仅影响本库创建的处理程序 (本地开发)。
+> 在 Azure Functions 中，host 管理处理程序。要在 host 管理的处理程序上设置 JSON 输出，请使用
+> `functions_formatter=JsonFormatter()`。在 Azure 中传递 `format="json"` 会发出警告。
+
+对于独立的本地开发或 CI 输出:
 
 ```python
 setup_logging(format="json")
-
-logger = get_logger(__name__)
-logger.info("Processing request")
-# {"timestamp": "...", "level": "INFO", "logger": "...", "message": "Processing request", ...}
 ```
 
-### Context Injection
+对于 Azure Functions / Core Tools，host 拥有处理程序。要在现有的 host 管理处理程序上强制使用 JSON 格式:
 
 ```python
-from azure_functions_logging import inject_context
+from azure_functions_logging import JsonFormatter, setup_logging
 
-def my_function(req, context):
-    inject_context(context)
-    logger.info("Handling request")  # includes invocation_id, function_name, trace_id
+setup_logging(functions_formatter=JsonFormatter())
 ```
 
-### Context Binding
+每行日志输出 (NDJSON — 每行一个 JSON 对象):
+
+```json
+{"timestamp": "2024-01-15T10:30:00+00:00", "level": "INFO", "logger": "my_module",
+ "message": "order accepted", "invocation_id": "abc-123", "function_name": "OrderHandler",
+ "cold_start": false, "trace_id": "00-abc...", "exception": null,
+ "extra": {"order_id": "o-999"}}
+```
+
+额外字段出现在 `extra` 中，并可在 Application Insights 中索引:
 
 ```python
-bound = logger.bind(user_id="abc", operation="checkout")
-bound.info("Processing")  # includes user_id + operation in every log line
+logger.info("order accepted", order_id="o-999", tenant_id="t-1")
 ```
 
-## Documentation
+## host.json 冲突检测
+
+如果您的 `host.json` 抑制了应用发出的日志级别，启动时会出现以下警告:
+
+```
+WARNING: host.json logLevel.default is 'Warning'. Logs below WARNING will be suppressed in Azure.
+```
+
+推荐的 `host.json` 基线:
+
+```json
+{
+  "version": "2.0",
+  "logging": {
+    "logLevel": {
+      "default": "Information",
+      "Function": "Information"
+    }
+  }
+}
+```
+
+### 发现顺序
+
+`host.json` 通过从当前工作目录向上遍历来定位:
+
+1. `cwd/host.json`
+2. 每个父目录，最多 5 层深。
+
+第一个存在的文件被采用。要绕过自动发现 (例如在测试或非标准布局中)，请传递显式路径:
+
+```python
+from pathlib import Path
+from azure_functions_logging import setup_logging
+
+setup_logging(host_json_path=Path("/site/wwwroot/host.json"))
+```
+
+## 噪声控制
+
+在不删除嘈杂第三方 logger 的情况下抑制它们:
+
+```python
+from azure_functions_logging import SamplingFilter, setup_logging
+import logging
+
+setup_logging()
+
+# 在 1 秒窗口内允许最多 10 条 azure-core 消息
+logging.getLogger("azure").addFilter(SamplingFilter(rate=10))
+
+# 在生产环境完全静默 urllib3
+logging.getLogger("urllib3").setLevel(logging.WARNING)
+```
+
+## PII Redaction
+
+在敏感字段到达 Application Insights 之前剥离它们:
+
+```python
+from azure_functions_logging import RedactionFilter, setup_logging
+import logging
+
+setup_logging()
+root = logging.getLogger()
+root.addFilter(RedactionFilter(sensitive_keys=["password", "token", "secret"]))
+```
+
+extra 字段中键名匹配 sensitive 键的任何日志记录将其值替换为 `***`。
+
+## 本地 vs 云端
+
+| 环境 | 格式 | 行为 |
+|------|------|------|
+| 本地终端 | `color` (默认) | 彩色 `[TIME] [LEVEL] [LOGGER] message` |
+| Azure / Core Tools | host-managed | 仅安装上下文过滤器；通过 `functions_formatter=JsonFormatter()` 在 host 处理程序上强制 NDJSON |
+| CI / 管道 | `json` | NDJSON, 机器可解析 |
+
+`setup_logging()` 检测 `FUNCTIONS_WORKER_RUNTIME` 和 `WEBSITE_INSTANCE_ID` 来自动选择正确路径。在 Azure 中，它安装上下文过滤器而不添加处理程序 (避免来自 host 管道的重复输出)。
+
+## 上下文绑定
+
+将请求范围的元数据附加到每条日志，而无需在每次调用中传递它:
+
+```python
+def process_order(order_id: str) -> None:
+    order_logger = logger.bind(order_id=order_id, region="eastus")
+    order_logger.info("processing started")   # 包含 order_id + region
+    order_logger.info("processing complete")  # 相同元数据，新消息
+```
+
+按调用创建绑定的 logger。不要在模块级别缓存它们。
+
+## 何时使用
+
+- 您需要在 Application Insights 中获得结构化、可查询的日志时
+- 您希望对单个请求的所有日志进行 `invocation_id` 关联时
+- 您需要无需自定义 instrumentation 的冷启动检测时
+- 您希望对第三方 logger 进行 PII redaction 或噪声控制时
+- 您的 `host.json` 配置静默抑制日志而您不知道原因时
+
+## 文档
 
 - 完整文档: [yeongseon.github.io/azure-functions-logging-python](https://yeongseon.github.io/azure-functions-logging-python/)
-- 产品需求文档: `PRD.md`
+- [Configuration reference](https://yeongseon.github.io/azure-functions-logging-python/configuration/)
+- [Troubleshooting guide](https://yeongseon.github.io/azure-functions-logging-python/troubleshooting/)
+- [API reference](https://yeongseon.github.io/azure-functions-logging-python/api/)
 
-## Ecosystem
+## 生态系统
 
-- [azure-functions-validation](https://github.com/yeongseon/azure-functions-validation) — 请求与响应校验
-- [azure-functions-openapi](https://github.com/yeongseon/azure-functions-openapi) — OpenAPI 与 Swagger UI
-- [azure-functions-langgraph](https://github.com/yeongseon/azure-functions-langgraph) — LangGraph 部署适配器
-- [azure-functions-doctor](https://github.com/yeongseon/azure-functions-doctor) — 诊断 CLI
-- [azure-functions-scaffold](https://github.com/yeongseon/azure-functions-scaffold) — 项目脚手架
-- [azure-functions-durable-graph](https://github.com/yeongseon/azure-functions-durable-graph) — 基于 Durable Functions 的图运行时 *(计划中)*
-- [azure-functions-python-cookbook](https://github.com/yeongseon/azure-functions-python-cookbook) — 食谱与示例
+本包是 **Azure Functions Python DX Toolkit** 的一部分。
 
-## Disclaimer
+**设计原则:** `azure-functions-logging` 拥有结构化日志和调用感知的可观测性。它丰富 Python 的标准 `logging` — 不替换它。相邻关注点属于 [`azure-functions-openapi`](https://github.com/yeongseon/azure-functions-openapi-python) (API 文档与 spec 生成)、[`azure-functions-validation`](https://github.com/yeongseon/azure-functions-validation-python) (请求/响应验证与序列化) 以及 [`azure-functions-langgraph`](https://github.com/yeongseon/azure-functions-langgraph-python) (LangGraph 运行时暴露)。
+
+| 包 | 角色 |
+|----|------|
+| [azure-functions-openapi-python](https://github.com/yeongseon/azure-functions-openapi-python) | OpenAPI spec 生成与 Swagger UI |
+| [azure-functions-validation-python](https://github.com/yeongseon/azure-functions-validation-python) | 请求/响应验证与序列化 |
+| [azure-functions-db-python](https://github.com/yeongseon/azure-functions-db-python) | 适用于 SQL、PostgreSQL、MySQL、SQLite 和 Cosmos DB 的数据库绑定 |
+| [azure-functions-langgraph-python](https://github.com/yeongseon/azure-functions-langgraph-python) | Azure Functions 的 LangGraph 部署适配器 |
+| [azure-functions-scaffold-python](https://github.com/yeongseon/azure-functions-scaffold-python) | 项目脚手架 CLI |
+| **azure-functions-logging-python** | 结构化日志与可观测性 |
+| [azure-functions-doctor-python](https://github.com/yeongseon/azure-functions-doctor-python) | 部署前诊断 CLI |
+| [azure-functions-durable-graph-python](https://github.com/yeongseon/azure-functions-durable-graph-python) | 基于 Durable Functions 的清单优先 (manifest-first) 图运行时 *(experimental)* |
+| [azure-functions-knowledge-python](https://github.com/yeongseon/azure-functions-knowledge-python) | 知识检索 (RAG) 装饰器 |
+| [azure-functions-cookbook-python](https://github.com/yeongseon/azure-functions-cookbook-python) | 自食狗粮示例 — 演练完整 toolkit 的可运行配方 |
+
+
+## 给 AI 编码助手的说明
+
+本包为 Azure Functions 提供结构化日志，对 stdlib logging 零修改。
+
+**LLM 友好资源:**
+- `llms.txt` — 简洁的 API 参考与 quick start (仓库根目录)
+- `llms-full.txt` — 完整的 API 签名、模式与设计原则 (仓库根目录)
+
+**代码生成的关键实现细节:**
+
+1. **从不修改 root logger** — 仅在处理程序上安装过滤器/格式化器
+2. **上下文注入基于 contextvar** — 不是 thread-local，与 asyncio 协同工作
+3. **幂等 setup** — 多次调用 `setup_logging()` 是安全的
+4. **两个环境，两种行为**:
+   - Azure/Core Tools: 仅在现有 root 处理程序上安装过滤器 (尊重 host.json)
+   - 本地开发: 向指定 logger 添加 ColorFormatter 或 JsonFormatter 处理程序
+5. **测试友好**:
+   - `inject_context()` 接受任何对象 (对 azure.functions.Context 没有强依赖)
+   - `with_context` 装饰器在同步与异步处理程序中都有效
+   - 如需要，可在测试 teardown 中使用 `reset_context()`
+
+**生成代码时:**
+- 仅从 `azure_functions_logging` 公共 API 导入 (无下划线)
+- 在模块级别或处理程序启动时调用 `setup_logging()` (而不是每次请求)
+- 在处理程序中优先使用 `with logging_context(context):`; 仅在配合 `try/finally restore_context(tokens)` 时使用原始 `inject_context(context)`
+- 对每次请求的字段使用 `logger.bind(key=value)` (而不是直接 logger.extra)
+- 对 PII 字段应用 `RedactionFilter`，对高频日志应用 `SamplingFilter`
+
+**示例模式:**
+```python
+from azure_functions_logging import get_logger, logging_context, setup_logging
+
+# 模块级
+setup_logging()
+logger = get_logger(__name__)
+
+# 每个处理程序
+def my_function(req: func.HttpRequest, context: func.Context) -> func.HttpResponse:
+    with logging_context(context):
+        req_logger = logger.bind(correlation_id=req.params.get("id"))
+        req_logger.info("Processing")
+        return func.HttpResponse("OK")
+```
+
 
 本项目是独立的社区项目，与 Microsoft 没有关联，也未获得 Microsoft 的认可或维护。
 
 Azure 和 Azure Functions 是 Microsoft Corporation 的商标。
 
-## License
+## 许可证
 
 MIT

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,7 +9,7 @@ Production-oriented, developer-friendly logging for the Azure Functions Python v
 Copy this into your function module:
 
 ```python
-from azure_functions_logging import get_logger, setup_logging
+from azure_functions_logging import get_logger, logging_context, setup_logging
 
 setup_logging()
 logger = get_logger(__name__)
@@ -35,10 +35,14 @@ This library addresses those gaps with a small API surface.
 - `setup_logging()` one-liner startup configuration.
 - Local colorized output (`format="color"`) for fast visual scanning.
 - Structured NDJSON output (`format="json"`) for production ingestion.
-- `inject_context(context)` to add invocation metadata fields.
+- `logging_context(context)` context manager that always restores prior context on exit (recommended).
+- `inject_context(context)` returns `ContextTokens` for paired `restore_context(tokens)` use in middleware.
+- `install_context_factory()` opt-in global LogRecordFactory so context flows to every `LogRecord`.
+- `JsonFormatter` for host-managed handlers via `setup_logging(functions_formatter=JsonFormatter())`.
 - Automatic `cold_start` flag detection on first invocation per process.
 - `FunctionLogger.bind()` for immutable request-scoped context binding.
-- Host-level `host.json` conflict warnings when Azure suppresses lower-level logs.
+- `FunctionLogger.log()` and `FunctionLogger.hasHandlers()` for stdlib parity.
+- Host-level `host.json` conflict warnings, with `host_json_path=` override and bounded parent-walk discovery.
 - Idempotent setup to avoid duplicate reconfiguration.
 
 ## What Gets Logged
@@ -54,9 +58,9 @@ Depending on formatter and context, events include:
 
 ```python
 import azure.functions as func
-from azure_functions_logging import get_logger, inject_context, setup_logging
+from azure_functions_logging import JsonFormatter, get_logger, logging_context, setup_logging
 
-setup_logging(format="json")
+setup_logging(functions_formatter=JsonFormatter())
 logger = get_logger(__name__)
 
 app = func.FunctionApp()
@@ -64,13 +68,13 @@ app = func.FunctionApp()
 
 @app.route(route="health")
 def health(req: func.HttpRequest, context: func.Context) -> func.HttpResponse:
-    inject_context(context)
-    request_logger = logger.bind(route="/health", method=req.method)
-    request_logger.info("health endpoint called")
-    return func.HttpResponse("ok", status_code=200)
+    with logging_context(context):
+        request_logger = logger.bind(route="/health", method=req.method)
+        request_logger.info("health endpoint called")
+        return func.HttpResponse("ok", status_code=200)
 ```
 
-This combines runtime context injection and request binding in a safe, explicit flow.
+This combines context-managed invocation context and request binding in a safe, explicit flow that always restores prior context on exit (even on exceptions).
 
 ## Environment-Aware Behavior
 
@@ -119,10 +123,9 @@ It is a focused logging utility, not a full observability stack.
 
 If you are integrating today:
 
-1. Add package and call `setup_logging()` once.
-2. Update handlers to call `inject_context(context)`.
-3. Add request-scoped keys with `bind()`.
-4. Select `json` format for production tiers.
-5. Verify `host.json` level settings to avoid silent suppression.
-
+1. Add the package and call `setup_logging()` once at startup.
+2. Wrap each handler body in `with logging_context(context):` (or apply `@with_context`).
+3. Add request-scoped keys with `logger.bind()`.
+4. Use `setup_logging(functions_formatter=JsonFormatter())` to emit NDJSON on host-managed handlers in Azure.
+5. Verify `host.json` level settings (or pass `host_json_path=`) to avoid silent suppression.
 When these are complete, your logs become immediately easier to read, correlate, and operate.

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -5,7 +5,7 @@
 ## Package Info
 
 - PyPI: `pip install azure-functions-logging`
-- Version: 0.4.1
+- Version: 0.7.1
 - Python: >=3.10, <3.15
 - License: MIT
 - Docs: https://yeongseon.github.io/azure-functions-logging-python/
@@ -23,6 +23,7 @@ pip install azure-functions-logging
 
 ```python
 from azure_functions_logging import setup_logging
+from pathlib import Path
 import logging
 
 def setup_logging(
@@ -31,22 +32,27 @@ def setup_logging(
     format: str = "color",
     logger_name: str | None = None,
     functions_formatter: logging.Formatter | None = None,
+    host_json_path: Path | None = None,
 ) -> None:
     """Configure logging for the current environment.
-    
+
     Behavior depends on detected environment:
     - **Azure / Core Tools**: Installs ContextFilter on root logger's handlers only.
       Does NOT add handlers or modify root logger level (respects host.json).
+      If `functions_formatter` is provided, it is applied to host-managed handlers.
     - **Standalone local**: Adds StreamHandler with ColorFormatter or JsonFormatter.
-    
+
     This function is idempotent per logger_name.
-    
+
     Args:
         level: Logging level for local dev. Ignored in Azure/Core Tools (default: INFO).
         format: Log format: "color" (default) or "json". Ignored if functions_formatter provided.
+                Passing format="json" in Azure emits a warning; use functions_formatter instead.
         logger_name: Optional logger name to configure. None = root logger.
-        functions_formatter: Custom formatter for Azure/Core Tools handlers.
-    
+        functions_formatter: Custom formatter for Azure/Core Tools host-managed handlers.
+        host_json_path: Explicit path to host.json. When None, walks up from cwd up to 5
+                        levels deep to discover host.json automatically.
+
     Raises:
         ValueError: If format not in {"color", "json"}.
     """
@@ -59,74 +65,44 @@ def setup_logging(
 from azure_functions_logging import get_logger, FunctionLogger
 
 def get_logger(name: str | None = None) -> FunctionLogger:
-    """Create a FunctionLogger wrapping a standard logging.Logger.
-    
-    Args:
-        name: Logger name. Typically __name__. None = root logger.
-    
-    Returns:
-        A FunctionLogger instance.
-    """
+    """Create a FunctionLogger wrapping a standard logging.Logger."""
     ...
 
 class FunctionLogger:
     """Wrapper around logging.Logger with context binding.
-    
-    Delegates all standard logging methods to underlying logger.
-    The bind() method returns new wrapper with merged context.
+
+    Delegates standard logging methods to the underlying logger.
+    The bind() method returns a new wrapper with merged context.
+    Reserved keys (invocation_id, function_name, trace_id, cold_start) are
+    automatically sanitized before being forwarded to stdlib logging.
     """
-    
-    def __init__(self, logger: logging.Logger) -> None:
-        """Wrap a standard logger."""
-        ...
-    
+
+    def __init__(self, logger: logging.Logger) -> None: ...
+
     @property
-    def name(self) -> str:
-        """Return underlying logger name."""
-        ...
-    
+    def name(self) -> str: ...
+
     def bind(self, **kwargs: Any) -> FunctionLogger:
-        """Return new FunctionLogger with merged context.
-        
-        Context from bind() is supplementary to global context
-        (invocation_id, function_name, etc.) from inject_context().
-        
-        Args:
-            **kwargs: Context key-value pairs to bind.
-        
-        Returns:
-            New FunctionLogger with merged context.
-        """
+        """Return new FunctionLogger with merged context."""
         ...
-    
-    def clear_context(self) -> None:
-        """Clear all bound context fields."""
+
+    def clear_context(self) -> None: ...
+
+    def hasHandlers(self) -> bool:
+        """Stdlib parity: True if any handler is reachable up the chain."""
         ...
-    
-    # Standard logging methods (all support extra= and context binding):
-    def debug(self, msg: object, *args: Any, **kwargs: Any) -> None:
-        """Log DEBUG message."""
+
+    def log(self, level: int, msg: object, *args: Any, **kwargs: Any) -> None:
+        """Stdlib parity: log at arbitrary numeric level. Routes through internal
+        sanitization and bound-context merging like the named-level methods."""
         ...
-    
-    def info(self, msg: object, *args: Any, **kwargs: Any) -> None:
-        """Log INFO message."""
-        ...
-    
-    def warning(self, msg: object, *args: Any, **kwargs: Any) -> None:
-        """Log WARNING message."""
-        ...
-    
-    def error(self, msg: object, *args: Any, **kwargs: Any) -> None:
-        """Log ERROR message."""
-        ...
-    
-    def critical(self, msg: object, *args: Any, **kwargs: Any) -> None:
-        """Log CRITICAL message."""
-        ...
-    
-    def exception(self, msg: object, *args: Any, **kwargs: Any) -> None:
-        """Log ERROR with exception traceback."""
-        ...
+
+    def debug(self, msg: object, *args: Any, **kwargs: Any) -> None: ...
+    def info(self, msg: object, *args: Any, **kwargs: Any) -> None: ...
+    def warning(self, msg: object, *args: Any, **kwargs: Any) -> None: ...
+    def error(self, msg: object, *args: Any, **kwargs: Any) -> None: ...
+    def critical(self, msg: object, *args: Any, **kwargs: Any) -> None: ...
+    def exception(self, msg: object, *args: Any, **kwargs: Any) -> None: ...
 ```
 
 ### JSON Formatter
@@ -222,25 +198,80 @@ class RedactionFilter(logging.Filter):
 ### Context Injection
 
 ```python
-from azure_functions_logging import inject_context, with_context
+from azure_functions_logging import (
+    ContextTokens,
+    inject_context,
+    logging_context,
+    restore_context,
+    reset_context,
+    install_context_factory,
+    get_logging_metadata,
+    with_context,
+)
 import azure.functions as func
 
-def inject_context(context: Any) -> None:
-    """Set invocation context from Azure Functions context object.
-    
-    Extracts invocation_id, function_name, trace_id, cold_start
-    and stores in contextvars. Safe to call with any object;
-    missing attributes silently ignored (context failures never
-    cause application failures).
-    
-    Args:
-        context: An Azure Functions context object (func.Context).
-    
+class ContextTokens:
+    """Bundle of contextvars Tokens returned by inject_context().
+    Pass to restore_context() to undo a single inject_context() call.
+    Treat as opaque.
+    """
+
+def inject_context(context: Any) -> ContextTokens:
+    """Set invocation context from an Azure Functions context object.
+
+    Extracts invocation_id, function_name, trace_id, cold_start and stores
+    them in contextvars. Returns a ContextTokens bundle that can be passed
+    to restore_context() to undo this specific injection.
+
+    Safe to call with any object; missing attributes are silently ignored
+    (context failures never cause application failures).
+
     Example:
         def handler(req, context):
-            inject_context(context)  # Must be first line
-            logger.info("Processing")  # Includes invocation_id, cold_start
+            tokens = inject_context(context)
+            try:
+                logger.info("Processing")
+            finally:
+                restore_context(tokens)
     """
+    ...
+
+def restore_context(tokens: ContextTokens) -> None:
+    """Restore the previous contextvar values captured in tokens.
+    Always pair with the matching inject_context() call."""
+    ...
+
+def reset_context() -> None:
+    """Unconditionally clear all context vars. Use only in test teardown—
+    prefer logging_context() / restore_context() in production code."""
+    ...
+
+def logging_context(context: Any) -> ContextManager[None]:
+    """Recommended primary pattern. Context manager that calls inject_context()
+    on enter and **always** calls restore_context() on exit (even when the body
+    raises). Prevents stale context from leaking into the next invocation on a
+    reused worker.
+
+    Example:
+        def handler(req, context):
+            with logging_context(context):
+                logger.info("handler started")
+    """
+    ...
+
+def install_context_factory() -> None:
+    """Opt-in: install a global logging.setLogRecordFactory() that copies
+    contextvars onto every LogRecord at creation time. Ensures coverage even
+    on handlers added after setup_logging() and on loggers that bypass the
+    filter chain. Once installed, invocation_id/function_name/trace_id/
+    cold_start become reserved LogRecord attributes—passing them via stdlib
+    extra= raises KeyError. Use FunctionLogger (auto-sanitizes) or rename keys.
+    """
+    ...
+
+def get_logging_metadata() -> dict[str, Any]:
+    """Return introspection metadata: package version, factory installed flag,
+    detected environment (azure/local), discovered host.json path, etc."""
     ...
 ```
 
@@ -258,30 +289,12 @@ def with_context(
     param: str = "context",
 ) -> _F | Callable[[_F], _F]:
     """Decorator that automatically injects invocation context.
-    
-    Finds the context parameter, calls inject_context() before handler,
-    and resets context variables in finally. Both sync and async supported.
-    
-    Usage without args:
-        @with_context
-        def handler(req, context):
-            logger.info("Automatic context")
-    
-    Usage with custom param name:
-        @with_context(param="ctx")
-        def handler(req, ctx):
-            logger.info("Still automatic")
-    
-    Args:
-        func: Handler function (when used without parentheses).
-        param: Context parameter name (default: "context").
-    
-    Returns:
-        Decorated function with auto context injection.
+
+    Finds the context parameter, calls inject_context() before the handler,
+    and calls restore_context() in finally. Sync and async handlers supported.
     """
     ...
 ```
-
 ### Contextvar Helpers (Advanced)
 
 ```python
@@ -327,6 +340,13 @@ class ContextFilter(logging.Filter):
 4. **Silent on context failures** — Missing attributes don't cause exceptions
 5. **Idempotent setup** — Calling setup_logging() multiple times is safe
 6. **Standard logging delegates** — FunctionLogger wraps, never replaces stdlib logging
+7. **Always-restoring context** — logging_context() / restore_context() prevent stale
+   context from leaking into the next invocation on a reused worker
+8. **Strict W3C traceparent validation** — _extract_trace_id() validates Trace Context
+   Level 1 (4 parts; 2/32/16/2 hex; rejects version ff and all-zero trace/span ids;
+   forward-compatible with future versions)
+9. **Bounded host.json discovery** — walks up from cwd, max 5 parent levels;
+   override with host_json_path= for tests / non-standard layouts
 
 ## Common Patterns
 

--- a/llms.txt
+++ b/llms.txt
@@ -5,7 +5,7 @@
 ## Package Info
 
 - PyPI: `pip install azure-functions-logging`
-- Version: 0.4.1
+- Version: 0.7.1
 - Python: >=3.10, <3.15
 - License: MIT
 - Docs: https://yeongseon.github.io/azure-functions-logging-python/
@@ -25,20 +25,26 @@ Key features:
 
 ## Core API
 
-- `setup_logging(level, format, ...)` — One-call logging setup for local or Azure
+- `setup_logging(level, format, functions_formatter, host_json_path, ...)` — One-call logging setup for local or Azure
 - `get_logger(name)` → `FunctionLogger` — Create a logger with context binding support
-- `FunctionLogger` — Enhanced logger wrapper with `bind()` for context
-- `JsonFormatter` — JSON log formatter (NDJSON)
+- `FunctionLogger` — Enhanced logger wrapper with `bind()`, `log()`, `hasHandlers()` for stdlib parity
+- `JsonFormatter` — JSON log formatter (NDJSON), use with `functions_formatter=` in Azure
 - `RedactionFilter` — Filter to redact sensitive fields (password, token, api_key, etc.)
 - `SamplingFilter` — Filter for log sampling/rate-limiting noisy loggers
-- `inject_context(context)` — Set contextvars-based fields from Azure Functions context
+- `logging_context(context)` — **Recommended** context manager: injects on enter, always restores on exit
+- `inject_context(context)` → `ContextTokens` — Set contextvars; returns tokens for paired restore
+- `restore_context(tokens)` — Restore previous contextvars from tokens (paired with `inject_context`)
+- `reset_context()` — Clear all context vars unconditionally (for test teardown)
 - `with_context` — Decorator to inject context per-request (sync/async)
+- `install_context_factory()` — Opt-in global LogRecordFactory so context flows to every record
+- `get_logging_metadata()` — Inspect installation state (factory installed, version, etc.)
+- `ContextTokens` — Typed token bundle returned by `inject_context()`
 
 ## Quick Start
 
 ```python
 import azure.functions as func
-from azure_functions_logging import get_logger, inject_context, setup_logging
+from azure_functions_logging import get_logger, logging_context, setup_logging
 
 setup_logging()
 logger = get_logger(__name__)
@@ -47,9 +53,9 @@ app = func.FunctionApp()
 
 @app.route(route="hello")
 def hello(req: func.HttpRequest, context: func.Context) -> func.HttpResponse:
-    inject_context(context)  # binds invocation_id, function_name, cold_start
-    logger.info("Request received")
-    return func.HttpResponse("OK")
+    with logging_context(context):  # binds invocation_id, function_name, cold_start; always restores on exit
+        logger.info("Request received")
+        return func.HttpResponse("OK")
 ```
 
 Or use the decorator:


### PR DESCRIPTION
## Summary

Closes #105.

Synchronizes Korean, Japanese, and Simplified Chinese READMEs with the English README v0.7.x structure, and refreshes `llms.txt` / `llms-full.txt` / `docs/index.md` to reflect the v0.7.1 API surface.

## Changes

- **README.ko.md / README.ja.md / README.zh-CN.md**: full rewrite mirroring English README sections (Why this exists, Before-After, KQL queries, host.json conflict detection with discovery order, with_context decorator, ContextTokens, etc.)
- **llms.txt**: bumped 0.4.1 → 0.7.1; added `logging_context`, `restore_context`, `reset_context`, `install_context_factory`, `get_logging_metadata`, `ContextTokens` to Core API; updated Quick Start to use `logging_context`
- **llms-full.txt**: bumped to 0.7.1; documented `setup_logging(host_json_path=...)`, `FunctionLogger.log()` / `hasHandlers()`, `ContextTokens`, `logging_context`, `restore_context`, `reset_context`, `install_context_factory`, `get_logging_metadata`; expanded design principles with W3C Trace Context Level 1 validation and bounded host.json discovery
- **docs/index.md**: Quick Start updated to `logging_context`; Azure handler example uses `JsonFormatter` + `logging_context`

## Verification

- `make lint` ✅
- `make typecheck` ✅ (24 source files, no issues)
- `make test` ✅ (199 passed, 3 skipped, coverage 95.25%)
- `make build` ✅ (sdist + wheel)