### PR TITLE
docs: address oracle iteration 1 findings (root logger contract, redaction, runnable snippets)

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -175,7 +175,7 @@ app = func.FunctionApp()
 
 @app.route(route="hello")
 def hello(req: func.HttpRequest, context: func.Context) -> func.HttpResponse:
-    with logging_context(context):  # invocation_id, function_name, cold_start をバインド、終了時にリセット
+    with logging_context(context):  # invocation_id, function_name, cold_start をバインドし、終了時に以前のコンテキストへ復元
         logger.info("Request received")
         # {"level": "INFO", "invocation_id": "abc-123", "cold_start": true, ...}
 
@@ -187,6 +187,9 @@ def hello(req: func.HttpRequest, context: func.Context) -> func.HttpResponse:
 低レベル制御またはカスタムミドルウェアと統合する場合は、トークンベース復元を使用してください:
 
 ```python
+from azure_functions_logging import inject_context, restore_context
+
+# `logger` と `context` がスコープにあると仮定 (Quick Start を参照)。
 tokens = inject_context(context)
 try:
     logger.info("Request received")
@@ -278,7 +281,7 @@ def hello(req: func.HttpRequest, context: func.Context) -> func.HttpResponse:
     return func.HttpResponse("OK")
 ```
 
-デコレータは名前で `context` パラメータを見つけ、ハンドラ実行前に `inject_context()` を呼び出し、戻った後 `finally` でコンテキスト変数をリセットします。
+デコレータは名前で `context` パラメータを見つけ、ハンドラ実行前に `inject_context()` を呼び出し、戻った後 `finally` で以前のコンテキストへ復元します。
 
 カスタムパラメータ名:
 
@@ -332,7 +335,7 @@ setup_logging(functions_formatter=JsonFormatter())
 ```json
 {"timestamp": "2024-01-15T10:30:00+00:00", "level": "INFO", "logger": "my_module",
  "message": "order accepted", "invocation_id": "abc-123", "function_name": "OrderHandler",
- "cold_start": false, "trace_id": "00-abc...", "exception": null,
+ "cold_start": false, "trace_id": "4bf92f3577b34da6a3ce929d0e0e4736", "exception": null,
  "extra": {"order_id": "o-999"}}
 ```
 
@@ -407,7 +410,9 @@ import logging
 
 setup_logging()
 root = logging.getLogger()
-root.addFilter(RedactionFilter(sensitive_keys=["password", "token", "secret"]))
+# 名前付きの子ロガーから出力されるレコードもリダクトされるよう、フィルタはハンドラに付与します。
+for handler in root.handlers:
+    handler.addFilter(RedactionFilter(sensitive_keys=["password", "token", "secret"]))
 ```
 
 extra フィールドのキーが sensitive キーと一致するすべてのログレコードは、その値が `***` で置き換えられます。
@@ -480,7 +485,7 @@ def process_order(order_id: str) -> None:
 
 **コード生成のための主要な実装詳細:**
 
-1. **ルートロガーを変更しない** — ハンドラにのみフィルタ/フォーマッタをインストール
+1. **ホスト構成を尊重** — Azure / Core Tools ではハンドラを追加せず、ルートロガーのレベルは `host.json` に委ねます。既存のルートハンドラ (および将来追加されるハンドラのためにルートロガー自体) に `ContextFilter` のみをインストールします。ローカル単独モードでは `setup_logging(logger_name=None)` がルートロガーを構成します (レベル設定、ハンドラがなければ `StreamHandler` を追加)。
 2. **コンテキスト注入は contextvar ベース** — thread-local ではなく、asyncio で動作
 3. **冪等な setup** — `setup_logging()` を複数回呼び出しても安全
 4. **2 つの環境、2 つの動作**:
@@ -496,6 +501,8 @@ def process_order(order_id: str) -> None:
 - `setup_logging()` をモジュールレベルまたはハンドラ起動時に呼び出す (リクエストごとではない)
 - ハンドラでは `with logging_context(context):` を優先; 生の `inject_context(context)` は `try/finally restore_context(tokens)` とのみ併用
 - リクエストごとのフィールドには `logger.bind(key=value)` を使用 (logger.extra への直接アクセスではない)
+- 暗黙的なハンドラごとのコンテキスト注入を好む場合は `with_context` デコレータを使用
+- 関数の `@with_context` メタデータを検査するには `get_logging_metadata(func)` を呼び出す (`dict[str, Any] | None` を返却)
 - PII フィールドには `RedactionFilter`、大量ログには `SamplingFilter` を適用
 
 **例パターン:**

--- a/README.ko.md
+++ b/README.ko.md
@@ -175,7 +175,7 @@ app = func.FunctionApp()
 
 @app.route(route="hello")
 def hello(req: func.HttpRequest, context: func.Context) -> func.HttpResponse:
-    with logging_context(context):  # invocation_id, function_name, cold_start 바인딩 후, 종료 시 복원
+    with logging_context(context):  # invocation_id, function_name, cold_start 바인딩, 종료 시 이전 컨텍스트로 복원
         logger.info("Request received")
         # {"level": "INFO", "invocation_id": "abc-123", "cold_start": true, ...}
 
@@ -187,6 +187,9 @@ def hello(req: func.HttpRequest, context: func.Context) -> func.HttpResponse:
 저수준 제어가 필요하거나 커스텀 미들웨어와 통합할 때는 토큰 기반 복원을 사용하세요:
 
 ```python
+from azure_functions_logging import inject_context, restore_context
+
+# `logger`와 `context`가 스코프에 있다고 가정 (Quick Start 참조).
 tokens = inject_context(context)
 try:
     logger.info("Request received")
@@ -278,7 +281,7 @@ def hello(req: func.HttpRequest, context: func.Context) -> func.HttpResponse:
     return func.HttpResponse("OK")
 ```
 
-데코레이터는 이름으로 `context` 매개변수를 찾고, 핸들러 실행 전 `inject_context()`를 호출하며, 반환 후 `finally`에서 컨텍스트 변수를 리셋합니다.
+데코레이터는 이름으로 `context` 매개변수를 찾고, 핸들러 실행 전 `inject_context()`를 호출하며, 반환 후 `finally`에서 이전 컨텍스트를 복원합니다.
 
 커스텀 매개변수 이름:
 
@@ -332,7 +335,7 @@ setup_logging(functions_formatter=JsonFormatter())
 ```json
 {"timestamp": "2024-01-15T10:30:00+00:00", "level": "INFO", "logger": "my_module",
  "message": "order accepted", "invocation_id": "abc-123", "function_name": "OrderHandler",
- "cold_start": false, "trace_id": "00-abc...", "exception": null,
+ "cold_start": false, "trace_id": "4bf92f3577b34da6a3ce929d0e0e4736", "exception": null,
  "extra": {"order_id": "o-999"}}
 ```
 
@@ -407,7 +410,9 @@ import logging
 
 setup_logging()
 root = logging.getLogger()
-root.addFilter(RedactionFilter(sensitive_keys=["password", "token", "secret"]))
+# 명명된 자식 로거의 레코드도 함께 정제되도록 필터를 핸들러에 부착합니다.
+for handler in root.handlers:
+    handler.addFilter(RedactionFilter(sensitive_keys=["password", "token", "secret"]))
 ```
 
 extra 필드의 키가 sensitive 키와 일치하는 모든 로그 레코드는 해당 값이 `***`로 대체됩니다.
@@ -480,7 +485,7 @@ def process_order(order_id: str) -> None:
 
 **코드 생성을 위한 핵심 구현 세부사항:**
 
-1. **루트 로거를 절대 수정하지 않음** — 핸들러에만 필터/포매터 설치
+1. **호스트 구성 보존** — Azure / Core Tools에서는 핸들러를 추가하지 않고 루트 로거 레벨을 `host.json`에 위임하며, 기존 루트 핸들러(및 루트 로거 자체)에 `ContextFilter`만 설치합니다. 로컬 단독 모드에서는 `setup_logging(logger_name=None)`이 루트 로거를 구성합니다 (레벨 설정, 핸들러 없으면 `StreamHandler` 추가).
 2. **컨텍스트 주입은 contextvar 기반** — thread-local이 아니므로 asyncio와 호환
 3. **멱등성 보장 setup** — `setup_logging()`을 여러 번 호출해도 안전
 4. **두 환경, 두 동작**:
@@ -496,6 +501,8 @@ def process_order(order_id: str) -> None:
 - `setup_logging()`은 모듈 레벨이나 핸들러 시작 시 호출 (요청당 호출 X)
 - 핸들러에서는 `with logging_context(context):`를 우선 사용; raw `inject_context(context)`는 반드시 `try/finally restore_context(tokens)`와 함께 사용
 - 요청당 필드에는 `logger.bind(key=value)` 사용 (logger.extra 직접 X)
+- 암묵적 핸들러별 컨텍스트 주입이 필요하면 `with_context` 데코레이터 사용
+- 함수에 적용된 `@with_context` 메타데이터를 검사하려면 `get_logging_metadata(func)` 호출 (`dict[str, Any] | None` 반환)
 - PII 필드에는 `RedactionFilter`, 대량 로그에는 `SamplingFilter` 적용
 
 **예시 패턴:**

--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ app = func.FunctionApp()
 
 @app.route(route="hello")
 def hello(req: func.HttpRequest, context: func.Context) -> func.HttpResponse:
-    with logging_context(context):  # binds invocation_id, function_name, cold_start; resets on exit
+    with logging_context(context):  # binds invocation_id, function_name, cold_start; restores previous context on exit
         logger.info("Request received")
         # {"level": "INFO", "invocation_id": "abc-123", "cold_start": true, ...}
 
@@ -187,6 +187,9 @@ def hello(req: func.HttpRequest, context: func.Context) -> func.HttpResponse:
 For lower-level control or when integrating with custom middleware, use token-based restore:
 
 ```python
+from azure_functions_logging import inject_context, restore_context
+
+# Assumes `logger` and `context` are in scope (see Quick Start).
 tokens = inject_context(context)
 try:
     logger.info("Request received")
@@ -278,7 +281,7 @@ def hello(req: func.HttpRequest, context: func.Context) -> func.HttpResponse:
     return func.HttpResponse("OK")
 ```
 
-The decorator finds the `context` parameter by name, calls `inject_context()` before your handler runs, and resets context variables in `finally` after it returns.
+The decorator finds the `context` parameter by name, calls `inject_context()` before your handler runs, and restores the previous context in `finally` after it returns.
 
 Custom parameter name:
 
@@ -340,7 +343,7 @@ Output per log line (NDJSON — one JSON object per line):
 ```json
 {"timestamp": "2024-01-15T10:30:00+00:00", "level": "INFO", "logger": "my_module",
  "message": "order accepted", "invocation_id": "abc-123", "function_name": "OrderHandler",
- "cold_start": false, "trace_id": "00-abc...", "exception": null,
+ "cold_start": false, "trace_id": "4bf92f3577b34da6a3ce929d0e0e4736", "exception": null,
  "extra": {"order_id": "o-999"}}
 ```
 
@@ -416,7 +419,9 @@ import logging
 
 setup_logging()
 root = logging.getLogger()
-root.addFilter(RedactionFilter(sensitive_keys=["password", "token", "secret"]))
+# Attach the filter to handlers so records from named child loggers are also redacted.
+for handler in root.handlers:
+    handler.addFilter(RedactionFilter(sensitive_keys=["password", "token", "secret"]))
 ```
 
 Any log record with extra fields whose keys match a sensitive key will have those values replaced with `***`.
@@ -489,7 +494,7 @@ This package provides structured logging for Azure Functions with zero modificat
 
 **Key Implementation Details for Code Generation:**
 
-1. **Never modify root logger** — Only install filters/formatters on handlers
+1. **Preserves host configuration** — In Azure / Core Tools, no handlers are added and the root logger level is left to `host.json`; only a `ContextFilter` is installed on existing root handlers (and on the root logger itself, so it covers handlers added later). In standalone local mode, `setup_logging(logger_name=None)` configures the root logger (sets level, adds a `StreamHandler` if none exist).
 2. **Context injection is contextvar-based** — Not thread-local, works with asyncio
 3. **Idempotent setup** — Calling setup_logging() multiple times is safe
 4. **Two environments, two behaviors**:

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -175,7 +175,7 @@ app = func.FunctionApp()
 
 @app.route(route="hello")
 def hello(req: func.HttpRequest, context: func.Context) -> func.HttpResponse:
-    with logging_context(context):  # 绑定 invocation_id, function_name, cold_start; 退出时重置
+    with logging_context(context):  # 绑定 invocation_id, function_name, cold_start; 退出时恢复先前上下文
         logger.info("Request received")
         # {"level": "INFO", "invocation_id": "abc-123", "cold_start": true, ...}
 
@@ -187,6 +187,9 @@ def hello(req: func.HttpRequest, context: func.Context) -> func.HttpResponse:
 如需较低级别的控制或与自定义中间件集成，请使用基于令牌 (token) 的恢复:
 
 ```python
+from azure_functions_logging import inject_context, restore_context
+
+# 假设 `logger` 和 `context` 已在作用域内 (参见 Quick Start)。
 tokens = inject_context(context)
 try:
     logger.info("Request received")
@@ -278,7 +281,7 @@ def hello(req: func.HttpRequest, context: func.Context) -> func.HttpResponse:
     return func.HttpResponse("OK")
 ```
 
-装饰器按名称查找 `context` 参数，在处理程序运行前调用 `inject_context()`，并在返回后的 `finally` 中重置上下文变量。
+装饰器按名称查找 `context` 参数，在处理程序运行前调用 `inject_context()`，并在返回后的 `finally` 中恢复先前上下文。
 
 自定义参数名:
 
@@ -332,7 +335,7 @@ setup_logging(functions_formatter=JsonFormatter())
 ```json
 {"timestamp": "2024-01-15T10:30:00+00:00", "level": "INFO", "logger": "my_module",
  "message": "order accepted", "invocation_id": "abc-123", "function_name": "OrderHandler",
- "cold_start": false, "trace_id": "00-abc...", "exception": null,
+ "cold_start": false, "trace_id": "4bf92f3577b34da6a3ce929d0e0e4736", "exception": null,
  "extra": {"order_id": "o-999"}}
 ```
 
@@ -407,7 +410,9 @@ import logging
 
 setup_logging()
 root = logging.getLogger()
-root.addFilter(RedactionFilter(sensitive_keys=["password", "token", "secret"]))
+# 将过滤器附加到处理程序，以便命名子 logger 的记录也被脱敏。
+for handler in root.handlers:
+    handler.addFilter(RedactionFilter(sensitive_keys=["password", "token", "secret"]))
 ```
 
 extra 字段中键名匹配 sensitive 键的任何日志记录将其值替换为 `***`。
@@ -480,7 +485,7 @@ def process_order(order_id: str) -> None:
 
 **代码生成的关键实现细节:**
 
-1. **从不修改 root logger** — 仅在处理程序上安装过滤器/格式化器
+1. **保留 host 配置** — 在 Azure / Core Tools 中不添加处理程序，root logger 级别交给 `host.json`；仅在已有 root 处理程序（以及 root logger 自身，以覆盖后续添加的处理程序）上安装 `ContextFilter`。在本地独立模式下，`setup_logging(logger_name=None)` 会配置 root logger（设置级别，无处理程序时添加 `StreamHandler`）。
 2. **上下文注入基于 contextvar** — 不是 thread-local，与 asyncio 协同工作
 3. **幂等 setup** — 多次调用 `setup_logging()` 是安全的
 4. **两个环境，两种行为**:
@@ -496,6 +501,8 @@ def process_order(order_id: str) -> None:
 - 在模块级别或处理程序启动时调用 `setup_logging()` (而不是每次请求)
 - 在处理程序中优先使用 `with logging_context(context):`; 仅在配合 `try/finally restore_context(tokens)` 时使用原始 `inject_context(context)`
 - 对每次请求的字段使用 `logger.bind(key=value)` (而不是直接 logger.extra)
+- 如需隐式按处理程序注入上下文，可使用 `with_context` 装饰器
+- 调用 `get_logging_metadata(func)` 检查函数的 `@with_context` 元数据 (返回 `dict[str, Any] | None`)
 - 对 PII 字段应用 `RedactionFilter`，对高频日志应用 `SamplingFilter`
 
 **示例模式:**

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -103,6 +103,11 @@ class FunctionLogger:
     def error(self, msg: object, *args: Any, **kwargs: Any) -> None: ...
     def critical(self, msg: object, *args: Any, **kwargs: Any) -> None: ...
     def exception(self, msg: object, *args: Any, **kwargs: Any) -> None: ...
+
+    # Stdlib parity: level inspection/configuration on the underlying logger.
+    def setLevel(self, level: int | str) -> None: ...
+    def isEnabledFor(self, level: int) -> bool: ...
+    def getEffectiveLevel(self) -> int: ...
 ```
 
 ### JSON Formatter
@@ -309,37 +314,19 @@ from azure_functions_logging import (
     install_context_factory,  # opt-in global LogRecordFactory
     ContextTokens,          # type alias used by inject_context/restore_context
 )
-import contextvars
+```
 
-# Context variables available for direct access in advanced scenarios:
-invocation_id_var: contextvars.ContextVar[str | None]
-function_name_var: contextvars.ContextVar[str | None]
-trace_id_var: contextvars.ContextVar[str | None]
-cold_start_var: contextvars.ContextVar[bool | None]
-
-class ContextFilter(logging.Filter):
-    """Logging filter copying contextvars onto LogRecord attributes.
-    
-    Installed on handlers (not loggers) to cover ALL loggers
-    including third-party libraries.
-    """
-    
-    CONTEXT_FIELDS: tuple[str, ...] = (
-        "invocation_id",
-        "function_name",
-        "trace_id",
-        "cold_start",
-    )
-    
-    def filter(self, record: logging.LogRecord) -> bool:
-        """Add context fields to log record. Always returns True."""
-        ...
+Context fields (`invocation_id`, `function_name`, `trace_id`, `cold_start`) are
+stored in private contextvars and surfaced on every `LogRecord` via the internal
+`ContextFilter`, which is installed automatically by `setup_logging()`. The filter
+and the underlying contextvars are **implementation details** — use the public
+helpers above instead of importing them directly.
 ```
 
 ## Design Principles
 
-1. **Root logger is never modified** — Only filters/formatters installed on handlers
-2. **Respects host.json** — In Azure/Core Tools, never changes root logger level
+1. **Narrow root logger contract** — In Azure/Core Tools, no handlers are added; `setup_logging()` installs `ContextFilter` on existing root handlers and on the root logger itself so records emitted through later-added handlers still carry context. In standalone mode (`logger_name=None`), the root logger's level is set and a `StreamHandler` is added only when no handlers exist.
+2. **Respects host.json** — In Azure/Core Tools, never changes root logger level or replaces existing handlers
 3. **No runtime dependency on azure-functions** — Works with any context-like object
 4. **Silent on context failures** — Missing attributes don't cause exceptions
 5. **Idempotent setup** — Calling setup_logging() multiple times is safe
@@ -471,8 +458,10 @@ Configure Application Insights in host.json to capture structured logs:
 }
 ```
 
-Log records with invocation_id, function_name, and custom fields are automatically
-captured by Application Insights. Use Analytics to query:
+Log records emitted through this library carry `invocation_id`, `function_name`,
+and any user-supplied `extra=` fields. In Application Insights these structured
+fields are flattened into the `customDimensions` column (not top-level table
+columns), so queries must reference them via `customDimensions.<field>`.
 
 ```
 traces

--- a/llms.txt
+++ b/llms.txt
@@ -20,12 +20,12 @@ Key features:
 - **Structured JSON output** — Application Insights-ready NDJSON format for production
 - **Noise control** — `SamplingFilter` rate-limits chatty third-party loggers
 - **PII protection** — `RedactionFilter` masks sensitive fields before they reach log aggregation
-- **No root logger mutation** — respects `host.json` configuration, installs filters only
+- **Root logger contract** — in Azure/Core Tools mode, no handlers are added; `ContextFilter` is installed on existing root handlers and on the root logger itself (covers handlers added later). In standalone mode (`logger_name=None`), the root logger's level is set and a `StreamHandler` is added if none exist.
 - **Zero runtime dependency** — on azure-functions (works with any context-like object)
 
 ## Core API
 
-- `setup_logging(level, format, functions_formatter, host_json_path, ...)` — One-call logging setup for local or Azure
+- `setup_logging(level, format, logger_name, functions_formatter, host_json_path, ...)` — One-call logging setup for local or Azure (pass `logger_name=None` for root logger configuration in standalone mode)
 - `get_logger(name)` → `FunctionLogger` — Create a logger with context binding support
 - `FunctionLogger` — Enhanced logger wrapper with `bind()`, `log()`, `hasHandlers()` for stdlib parity
 - `JsonFormatter` — JSON log formatter (NDJSON), use with `functions_formatter=` in Azure


### PR DESCRIPTION
## Priority: P1

## Context
Oracle iteration 1 review of the docs scored 82/100 with seven findings (4×P1, 3×P2) plus localization drift. This PR addresses all of them so the next Oracle re-review can target 100/100.

## Changes
- **Root logger contract** (P1, finding #2): correct README/llms.txt/llms-full.txt claims that the root logger is *never* modified. The library does install `ContextFilter` on the root logger in Azure mode (covers handlers added later) and configures the root logger when `logger_name=None` in standalone mode (sets level, adds a `StreamHandler` if none exist).
- **Runnable snippets** (P1, finding #1): make context-manager / token examples runnable by importing `inject_context` / `restore_context` and noting that `logger` / `context` come from Quick Start.
- **PII redaction wiring** (P1, finding #3): attach `RedactionFilter` to root handlers (not the root logger itself), so records emitted by named child loggers also get redacted.
- **API surface accuracy** (P1, finding #4):
  - `llms.txt`: include `logger_name` in the `setup_logging` signature.
  - `llms-full.txt`: add `setLevel` / `isEnabledFor` / `getEffectiveLevel` to the `FunctionLogger` reference; remove private `_context` internals (`invocation_id_var`, `function_name_var`, `trace_id_var`, `cold_start_var`, `ContextFilter`) from public docs.
- **JSON example trace_id** (P2, finding #5): replace invalid `00-abc...` with a 32-hex value matching what `_extract_trace_id()` actually returns.
- **`with_context` / `logging_context` exit semantics** (P2, finding #6): say "restore previous context" instead of "reset".
- **App Insights wording** (P2, finding #7): clarify that structured fields land in `customDimensions`, not top-level table columns.
- **Localization sync**: mirror every fix into `README.ko.md`, `README.ja.md`, `README.zh-CN.md`, including the previously-missing `with_context` decorator and `get_logging_metadata(func)` bullets.

## Validation
- `make lint` — clean
- `make typecheck` — clean (24 source files)
- `make test` — 199 passed, 3 skipped (e2e), coverage 95.25% (≥95%)
- `make build` — sdist + wheel produced

## Out of scope
- Pre-existing P2 issues #82, #83
- Source-code changes (this PR is docs-only)

## References
- Oracle iteration 1 review (session ses_1ee818470ffepXMqh1si7fPyh5)
- Builds on the iter-0 follow-up sequence merged via PRs #116–#120