### PR TITLE
docs: fix broken runnable snippets in llms.txt and llms-full.txt

### DIFF
--- a/llms-full.txt
+++ b/llms-full.txt
@@ -397,11 +397,12 @@ handler = logging.StreamHandler()
 handler.addFilter(SamplingFilter(rate=10, window=1.0))
 urllib3_logger.addHandler(handler)
 
-# Redact passwords from custom field
-custom_logger = get_logger("myapp.auth")
+# Redact passwords on a stdlib logger (FunctionLogger does not expose addHandler;
+# attach handlers/filters to the underlying stdlib logger instead).
+auth_logger = logging.getLogger("myapp.auth")
 handler = logging.StreamHandler()
 handler.addFilter(RedactionFilter())
-custom_logger.addHandler(handler)
+auth_logger.addHandler(handler)
 ```
 
 ### Per-request context with bind() (using `logging_context`):

--- a/llms.txt
+++ b/llms.txt
@@ -61,6 +61,7 @@ def hello(req: func.HttpRequest, context: func.Context) -> func.HttpResponse:
 Or use the decorator:
 
 ```python
+import azure.functions as func
 from azure_functions_logging import with_context, get_logger, setup_logging
 
 setup_logging()


### PR DESCRIPTION
## Summary
Closes #114.

Fixes broken runnable snippets identified by Oracle review of merged PR #110.

## Changes
- **`llms.txt`** decorator example: add missing `import azure.functions as func` (the snippet uses `func.HttpResponse`).
- **`llms-full.txt`** "Filtered third-party logging" example: replace `get_logger("myapp.auth").addHandler(...)` with `logging.getLogger("myapp.auth").addHandler(...)`. `FunctionLogger` does not expose `addHandler`; handlers and filters must be attached to the underlying stdlib logger.

## Validation
- `make lint` ✅
- `make typecheck` ✅
- `make test` ✅ (199 passed, coverage 95.25%)