### PR TITLE
docs: P2 polish for type accuracy and feature visibility

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -234,7 +234,7 @@ curl -s "https://<your-app>.azurewebsites.net/api/logme?correlation_id=demo-123"
 
 - `invocation_id` — 実行ごとに一意、1 リクエストのすべてのログを相関させる
 - `function_name` — Azure Functions の関数名
-- `trace_id` — プラットフォームからのトレースコンテキスト
+- `trace_id` — プラットフォームからのトレースコンテキスト。有効な W3C `traceparent` ヘッダーからのみ抽出され、厳格に検証されるため不正な値は無視されます
 - `cold_start` — この worker プロセスの最初の呼び出しで `True`
 
 > **`cold_start` のセマンティクス。** `cold_start=True` は *モジュールロード後にこの Python worker プロセスで観測された最初の呼び出し* を意味します。**プラットフォームレベル** のコールドスタートメトリックではなく、Azure Functions メトリクスが報告する App Service plan / instance 割当のコールドスタートには対応しません。同じ worker での後続の呼び出しは、worker がリサイクルされるまで `cold_start=False` を発行します。

--- a/README.ko.md
+++ b/README.ko.md
@@ -234,7 +234,7 @@ curl -s "https://<your-app>.azurewebsites.net/api/logme?correlation_id=demo-123"
 
 - `invocation_id` — 실행마다 고유, 한 요청의 모든 로그를 상관시킴
 - `function_name` — Azure Functions 함수 이름
-- `trace_id` — 플랫폼의 trace 컨텍스트
+- `trace_id` — 플랫폼의 trace 컨텍스트. 유효한 W3C `traceparent` 헤더에서만 추출되며, 유효성 검증이 엄격하여 잘못된 값은 무시됩니다
 - `cold_start` — 이 worker 프로세스의 첫 호출일 때 `True`
 
 > **`cold_start` 의미.** `cold_start=True`는 *모듈 로드 후 이 Python worker 프로세스에서 관측된 첫 호출*을 의미합니다. **플랫폼 레벨**의 cold start 메트릭이 아니며, Azure Functions 메트릭이 보고하는 App Service plan / instance 할당 cold start와는 일치하지 않습니다. 같은 worker의 후속 호출은 worker가 재활용될 때까지 `cold_start=False`를 발행합니다.

--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ Use `logging_context()` to bind invocation context for the duration of a handler
 
 - `invocation_id` — unique per execution, correlates all logs for one request
 - `function_name` — the Azure Functions function name
-- `trace_id` — trace context from the platform
+- `trace_id` — trace context from the platform; extracted only from valid W3C `traceparent` headers (strict validation, invalid values are ignored)
 - `cold_start` — `True` on first invocation of this worker process
 
 > **`cold_start` semantics.** `cold_start=True` means *the first invocation observed by this Python worker process after module load*. It is **not** a platform-level cold start metric and does not correspond to App Service plan / instance allocation cold starts reported by Azure Functions metrics. Subsequent invocations on the same worker emit `cold_start=False` until the worker is recycled.
@@ -505,6 +505,8 @@ This package provides structured logging for Azure Functions with zero modificat
 - Call `setup_logging()` at module level or handler startup (not per-request)
 - Prefer `with logging_context(context):` in handlers; use raw `inject_context(context)` only with `try/finally restore_context(tokens)`
 - Use `logger.bind(key=value)` for per-request fields (not direct logger.extra)
+- Use `with_context` decorator if you prefer to inject context implicitly per-handler
+- Call `get_logging_metadata(func)` to inspect `@with_context` metadata on a function (returns `dict[str, Any] | None`)
 - Apply `RedactionFilter` for PII fields, `SamplingFilter` for high-volume logs
 
 **Example Pattern:**

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -234,7 +234,7 @@ curl -s "https://<your-app>.azurewebsites.net/api/logme?correlation_id=demo-123"
 
 - `invocation_id` — 每次执行唯一，关联一个请求的所有日志
 - `function_name` — Azure Functions 函数名
-- `trace_id` — 来自平台的 trace 上下文
+- `trace_id` — 来自平台的 trace 上下文；仅从有效的 W3C `traceparent` 头中提取（严格校验，无效值会被忽略）
 - `cold_start` — 此 worker 进程的首次调用时为 `True`
 
 > **`cold_start` 语义。** `cold_start=True` 表示 *模块加载后此 Python worker 进程观察到的首次调用*。它**不是**平台级别的冷启动指标，与 Azure Functions 指标报告的 App Service plan / instance 分配冷启动不对应。在同一 worker 上的后续调用，在 worker 被回收之前会发出 `cold_start=False`。

--- a/docs/index.md
+++ b/docs/index.md
@@ -50,7 +50,7 @@ This library addresses those gaps with a small API surface.
 Depending on formatter and context, events include:
 
 - Timestamp, level, logger name, message.
-- Invocation metadata: `invocation_id`, `function_name`, `trace_id`, `cold_start`.
+- Invocation metadata: `invocation_id`, `function_name`, `trace_id` (from W3C `traceparent` headers, strict validation), `cold_start`.
 - Structured per-event fields from keyword arguments.
 - Bound context keys from `bind()`.
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -32,7 +32,7 @@ def setup_logging(
     format: str = "color",
     logger_name: str | None = None,
     functions_formatter: logging.Formatter | None = None,
-    host_json_path: Path | None = None,
+    host_json_path: Path | str | None = None,
 ) -> None:
     """Configure logging for the current environment.
 


### PR DESCRIPTION
## Summary
Closes #115.

P2 polish addressing remaining items from Oracle review of merged PR #110.

## Changes
- **`llms-full.txt`**: Fix `host_json_path` type annotation — `Path | str | None` (not `Path | None`), matching `_setup.py:31-38`.
- **W3C traceparent visibility** — add note about strict W3C `traceparent` validation in `trace_id` description across all 4 READMEs (`README.md`, `README.ko.md`, `README.ja.md`, `README.zh-CN.md`) and `docs/index.md`.
- **`README.md` AI Assistants guidance** — add `get_logging_metadata(func)` and `with_context` decorator usage notes.

## Validation
- `make lint` ✅
- `make typecheck` ✅
- `make test` ✅ (199 passed, coverage 95.25%)