### PR TITLE
docs: precise environment-aware behavior summary (oracle iter 2)

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -489,8 +489,8 @@ def process_order(order_id: str) -> None:
 2. **コンテキスト注入は contextvar ベース** — thread-local ではなく、asyncio で動作
 3. **冪等な setup** — `setup_logging()` を複数回呼び出しても安全
 4. **2 つの環境、2 つの動作**:
-   - Azure/Core Tools: 既存の root ハンドラにフィルタのみインストール (host.json を尊重)
-   - ローカル開発: 指定されたロガーに ColorFormatter または JsonFormatter ハンドラを追加
+   - Azure/Core Tools: 既存の root ハンドラと root ロガー自身に `ContextFilter` をインストールします。ハンドラの追加や root レベルの変更は行いません (`host.json` を尊重)。
+   - スタンドアロンのローカル実行: 対象/ルートロガーのレベルを設定します。**ハンドラが 1 つも存在しない場合に限り** `StreamHandler` (ColorFormatter または JsonFormatter) を追加し、そうでなければ既存のハンドラにフィルタのみ付加します。
 5. **テストフレンドリー**:
    - `inject_context()` は任意のオブジェクトを受け入れる (azure.functions.Context への強い依存なし)
    - `with_context` デコレータは同期および非同期ハンドラで動作

--- a/README.ko.md
+++ b/README.ko.md
@@ -489,8 +489,8 @@ def process_order(order_id: str) -> None:
 2. **컨텍스트 주입은 contextvar 기반** — thread-local이 아니므로 asyncio와 호환
 3. **멱등성 보장 setup** — `setup_logging()`을 여러 번 호출해도 안전
 4. **두 환경, 두 동작**:
-   - Azure/Core Tools: 기존 root 핸들러에 필터만 설치 (host.json 존중)
-   - 로컬 개발: 지정된 로거에 ColorFormatter 또는 JsonFormatter 핸들러 추가
+   - Azure/Core Tools: 기존 root 핸들러와 root 로거 자체에 `ContextFilter`를 설치합니다. 핸들러를 추가하거나 root 레벨을 변경하지 않습니다 (`host.json` 존중).
+   - 로컬 독립 실행: 대상/루트 로거 레벨을 설정합니다. **핸들러가 하나도 없을 때만** `StreamHandler` (ColorFormatter 또는 JsonFormatter)를 추가하고, 그렇지 않으면 기존 핸들러에 필터만 부착합니다.
 5. **테스트 친화적**:
    - `inject_context()`는 어떤 객체든 받음 (azure.functions.Context에 강한 의존성 없음)
    - `with_context` 데코레이터는 동기 및 비동기 핸들러에서 동작

--- a/README.md
+++ b/README.md
@@ -498,8 +498,8 @@ This package provides structured logging for Azure Functions with zero modificat
 2. **Context injection is contextvar-based** — Not thread-local, works with asyncio
 3. **Idempotent setup** — Calling setup_logging() multiple times is safe
 4. **Two environments, two behaviors**:
-   - Azure/Core Tools: Only install filters on existing root handlers (respects host.json)
-   - Local dev: Add ColorFormatter or JsonFormatter handler to specified logger
+   - Azure/Core Tools: install `ContextFilter` on existing root handlers and on the root logger itself; do not add handlers or change the root level (respects `host.json`).
+   - Standalone local: set the target/root logger level; add a `StreamHandler` (ColorFormatter or JsonFormatter) **only if no handlers exist**, otherwise just attach filters to existing handlers.
 5. **Test-friendly**:
    - `inject_context()` accepts any object (no hard dependency on azure.functions.Context)
    - `with_context` decorator works with sync and async handlers

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -489,8 +489,8 @@ def process_order(order_id: str) -> None:
 2. **上下文注入基于 contextvar** — 不是 thread-local，与 asyncio 协同工作
 3. **幂等 setup** — 多次调用 `setup_logging()` 是安全的
 4. **两个环境，两种行为**:
-   - Azure/Core Tools: 仅在现有 root 处理程序上安装过滤器 (尊重 host.json)
-   - 本地开发: 向指定 logger 添加 ColorFormatter 或 JsonFormatter 处理程序
+   - Azure/Core Tools: 在现有 root 处理程序以及 root logger 自身上安装 `ContextFilter`；不添加处理程序，也不修改 root 级别（尊重 `host.json`）。
+   - 本地独立运行: 设置目标/根 logger 级别；**仅当不存在任何处理程序时**添加 `StreamHandler`（ColorFormatter 或 JsonFormatter），否则仅在现有处理程序上附加过滤器。
 5. **测试友好**:
    - `inject_context()` 接受任何对象 (对 azure.functions.Context 没有强依赖)
    - `with_context` 装饰器在同步与异步处理程序中都有效

--- a/docs/index.md
+++ b/docs/index.md
@@ -80,8 +80,8 @@ This combines context-managed invocation context and request binding in a safe, 
 
 Behavior changes intentionally by runtime:
 
-- Local standalone process: installs handler and formatter (`color` or `json`).
-- Azure/Core Tools runtime: installs context filter only and avoids handler duplication.
+- Local standalone process: sets the target/root logger level; adds a `StreamHandler` (`color` or `json`) only if no handlers exist, otherwise just attaches filters to existing handlers.
+- Azure/Core Tools runtime: installs `ContextFilter` on existing root handlers **and on the root logger itself** (so records flowing through later-added handlers still carry context); does not add handlers or change root level.
 
 !!! warning
     In Azure-hosted execution, host-level `host.json` settings can still suppress logs even when application-level setup appears correct.

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -37,10 +37,8 @@ def setup_logging(
     """Configure logging for the current environment.
 
     Behavior depends on detected environment:
-    - **Azure / Core Tools**: Installs ContextFilter on root logger's handlers only.
-      Does NOT add handlers or modify root logger level (respects host.json).
-      If `functions_formatter` is provided, it is applied to host-managed handlers.
-    - **Standalone local**: Adds StreamHandler with ColorFormatter or JsonFormatter.
+    - **Azure / Core Tools**: Installs ContextFilter on existing root handlers AND on the root logger itself (so records emitted through later-added handlers still carry context). Does NOT add handlers or modify root logger level (respects host.json). If `functions_formatter` is provided, it is applied to host-managed handlers.
+    - **Standalone local**: Sets the target/root logger level. Adds a StreamHandler (ColorFormatter or JsonFormatter) ONLY when no handlers exist; otherwise just attaches filters to existing handlers.
 
     This function is idempotent per logger_name.
 


### PR DESCRIPTION
## Priority: P2

## Context
Oracle iteration 2 review scored 94/100 with one P2 finding: the iter-1 fixes corrected the longer-form root-logger contract paragraphs but left short environment-summary bullets in 6 files still saying 'install filters on existing root handlers only' / 'add a handler locally'. Those bullets miss (a) the ContextFilter installed on the root logger itself in Azure mode, and (b) that local mode only adds a handler when none exist.

## Changes
Normalized wording across all 6 files to match `_setup.py` behavior exactly:
- Azure/Core Tools: install `ContextFilter` on existing root handlers AND on the root logger itself; do not add handlers or change root level (respects `host.json`).
- Standalone local: set target/root logger level; add a `StreamHandler` only when no handlers exist, otherwise just attach filters to existing handlers.

Mirrored across:
- README.md, README.ko.md, README.ja.md, README.zh-CN.md
- llms-full.txt (setup_logging docstring)
- docs/index.md (Environment-Aware Behavior section)

## Validation
- `make lint` clean
- `make typecheck` clean
- `make test` 199 passed, coverage 95.25%
- `make build` ok

## References
- Oracle iteration 2 review (session ses_1ee19c9abffeiaSRf9DD1fP2Sq, score 94/100)
- Iteration 1 PR: #121