### PR TITLE
docs: clarify root-logger filter scope and traceparent version semantics (oracle iter 4)

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -485,7 +485,7 @@ def process_order(order_id: str) -> None:
 
 **コード生成のための主要な実装詳細:**
 
-1. **ホスト構成を尊重** — Azure / Core Tools ではハンドラを追加せず、ルートロガーのレベルは `host.json` に委ねます。既存のルートハンドラ (および将来追加されるハンドラのためにルートロガー自体) に `ContextFilter` のみをインストールします。ローカル単独モードでは `setup_logging(logger_name=None)` がルートロガーを構成します (レベル設定、ハンドラがなければ `StreamHandler` を追加)。
+1. **ホスト構成を尊重** — Azure / Core Tools ではハンドラを追加せず、ルートロガーのレベルは `host.json` に委ねます。既存のルートハンドラとルートロガー自身に `ContextFilter` をインストールします（ルートロガーでの直接呼び出しはコンテキストを仲介する）。名前付きの子ロガーから伝搬されて後から追加されたハンドラへ到達するレコードにもコンテキストを保証したい場合は `install_context_factory()` を呼び出してください。ローカル単独モードでは `setup_logging(logger_name=None)` がルートロガーを構成します（レベル設定、ハンドラがなければ `StreamHandler` 追加）。
 2. **コンテキスト注入は contextvar ベース** — thread-local ではなく、asyncio で動作
 3. **冪等な setup** — `setup_logging()` を複数回呼び出しても安全
 4. **2 つの環境、2 つの動作**:

--- a/README.ko.md
+++ b/README.ko.md
@@ -485,7 +485,7 @@ def process_order(order_id: str) -> None:
 
 **코드 생성을 위한 핵심 구현 세부사항:**
 
-1. **호스트 구성 보존** — Azure / Core Tools에서는 핸들러를 추가하지 않고 루트 로거 레벨을 `host.json`에 위임하며, 기존 루트 핸들러(및 루트 로거 자체)에 `ContextFilter`만 설치합니다. 로컬 단독 모드에서는 `setup_logging(logger_name=None)`이 루트 로거를 구성합니다 (레벨 설정, 핸들러 없으면 `StreamHandler` 추가).
+1. **호스트 구성 보존** — Azure / Core Tools에서는 핸들러를 추가하지 않고 루트 로거 레벨을 `host.json`에 위임하며, 기존 루트 핸들러와 루트 로거 자체에 `ContextFilter`를 설치합니다 (루트 로거에서 직접 호출되는 레코드에 컨텍스트를 익수함). 이름 있는 자식 로거에서 이마 추가되는 핸들러에 전파되는 레코드의 경우 `install_context_factory()`를 호출하여 컨텍스트 커버리지를 보장하세요. 로컬 단독 모드에서는 `setup_logging(logger_name=None)`이 루트 로거를 구성합니다 (레벨 설정, 핸들러 없으면 `StreamHandler` 추가).
 2. **컨텍스트 주입은 contextvar 기반** — thread-local이 아니므로 asyncio와 호환
 3. **멱등성 보장 setup** — `setup_logging()`을 여러 번 호출해도 안전
 4. **두 환경, 두 동작**:

--- a/README.md
+++ b/README.md
@@ -494,7 +494,7 @@ This package provides structured logging for Azure Functions with zero modificat
 
 **Key Implementation Details for Code Generation:**
 
-1. **Preserves host configuration** — In Azure / Core Tools, no handlers are added and the root logger level is left to `host.json`; only a `ContextFilter` is installed on existing root handlers (and on the root logger itself, so it covers handlers added later). In standalone local mode, `setup_logging(logger_name=None)` configures the root logger (sets level, adds a `StreamHandler` if none exist).
+1. **Preserves host configuration** — In Azure / Core Tools, no handlers are added and the root logger level is left to `host.json`; `ContextFilter` is installed on existing root handlers and on the root logger itself (so direct calls on the root logger carry context). For records that propagate from named child loggers to handlers attached later (e.g. by the host or third-party libraries), call `install_context_factory()` to guarantee context coverage. In standalone local mode, `setup_logging(logger_name=None)` configures the root logger (sets level, adds a `StreamHandler` if none exist).
 2. **Context injection is contextvar-based** — Not thread-local, works with asyncio
 3. **Idempotent setup** — Calling setup_logging() multiple times is safe
 4. **Two environments, two behaviors**:

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -485,7 +485,7 @@ def process_order(order_id: str) -> None:
 
 **代码生成的关键实现细节:**
 
-1. **保留 host 配置** — 在 Azure / Core Tools 中不添加处理程序，root logger 级别交给 `host.json`；仅在已有 root 处理程序（以及 root logger 自身，以覆盖后续添加的处理程序）上安装 `ContextFilter`。在本地独立模式下，`setup_logging(logger_name=None)` 会配置 root logger（设置级别，无处理程序时添加 `StreamHandler`）。
+1. **保留 host 配置** — 在 Azure / Core Tools 中不添加处理程序，root logger 级别交给 `host.json`；在已有 root 处理程序以及 root logger 自身上安装 `ContextFilter`（以便在 root logger 上的直接调用携带上下文）。若需覆盖从命名子 logger 传播到后续添加处理程序的记录，请调用 `install_context_factory()` 以保证上下文覆盖。在本地独立模式下，`setup_logging(logger_name=None)` 会配置 root logger（设置级别，无处理程序时添加 `StreamHandler`）。
 2. **上下文注入基于 contextvar** — 不是 thread-local，与 asyncio 协同工作
 3. **幂等 setup** — 多次调用 `setup_logging()` 是安全的
 4. **两个环境，两种行为**:

--- a/docs/index.md
+++ b/docs/index.md
@@ -81,7 +81,7 @@ This combines context-managed invocation context and request binding in a safe, 
 Behavior changes intentionally by runtime:
 
 - Local standalone process: sets the target/root logger level; adds a `StreamHandler` (`color` or `json`) only if no handlers exist, otherwise just attaches filters to existing handlers.
-- Azure/Core Tools runtime: installs `ContextFilter` on existing root handlers **and on the root logger itself** (so records flowing through later-added handlers still carry context); does not add handlers or change root level.
+- Azure/Core Tools runtime: installs `ContextFilter` on existing root handlers **and on the root logger itself** (so direct calls on the root logger carry context); does not add handlers or change root level. To guarantee context on records that propagate from named child loggers to handlers attached later, call `install_context_factory()`.
 
 !!! warning
     In Azure-hosted execution, host-level `host.json` settings can still suppress logs even when application-level setup appears correct.

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -37,7 +37,7 @@ def setup_logging(
     """Configure logging for the current environment.
 
     Behavior depends on detected environment:
-    - **Azure / Core Tools**: Installs ContextFilter on existing root handlers AND on the root logger itself (so records emitted through later-added handlers still carry context). Does NOT add handlers or modify root logger level (respects host.json). If `functions_formatter` is provided, it is applied to host-managed handlers.
+    - **Azure / Core Tools**: Installs ContextFilter on existing root handlers AND on the root logger itself (so direct calls on the root logger carry context). Does NOT add handlers or modify root logger level (respects host.json). If `functions_formatter` is provided, it is applied to host-managed handlers. NOTE: a filter on the root logger does not run for records that propagate from named child loggers to host/third-party handlers attached later — use `install_context_factory()` to guarantee context coverage in that case.
     - **Standalone local**: Sets the target/root logger level. Adds a StreamHandler (ColorFormatter or JsonFormatter) ONLY when no handlers exist; otherwise just attaches filters to existing handlers.
 
     This function is idempotent per logger_name.
@@ -323,7 +323,7 @@ helpers above instead of importing them directly.
 
 ## Design Principles
 
-1. **Narrow root logger contract** — In Azure/Core Tools, no handlers are added; `setup_logging()` installs `ContextFilter` on existing root handlers and on the root logger itself so records emitted through later-added handlers still carry context. In standalone mode (`logger_name=None`), the root logger's level is set and a `StreamHandler` is added only when no handlers exist.
+1. **Narrow root logger contract** — In Azure/Core Tools, no handlers are added; `setup_logging()` installs `ContextFilter` on existing root handlers and on the root logger itself (so direct calls on the root logger carry context). To guarantee context on records that propagate from named child loggers to handlers attached later (host- or third-party-installed), call `install_context_factory()`. In standalone mode (`logger_name=None`), the root logger's level is set and a `StreamHandler` is added only when no handlers exist.
 2. **Respects host.json** — In Azure/Core Tools, never changes root logger level or replaces existing handlers
 3. **No runtime dependency on azure-functions** — Works with any context-like object
 4. **Silent on context failures** — Missing attributes don't cause exceptions
@@ -332,8 +332,10 @@ helpers above instead of importing them directly.
 7. **Always-restoring context** — logging_context() / restore_context() prevent stale
    context from leaking into the next invocation on a reused worker
 8. **Strict W3C traceparent validation** — trace IDs are extracted only from valid W3C
-   `traceparent` headers (Trace Context Level 1: 4 parts; 2/32/16/2 hex; rejects
-   version `ff` and all-zero trace/span ids; forward-compatible with future versions)
+   `traceparent` headers (version `00` requires exactly 4 parts; later versions may
+   include trailing fields, which are ignored after validating the first four:
+   2/32/16/2 hex; version `ff` and all-zero trace/span ids are rejected;
+   forward-compatible with future versions)
 9. **Bounded host.json discovery** — walks up from cwd, max 5 parent levels;
    override with host_json_path= for tests / non-standard layouts
 

--- a/llms.txt
+++ b/llms.txt
@@ -20,7 +20,7 @@ Key features:
 - **Structured JSON output** — Application Insights-ready NDJSON format for production
 - **Noise control** — `SamplingFilter` rate-limits chatty third-party loggers
 - **PII protection** — `RedactionFilter` masks sensitive fields before they reach log aggregation
-- **Root logger contract** — in Azure/Core Tools mode, no handlers are added; `ContextFilter` is installed on existing root handlers and on the root logger itself (covers handlers added later). In standalone mode (`logger_name=None`), the root logger's level is set and a `StreamHandler` is added if none exist.
+- **Root logger contract** — in Azure/Core Tools mode, no handlers are added; `ContextFilter` is installed on existing root handlers and on the root logger itself (so direct calls on the root logger carry context). To guarantee coverage for records that propagate from named child loggers to handlers attached later, call `install_context_factory()`. In standalone mode (`logger_name=None`), the root logger's level is set and a `StreamHandler` is added if none exist.
 - **Zero runtime dependency** — on azure-functions (works with any context-like object)
 
 ## Core API


### PR DESCRIPTION
## Summary

Oracle iteration 4 review scored 94/100 with 1 P2 + 1 P3. This PR addresses both findings, mirrored across English and localized (ko/ja/zh-CN) docs.

## Findings Addressed

### P2 — Root-logger filter coverage overstatement
Python's `logging.Filter` attached to a logger only runs for records logged AT that logger, NOT for records propagating from child loggers to ancestor handlers. Previous wording claimed the filter "covers later-added handlers" / "records flowing through later-added handlers", which is incorrect.

**Fix:** Reworded to state the filter applies to records logged directly on the root logger, and direct readers to `install_context_factory()` for guaranteed coverage of records propagated from named child loggers.

Files: `README.md`, `README.ko.md`, `README.ja.md`, `README.zh-CN.md`, `llms.txt`, `llms-full.txt`, `docs/index.md`.

### P3 — W3C traceparent version semantics
Previous wording said traceparent must have "exactly 4 parts". Per the W3C spec, version `00` requires exactly 4 parts, but later versions MAY include trailing fields (ignored after validating the first four).

**Fix:** Reworded `llms-full.txt:334-336` to reflect version-aware semantics.

## Validation
- `make lint` ✓
- `make typecheck` ✓
- `make test` 199 passed @ 95.25% coverage ✓
- `make build` ✓

## Iteration history
- iter 1 → PR #121 (82/100)
- iter 2 → PR #122 (94/100)
- iter 3 → PR #123 (93/100)
- iter 4 → this PR (target ≥95, goal 100)