### PR TITLE
docs: clarify Azure Functions JSON output requires functions_formatter

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -91,9 +91,10 @@ Behavior changes intentionally by runtime:
 Use these defaults unless you have a specific reason to diverge:
 
 - Local development: `setup_logging(format="color")`
-- Production environments: `setup_logging(format="json")`
+- Production (standalone): `setup_logging(format="json")`
+- Production (Azure Functions / Core Tools): `setup_logging(functions_formatter=JsonFormatter())` — `format="json"` alone is ignored on host-managed handlers
 - Logger creation: `get_logger(__name__)`
-- Function entrypoint: `inject_context(context)` as first operation
+- Function entrypoint: `with logging_context(context):` wrapping the body, or `tokens = inject_context(context); try: ...; finally: restore_context(tokens)`
 
 ## Documentation Map
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -359,12 +359,23 @@ setup_logging()  # Color in local, filter in Azure
 logger = get_logger(__name__)
 ```
 
-### JSON output everywhere:
+### JSON output:
+
+Standalone local process (formatter applied directly):
+
+```python
+from azure_functions_logging import setup_logging, get_logger
+
+setup_logging(format="json")
+logger = get_logger(__name__)
+```
+
+Azure Functions / Core Tools (host owns the handlers — `format="json"` alone is ignored; pass `functions_formatter` instead):
 
 ```python
 from azure_functions_logging import setup_logging, get_logger, JsonFormatter
 
-setup_logging(format="json")
+setup_logging(functions_formatter=JsonFormatter())
 logger = get_logger(__name__)
 ```
 


### PR DESCRIPTION
## Summary

Closes #111. Fixes misleading JSON output guidance in `docs/index.md` and `llms-full.txt`.

## Changes

- `docs/index.md` Recommended Defaults: split production guidance into standalone (`format="json"`) vs Azure (`functions_formatter=JsonFormatter()`); replaced bare `inject_context(context)` recommendation with `with logging_context(context):` / `restore_context(tokens)` patterns.
- `llms-full.txt` JSON output section: replaced "JSON output everywhere" example with two distinct examples — standalone local (`format="json"`) and Azure/Core Tools (`functions_formatter=JsonFormatter()`).

## Verification

- `make lint` ✅
- `make typecheck` ✅
- `make test` ✅ (199 passed, coverage 95.25%)
- `make build` ✅