### PR TITLE
docs: align quickstart with NDJSON output, fix host warning text and llms-full imports (oracle iter 5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
 ### Bug Fixes
 
 - *(logger)* Correct merge precedence to bind < extra < kwargs 

--- a/README.ja.md
+++ b/README.ja.md
@@ -75,9 +75,9 @@ Order: {'customer': 'Alice', 'total': 99.99}
 ```python
 import azure.functions as func
 
-from azure_functions_logging import get_logger, logging_context, setup_logging
+from azure_functions_logging import JsonFormatter, get_logger, logging_context, setup_logging
 
-setup_logging()
+setup_logging(functions_formatter=JsonFormatter())
 logger = get_logger(__name__)
 app = func.FunctionApp()
 
@@ -202,7 +202,7 @@ finally:
 ローカルで Functions host を起動 ([e2e サンプルアプリ](examples/e2e_app) 使用):
 
 ```bash
-func start
+func start --script-root examples/e2e_app
 ```
 
 ### ローカルおよび Azure での検証
@@ -350,7 +350,7 @@ logger.info("order accepted", order_id="o-999", tenant_id="t-1")
 `host.json` がアプリが発行するログレベルを抑制する場合、起動時にこの警告が表示されます:
 
 ```
-WARNING: host.json logLevel.default is 'Warning'. Logs below WARNING will be suppressed in Azure.
+host.json logLevel for default is set to 'Warning' which is more restrictive than the configured level 'INFO'. Logs below 'Warning' will be suppressed by the Azure Functions host.
 ```
 
 推奨される `host.json` ベースライン:

--- a/README.ko.md
+++ b/README.ko.md
@@ -75,9 +75,9 @@ Order: {'customer': 'Alice', 'total': 99.99}
 ```python
 import azure.functions as func
 
-from azure_functions_logging import get_logger, logging_context, setup_logging
+from azure_functions_logging import JsonFormatter, get_logger, logging_context, setup_logging
 
-setup_logging()
+setup_logging(functions_formatter=JsonFormatter())
 logger = get_logger(__name__)
 app = func.FunctionApp()
 
@@ -202,7 +202,7 @@ finally:
 Functions host를 로컬에서 실행 ([e2e 예제 앱](examples/e2e_app) 사용):
 
 ```bash
-func start
+func start --script-root examples/e2e_app
 ```
 
 ### 로컬 및 Azure에서 검증
@@ -350,7 +350,7 @@ logger.info("order accepted", order_id="o-999", tenant_id="t-1")
 `host.json`이 앱이 발행하는 로그 레벨을 억제하면 시작 시 다음과 같은 경고가 표시됩니다:
 
 ```
-WARNING: host.json logLevel.default is 'Warning'. Logs below WARNING will be suppressed in Azure.
+host.json logLevel for default is set to 'Warning' which is more restrictive than the configured level 'INFO'. Logs below 'Warning' will be suppressed by the Azure Functions host.
 ```
 
 권장 `host.json` 기본값:
@@ -485,7 +485,7 @@ def process_order(order_id: str) -> None:
 
 **코드 생성을 위한 핵심 구현 세부사항:**
 
-1. **호스트 구성 보존** — Azure / Core Tools에서는 핸들러를 추가하지 않고 루트 로거 레벨을 `host.json`에 위임하며, 기존 루트 핸들러와 루트 로거 자체에 `ContextFilter`를 설치합니다 (루트 로거에서 직접 호출되는 레코드에 컨텍스트를 익수함). 이름 있는 자식 로거에서 이마 추가되는 핸들러에 전파되는 레코드의 경우 `install_context_factory()`를 호출하여 컨텍스트 커버리지를 보장하세요. 로컬 단독 모드에서는 `setup_logging(logger_name=None)`이 루트 로거를 구성합니다 (레벨 설정, 핸들러 없으면 `StreamHandler` 추가).
+1. **호스트 구성 보존** — Azure / Core Tools에서는 핸들러를 추가하지 않고 루트 로거 레벨을 `host.json`에 위임하며, 기존 루트 핸들러와 루트 로거 자체에 `ContextFilter`를 설치합니다 (루트 로거에 직접 기록되는 레코드에도 컨텍스트가 실립니다). 이름 있는 자식 로거에서 이후 추가되는 핸들러로 전파되는 레코드까지 보장하려면 `install_context_factory()`를 호출하세요. 로컬 단독 모드에서는 `setup_logging(logger_name=None)`이 루트 로거를 구성합니다 (레벨 설정, 핸들러 없으면 `StreamHandler` 추가).
 2. **컨텍스트 주입은 contextvar 기반** — thread-local이 아니므로 asyncio와 호환
 3. **멱등성 보장 setup** — `setup_logging()`을 여러 번 호출해도 안전
 4. **두 환경, 두 동작**:

--- a/README.md
+++ b/README.md
@@ -75,9 +75,9 @@ Order: {'customer': 'Alice', 'total': 99.99}
 ```python
 import azure.functions as func
 
-from azure_functions_logging import get_logger, logging_context, setup_logging
+from azure_functions_logging import JsonFormatter, get_logger, logging_context, setup_logging
 
-setup_logging()
+setup_logging(functions_formatter=JsonFormatter())
 logger = get_logger(__name__)
 app = func.FunctionApp()
 
@@ -202,7 +202,7 @@ Use `reset_context()` only when you intentionally want to clear all context (e.g
 Start the Functions host locally (using the [e2e example app](examples/e2e_app)):
 
 ```bash
-func start
+func start --script-root examples/e2e_app
 ```
 
 ### Verify locally and on Azure
@@ -358,7 +358,7 @@ logger.info("order accepted", order_id="o-999", tenant_id="t-1")
 If your `host.json` suppresses log levels that your app emits, you get this warning at startup:
 
 ```
-WARNING: host.json logLevel.default is 'Warning'. Logs below WARNING will be suppressed in Azure.
+host.json logLevel for default is set to 'Warning' which is more restrictive than the configured level 'INFO'. Logs below 'Warning' will be suppressed by the Azure Functions host.
 ```
 
 Recommended `host.json` baseline:

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -75,9 +75,9 @@ Order: {'customer': 'Alice', 'total': 99.99}
 ```python
 import azure.functions as func
 
-from azure_functions_logging import get_logger, logging_context, setup_logging
+from azure_functions_logging import JsonFormatter, get_logger, logging_context, setup_logging
 
-setup_logging()
+setup_logging(functions_formatter=JsonFormatter())
 logger = get_logger(__name__)
 app = func.FunctionApp()
 
@@ -202,7 +202,7 @@ finally:
 在本地启动 Functions host (使用 [e2e 示例应用](examples/e2e_app)):
 
 ```bash
-func start
+func start --script-root examples/e2e_app
 ```
 
 ### 在本地与 Azure 上验证
@@ -350,7 +350,7 @@ logger.info("order accepted", order_id="o-999", tenant_id="t-1")
 如果您的 `host.json` 抑制了应用发出的日志级别，启动时会出现以下警告:
 
 ```
-WARNING: host.json logLevel.default is 'Warning'. Logs below WARNING will be suppressed in Azure.
+host.json logLevel for default is set to 'Warning' which is more restrictive than the configured level 'INFO'. Logs below 'Warning' will be suppressed by the Azure Functions host.
 ```
 
 推荐的 `host.json` 基线:

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -201,6 +201,12 @@ class RedactionFilter(logging.Filter):
 ### Context Injection
 
 ```python
+import contextvars
+from collections.abc import Iterator
+from typing import Any
+
+import azure.functions as func
+
 from azure_functions_logging import (
     ContextTokens,
     inject_context,
@@ -211,7 +217,6 @@ from azure_functions_logging import (
     get_logging_metadata,
     with_context,
 )
-import azure.functions as func
 
 # ContextTokens is a type alias (not a class) — opaque mapping returned by
 # inject_context(). Pass to restore_context() to undo a single inject_context() call.
@@ -247,7 +252,7 @@ def reset_context() -> None:
     prefer logging_context() / restore_context() in production code."""
     ...
 
-def logging_context(context: Any) -> ContextManager[None]:
+def logging_context(context: Any) -> Iterator[None]:
     """Recommended primary pattern. Context manager that calls inject_context()
     on enter and **always** calls restore_context() on exit (even when the body
     raises). Prevents stale context from leaking into the next invocation on a


### PR DESCRIPTION
## Summary

Oracle iteration 5 review scored 93/100 (ITERATE) with 2 P1, 2 P2, 1 P3. This PR addresses all findings.

## Findings Addressed

### P1 — Quickstart snippet does not produce NDJSON output
\`setup_logging()\` alone does not switch host-managed handlers to \`JsonFormatter\`. Updated quickstart to call \`setup_logging(functions_formatter=JsonFormatter())\` so the snippet actually emits the JSON shown in the "Production output" caption.

Files: README.md, README.ko.md, README.ja.md, README.zh-CN.md (lines 78, 80).

### P1 — \`func start\` not runnable from repo root
The repo's only \`host.json\` lives under \`examples/e2e_app\`, so \`func start\` from repo root fails. Replaced with \`func start --script-root examples/e2e_app\`.

Files: README.md:205, README.ko.md:205, README.ja.md:205, README.zh-CN.md:205.

### P2 — host.json conflict warning text is stale
Updated sample warning to match actual text emitted by \`_host_config.warn_host_json_level_conflict()\` (category-aware, includes configured Python level name).

Files: README.md:361, README.ko.md:353, README.ja.md:353, README.zh-CN.md:353.

### P2 — llms-full.txt context-injection block not runnable + wrong return annotation
- Added missing imports (\`contextvars\`, \`Iterator\`, \`Any\`) so the block executes.
- Changed \`logging_context(...) -> ContextManager[None]\` to \`Iterator[None]\` to match \`_context.py:197\` exactly.

### P2 — CHANGELOG ambiguity
Added \`## Unreleased\` header above the post-0.7.1 entries so readers can tell shipped vs in-flight.

### P3 — Garbled Korean
Fixed typos (\`익수함\` → \`실립니다\`, \`이마 추가되는\` → \`이후 추가되는\`) in README.ko.md:488 to match English semantics.

## Validation
- \`make lint\` ✓
- \`make typecheck\` ✓
- \`make test\` 199 passed @ 95.25% coverage ✓
- \`make build\` ✓

## Iteration history
- iter 1 → PR #121 (82/100)
- iter 2 → PR #122 (94/100)
- iter 3 → PR #123 (93/100)
- iter 4 → PR #124 (94/100)
- iter 5 → this PR (target ≥95, goal 100)