### PR TITLE
docs: clarify functions_formatter scope, fix color-format pattern and stray fence (oracle iter 6)

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -177,7 +177,7 @@ app = func.FunctionApp()
 def hello(req: func.HttpRequest, context: func.Context) -> func.HttpResponse:
     with logging_context(context):  # invocation_id, function_name, cold_start をバインドし、終了時に以前のコンテキストへ復元
         logger.info("Request received")
-        # {"level": "INFO", "invocation_id": "abc-123", "cold_start": true, ...}
+        # ログレコードに invocation_id, function_name, cold_start が付与されます
 
         return func.HttpResponse("OK")
 ```
@@ -421,7 +421,7 @@ extra フィールドのキーが sensitive キーと一致するすべてのロ
 
 | 環境 | フォーマット | 動作 |
 |------|------------|------|
-| ローカルターミナル | `color` (デフォルト) | 色付き `[TIME] [LEVEL] [LOGGER] message` |
+| ローカルターミナル | `color` (デフォルト) | 色付きで人間が読める形式: `HH:MM:SS LEVEL logger  message [context...]` |
 | Azure / Core Tools | host-managed | コンテキストフィルタのみインストール; host ハンドラに NDJSON を強制するには `functions_formatter=JsonFormatter()` を渡す |
 | CI / パイプライン | `json` | NDJSON、機械パース可能 |
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -177,7 +177,7 @@ app = func.FunctionApp()
 def hello(req: func.HttpRequest, context: func.Context) -> func.HttpResponse:
     with logging_context(context):  # invocation_id, function_name, cold_start 바인딩, 종료 시 이전 컨텍스트로 복원
         logger.info("Request received")
-        # {"level": "INFO", "invocation_id": "abc-123", "cold_start": true, ...}
+        # 로그 레코드에 invocation_id, function_name, cold_start가 실립니다
 
         return func.HttpResponse("OK")
 ```
@@ -421,7 +421,7 @@ extra 필드의 키가 sensitive 키와 일치하는 모든 로그 레코드는 
 
 | 환경 | 포맷 | 동작 |
 |------|------|------|
-| 로컬 터미널 | `color` (기본) | 색상 적용된 `[TIME] [LEVEL] [LOGGER] message` |
+| 로컬 터미널 | `color` (기본) | 색상 적용된 읽기 쉬운 형식: `HH:MM:SS LEVEL logger  message [context...]` |
 | Azure / Core Tools | host-managed | 컨텍스트 필터만 설치; host 핸들러에 NDJSON을 강제하려면 `functions_formatter=JsonFormatter()`를 전달 |
 | CI / 파이프라인 | `json` | NDJSON, 머신 파싱 가능 |
 

--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ app = func.FunctionApp()
 def hello(req: func.HttpRequest, context: func.Context) -> func.HttpResponse:
     with logging_context(context):  # binds invocation_id, function_name, cold_start; restores previous context on exit
         logger.info("Request received")
-        # {"level": "INFO", "invocation_id": "abc-123", "cold_start": true, ...}
+        # log record now carries invocation_id, function_name, cold_start
 
         return func.HttpResponse("OK")
 ```
@@ -430,7 +430,7 @@ Any log record with extra fields whose keys match a sensitive key will have thos
 
 | Environment | Format | Behavior |
 |-------------|--------|---------|
-| Local terminal | `color` (default) | Colorized `[TIME] [LEVEL] [LOGGER] message` |
+| Local terminal | `color` (default) | Colorized human-readable: `HH:MM:SS LEVEL logger  message [context...]` |
 | Azure / Core Tools | host-managed | Installs context filters only; pass `functions_formatter=JsonFormatter()` to force NDJSON on host handlers |
 | CI / pipeline | `json` | NDJSON, machine-parseable |
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -177,7 +177,7 @@ app = func.FunctionApp()
 def hello(req: func.HttpRequest, context: func.Context) -> func.HttpResponse:
     with logging_context(context):  # 绑定 invocation_id, function_name, cold_start; 退出时恢复先前上下文
         logger.info("Request received")
-        # {"level": "INFO", "invocation_id": "abc-123", "cold_start": true, ...}
+        # 日志记录现在携带 invocation_id、function_name、cold_start
 
         return func.HttpResponse("OK")
 ```
@@ -421,7 +421,7 @@ extra 字段中键名匹配 sensitive 键的任何日志记录将其值替换为
 
 | 环境 | 格式 | 行为 |
 |------|------|------|
-| 本地终端 | `color` (默认) | 彩色 `[TIME] [LEVEL] [LOGGER] message` |
+| 本地终端 | `color` (默认) | 彩色人类可读格式: `HH:MM:SS LEVEL logger  message [context...]` |
 | Azure / Core Tools | host-managed | 仅安装上下文过滤器；通过 `functions_formatter=JsonFormatter()` 在 host 处理程序上强制 NDJSON |
 | CI / 管道 | `json` | NDJSON, 机器可解析 |
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -44,8 +44,8 @@ def setup_logging(
 
     Args:
         level: Logging level for local dev. Ignored in Azure/Core Tools (default: INFO).
-        format: Log format: "color" (default) or "json". Ignored if functions_formatter provided.
-                Passing format="json" in Azure emits a warning; use functions_formatter instead.
+        format: Log format. "color" (default) or "json". In standalone local mode, selects ColorFormatter vs JsonFormatter. In Azure/Core Tools, host handlers are host-managed; use functions_formatter to set their formatter (passing format="json" alone emits a warning).
+                Passing format="json" in Azure without functions_formatter emits a warning.
         logger_name: Optional logger name to configure. None = root logger.
         functions_formatter: Custom formatter for Azure/Core Tools host-managed handlers.
         host_json_path: Explicit path to host.json. When None, walks up from cwd up to 5
@@ -324,7 +324,7 @@ stored in private contextvars and surfaced on every `LogRecord` via the internal
 `ContextFilter`, which is installed automatically by `setup_logging()`. The filter
 and the underlying contextvars are **implementation details** — use the public
 helpers above instead of importing them directly.
-```
+
 
 ## Design Principles
 
@@ -487,7 +487,7 @@ traces
 - Use `setup_logging(format="json")` instead of default color format.
 
 **Q: Can I use custom formatters?**
-- Yes, pass `functions_formatter=MyFormatter()` to setup_logging().
+- Yes, in Azure/Core Tools pass `functions_formatter=MyFormatter()` to setup_logging() to format host-managed handlers. In standalone local mode the built-in `format="color"` / `format="json"` selection applies (custom formatters are not yet wired into the standalone branch).
 
 **Q: Does this work without azure-functions?**
 - Yes, pass any object with invocation_id, function_name attributes to inject_context().


### PR DESCRIPTION
## Summary

Oracle iteration 6 review scored 96/100 (READY) with 2 P2 + 2 P3. Continuing toward 100/100. This PR addresses all findings.

## Findings Addressed

### P2 — \`functions_formatter\` mode-specific behavior overstated
\`functions_formatter\` is only applied in the Azure/Core Tools branch of \`_setup.py\`. Standalone local mode uses \`format\` to choose ColorFormatter vs JsonFormatter; \`functions_formatter\` is ignored there. Reworded \`llms-full.txt\` setup_logging docstring (lines 47-48) and the FAQ entry (line 490).

### P2 — Stray code fence
\`llms-full.txt:327\` had a stray \`\`\`\`\`\` after the prose section. Removed.

### P3 — Misleading JSON-shaped comment in quickstart
\`README.md:180\` (mirrored ko/ja/zh-CN) showed a JSON-shaped output comment, but the quickstart calls plain \`setup_logging()\` which uses the color formatter locally. Replaced with a descriptive comment about which context fields the record now carries.

### P3 — Wrong color-format pattern in 'Local vs Cloud' table
Table claimed \`[TIME] [LEVEL] [LOGGER] message\`, but \`_formatter.py\` produces \`HH:MM:SS LEVEL logger  message [context...]\`. Aligned with the concrete example earlier in the README. Mirrored across en/ko/ja/zh-CN.

## Validation
- \`make lint\` ✓
- \`make typecheck\` ✓
- \`make test\` 199 passed @ 95.25% coverage ✓
- \`make build\` ✓

## Iteration history
- iter 1 → PR #121 (82/100)
- iter 2 → PR #122 (94/100)
- iter 3 → PR #123 (93/100)
- iter 4 → PR #124 (94/100)
- iter 5 → PR #125 (93/100)
- iter 6 → PR #125 follow-up review (96/100 READY)
- iter 7 → this PR (target 100/100)