### PR TITLE
docs: tighten env detection, trace_id wording, App Insights hedge, llms.txt signature (oracle iter 3)

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -425,7 +425,7 @@ extra フィールドのキーが sensitive キーと一致するすべてのロ
 | Azure / Core Tools | host-managed | コンテキストフィルタのみインストール; host ハンドラに NDJSON を強制するには `functions_formatter=JsonFormatter()` を渡す |
 | CI / パイプライン | `json` | NDJSON、機械パース可能 |
 
-`setup_logging()` は `FUNCTIONS_WORKER_RUNTIME` と `WEBSITE_INSTANCE_ID` を検出し、自動的に正しいパスを選択します。Azure では、ハンドラを追加せずにコンテキストフィルタをインストールします (host パイプラインからの重複出力を回避)。
+`setup_logging()` は `FUNCTIONS_WORKER_RUNTIME` を検出し、Azure Functions / Core Tools とスタンドアロンのローカル実行を区別します。Azure モードではハンドラを追加せずにコンテキストフィルタをインストールします (host パイプラインからの重複出力を回避)。
 
 ## コンテキストバインディング
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -425,7 +425,7 @@ extra 필드의 키가 sensitive 키와 일치하는 모든 로그 레코드는 
 | Azure / Core Tools | host-managed | 컨텍스트 필터만 설치; host 핸들러에 NDJSON을 강제하려면 `functions_formatter=JsonFormatter()`를 전달 |
 | CI / 파이프라인 | `json` | NDJSON, 머신 파싱 가능 |
 
-`setup_logging()`은 `FUNCTIONS_WORKER_RUNTIME`과 `WEBSITE_INSTANCE_ID`를 감지하여 자동으로 올바른 경로를 선택합니다. Azure에서는 핸들러를 추가하지 않고 컨텍스트 필터를 설치합니다 (host 파이프라인의 중복 출력을 피함).
+`setup_logging()`은 `FUNCTIONS_WORKER_RUNTIME`를 감지하여 Azure Functions / Core Tools와 로컬 독립 실행을 구분합니다. Azure 모드에서는 핸들러를 추가하지 않고 컨텍스트 필터만 설치합니다 (host 파이프라인의 중복 출력을 회피).
 
 ## 컨텍스트 바인딩
 

--- a/README.md
+++ b/README.md
@@ -434,7 +434,7 @@ Any log record with extra fields whose keys match a sensitive key will have thos
 | Azure / Core Tools | host-managed | Installs context filters only; pass `functions_formatter=JsonFormatter()` to force NDJSON on host handlers |
 | CI / pipeline | `json` | NDJSON, machine-parseable |
 
-`setup_logging()` detects `FUNCTIONS_WORKER_RUNTIME` and `WEBSITE_INSTANCE_ID` to choose the right path automatically. In Azure, it installs context filters without adding handlers (avoids duplicate output from the host pipeline).
+`setup_logging()` detects `FUNCTIONS_WORKER_RUNTIME` to distinguish Azure Functions / Core Tools from standalone local execution. In Azure mode it installs context filters without adding handlers (avoids duplicate output from the host pipeline).
 
 ## Context Binding
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -425,7 +425,7 @@ extra 字段中键名匹配 sensitive 键的任何日志记录将其值替换为
 | Azure / Core Tools | host-managed | 仅安装上下文过滤器；通过 `functions_formatter=JsonFormatter()` 在 host 处理程序上强制 NDJSON |
 | CI / 管道 | `json` | NDJSON, 机器可解析 |
 
-`setup_logging()` 检测 `FUNCTIONS_WORKER_RUNTIME` 和 `WEBSITE_INSTANCE_ID` 来自动选择正确路径。在 Azure 中，它安装上下文过滤器而不添加处理程序 (避免来自 host 管道的重复输出)。
+`setup_logging()` 检测 `FUNCTIONS_WORKER_RUNTIME` 以区分 Azure Functions / Core Tools 与本地独立运行。在 Azure 模式下，它不添加处理程序仅安装上下文过滤器（避免来自 host 管道的重复输出）。
 
 ## 上下文绑定
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -331,9 +331,9 @@ helpers above instead of importing them directly.
 6. **Standard logging delegates** — FunctionLogger wraps, never replaces stdlib logging
 7. **Always-restoring context** — logging_context() / restore_context() prevent stale
    context from leaking into the next invocation on a reused worker
-8. **Strict W3C traceparent validation** — _extract_trace_id() validates Trace Context
-   Level 1 (4 parts; 2/32/16/2 hex; rejects version ff and all-zero trace/span ids;
-   forward-compatible with future versions)
+8. **Strict W3C traceparent validation** — trace IDs are extracted only from valid W3C
+   `traceparent` headers (Trace Context Level 1: 4 parts; 2/32/16/2 hex; rejects
+   version `ff` and all-zero trace/span ids; forward-compatible with future versions)
 9. **Bounded host.json discovery** — walks up from cwd, max 5 parent levels;
    override with host_json_path= for tests / non-standard layouts
 
@@ -457,9 +457,12 @@ Configure Application Insights in host.json to capture structured logs:
 ```
 
 Log records emitted through this library carry `invocation_id`, `function_name`,
-and any user-supplied `extra=` fields. In Application Insights these structured
-fields are flattened into the `customDimensions` column (not top-level table
-columns), so queries must reference them via `customDimensions.<field>`.
+and any user-supplied `extra=` fields. When the host pipeline forwards them to
+Application Insights, structured fields typically appear under `customDimensions`
+(not as top-level table columns), so queries should reference them via
+`customDimensions.<field>`. Exact ingestion shape depends on the host/exporter
+pipeline; some setups may surface fields differently or leave them in the raw
+`message`.
 
 ```
 traces

--- a/llms.txt
+++ b/llms.txt
@@ -25,9 +25,9 @@ Key features:
 
 ## Core API
 
-- `setup_logging(level, format, logger_name, functions_formatter, host_json_path, ...)` — One-call logging setup for local or Azure (pass `logger_name=None` for root logger configuration in standalone mode)
+- `setup_logging(*, level=logging.INFO, format="color", logger_name=None, functions_formatter=None, host_json_path=None)` — Keyword-only. One-call logging setup for local or Azure (pass `logger_name=None` for root logger configuration in standalone mode).
 - `get_logger(name)` → `FunctionLogger` — Create a logger with context binding support
-- `FunctionLogger` — Enhanced logger wrapper with `bind()`, `log()`, `hasHandlers()` for stdlib parity
+- `FunctionLogger` — Enhanced logger wrapper with `bind()`, `log()`, `hasHandlers()`, `setLevel()`, `isEnabledFor()`, `getEffectiveLevel()` for stdlib parity
 - `JsonFormatter` — JSON log formatter (NDJSON), use with `functions_formatter=` in Azure
 - `RedactionFilter` — Filter to redact sensitive fields (password, token, api_key, etc.)
 - `SamplingFilter` — Filter for log sampling/rate-limiting noisy loggers


### PR DESCRIPTION
## Priority: P2

## Context
Oracle iteration 3 review scored 93/100 with 3 P2 + 1 P3 finding. This PR addresses all of them.

## Changes
**P2-1** — `setup_logging()` env detection (README.md:437 + ko/ja/zh-CN mirrors): the function only checks `FUNCTIONS_WORKER_RUNTIME`. `WEBSITE_INSTANCE_ID` is defined as a separate helper but unused by `setup_logging` branching, so it's removed from the explanation.

**P2-2** — `llms-full.txt:334` (Design Principles): rewritten as observable behavior instead of naming the private `_extract_trace_id()` helper.

**P2-3** — `llms-full.txt:459-462` (App Insights): `customDimensions` is now described as the typical shape, with explicit acknowledgement that ingestion shape depends on host/exporter pipeline.

**P3** — `llms.txt:28,30`: `setup_logging` shown with keyword-only `*` signature and defaults; `FunctionLogger` parity bullet expanded with `setLevel`, `isEnabledFor`, `getEffectiveLevel`.

## Validation
- `make lint` clean
- `make typecheck` clean
- `make test` 199 passed, coverage 95.25%
- `make build` ok

## References
- Oracle iter 3 review (session ses_1ee13a39cffepsKrP93up4BU6Y)
- Iter 2 PR: #122 (94/100)
- Iter 1 PR: #121 (82/100 -> 94/100)