### PR TITLE
docs: scope output examples and fix SamplingFilter attachment (oracle iter 7)

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -89,13 +89,13 @@ def process_order(req: func.HttpRequest, context: func.Context) -> func.HttpResp
         return func.HttpResponse("OK")
 ```
 
-ローカルターミナル出力 (色付き):
+スタンドアロンで実行した際 (例: `python app.py`、カラーフォーマッタ) のローカルターミナル出力:
 
 ```
 10:30:00 INFO     function_app  Processing order  [invocation_id=abc-123-def, function_name=process_order, cold_start=true]
 ```
 
-本番出力 (Application Insights 用 NDJSON):
+`func start` / Azure 環境での本番出力 (`functions_formatter` が設定されているため Application Insights 用 NDJSON が適用される):
 
 ```json
 {"timestamp": "2024-01-15T10:30:00+00:00", "level": "INFO", "logger": "function_app",
@@ -339,7 +339,7 @@ setup_logging(functions_formatter=JsonFormatter())
  "extra": {"order_id": "o-999"}}
 ```
 
-追加フィールドは `extra` に表示され、Application Insights でインデックス可能です:
+追加フィールドは出力される JSON の `extra` に含まれます。Application Insights で直接インデックス可能かどうかは ingestion パイプラインに依存します: JSON が `customDimensions` にパースされる場合は直接クエリ可能ですが、JSON が `message` カラムに残る場合はまず `parse_json(message)` を通す必要があります。
 
 ```python
 logger.info("order accepted", order_id="o-999", tenant_id="t-1")
@@ -393,8 +393,11 @@ import logging
 
 setup_logging()
 
-# 1 秒ウィンドウあたり azure-core メッセージを最大 10 個まで許可
-logging.getLogger("azure").addFilter(SamplingFilter(rate=10))
+# ノイズーな azure.* ロガーをサンプリング: 1 秒ウィンドウあたり最大 10 レコードを保持
+# ロガーにアタッチしたフィルターは、子ロガーから伝播されるレコードには実行されないため、
+# ルートハンドラーにアタッチし、ロガー名でスコープを限定します。
+for handler in logging.getLogger().handlers:
+    handler.addFilter(SamplingFilter(rate=10, name="azure"))
 
 # 本番で urllib3 を完全に沈黙
 logging.getLogger("urllib3").setLevel(logging.WARNING)

--- a/README.ko.md
+++ b/README.ko.md
@@ -89,13 +89,13 @@ def process_order(req: func.HttpRequest, context: func.Context) -> func.HttpResp
         return func.HttpResponse("OK")
 ```
 
-로컬 터미널 출력 (색상 적용):
+단독 실행할 때 (예: `python app.py`, 컬러 포맷터) 로컬 터미널 출력:
 
 ```
 10:30:00 INFO     function_app  Processing order  [invocation_id=abc-123-def, function_name=process_order, cold_start=true]
 ```
 
-프로덕션 출력 (Application Insights용 NDJSON):
+`func start` / Azure 환경에서의 프로덕션 출력 (`functions_formatter`가 설정되어 있으므로 Application Insights용 NDJSON이 적용됨):
 
 ```json
 {"timestamp": "2024-01-15T10:30:00+00:00", "level": "INFO", "logger": "function_app",
@@ -339,7 +339,7 @@ setup_logging(functions_formatter=JsonFormatter())
  "extra": {"order_id": "o-999"}}
 ```
 
-추가 필드는 `extra`에 표시되며 Application Insights에서 인덱싱 가능합니다:
+추가 필드는 발행되는 JSON의 `extra`에 포함됩니다. Application Insights에서 직접 인덱싱 가능한지 여부는 ingestion 파이프라인에 따라 다릅니다: JSON이 `customDimensions`로 파싱되는 경우 직접 쿼리 가능하며, JSON이 `message` 컬럼에 남아 있는 경우 먼저 `parse_json(message)`를 거쳐야 합니다.
 
 ```python
 logger.info("order accepted", order_id="o-999", tenant_id="t-1")
@@ -393,8 +393,11 @@ import logging
 
 setup_logging()
 
-# 1초 윈도우당 azure-core 메시지를 최대 10개까지 허용
-logging.getLogger("azure").addFilter(SamplingFilter(rate=10))
+# 시끄러운 azure.* 로거 샘플링: 1초 윈도우당 최대 10개 레코드 유지
+# 로거에 붙은 필터는 하위 로거에서 전파되는 레코드에는 실행되지 않으므로,
+# 루트 핸들러에 붙이고 로거 이름으로 범위를 제한하세요.
+for handler in logging.getLogger().handlers:
+    handler.addFilter(SamplingFilter(rate=10, name="azure"))
 
 # 프로덕션에서 urllib3를 완전히 침묵
 logging.getLogger("urllib3").setLevel(logging.WARNING)

--- a/README.md
+++ b/README.md
@@ -89,13 +89,13 @@ def process_order(req: func.HttpRequest, context: func.Context) -> func.HttpResp
         return func.HttpResponse("OK")
 ```
 
-Local terminal output (colorized):
+Local terminal output when run standalone (e.g. `python app.py`, color formatter):
 
 ```
 10:30:00 INFO     function_app  Processing order  [invocation_id=abc-123-def, function_name=process_order, cold_start=true]
 ```
 
-Production output (NDJSON for Application Insights):
+Production output under `func start` / Azure (Application Insights NDJSON, applied because `functions_formatter` is set):
 
 ```json
 {"timestamp": "2024-01-15T10:30:00+00:00", "level": "INFO", "logger": "function_app",
@@ -347,7 +347,7 @@ Output per log line (NDJSON — one JSON object per line):
  "extra": {"order_id": "o-999"}}
 ```
 
-Extra fields appear in `extra` and are indexable in Application Insights:
+Extra fields appear under `extra` in the emitted JSON. Whether they are directly indexable in Application Insights depends on your ingestion pipeline: when JSON is parsed into `customDimensions` they are queryable directly; when the JSON stays in the `message` column you need `parse_json(message)` first.
 
 ```python
 logger.info("order accepted", order_id="o-999", tenant_id="t-1")
@@ -402,8 +402,11 @@ import logging
 
 setup_logging()
 
-# Allow up to 10 azure-core messages per 1-second window
-logging.getLogger("azure").addFilter(SamplingFilter(rate=10))
+# Sample noisy azure.* loggers: keep up to 10 records per 1-second window.
+# Filters attached to a logger don't run for records propagated from
+# descendants, so attach to the root handlers and scope by logger name.
+for handler in logging.getLogger().handlers:
+    handler.addFilter(SamplingFilter(rate=10, name="azure"))
 
 # Silence urllib3 completely in production
 logging.getLogger("urllib3").setLevel(logging.WARNING)

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -89,13 +89,13 @@ def process_order(req: func.HttpRequest, context: func.Context) -> func.HttpResp
         return func.HttpResponse("OK")
 ```
 
-本地终端输出 (彩色):
+独立运行时 (如 `python app.py`，彩色格式化器) 的本地终端输出:
 
 ```
 10:30:00 INFO     function_app  Processing order  [invocation_id=abc-123-def, function_name=process_order, cold_start=true]
 ```
 
-生产输出 (用于 Application Insights 的 NDJSON):
+在 `func start` / Azure 环境下的生产输出 (因为设置了 `functions_formatter`，适用于 Application Insights 的 NDJSON):
 
 ```json
 {"timestamp": "2024-01-15T10:30:00+00:00", "level": "INFO", "logger": "function_app",
@@ -339,7 +339,7 @@ setup_logging(functions_formatter=JsonFormatter())
  "extra": {"order_id": "o-999"}}
 ```
 
-额外字段出现在 `extra` 中，并可在 Application Insights 中索引:
+额外字段出现在发出的 JSON 的 `extra` 中。在 Application Insights 中是否可直接索引取决于您的 ingestion 管道: 当 JSON 被解析为 `customDimensions` 时可直接查询；当 JSON 保留在 `message` 列中时，需要先使用 `parse_json(message)`。
 
 ```python
 logger.info("order accepted", order_id="o-999", tenant_id="t-1")
@@ -393,8 +393,11 @@ import logging
 
 setup_logging()
 
-# 在 1 秒窗口内允许最多 10 条 azure-core 消息
-logging.getLogger("azure").addFilter(SamplingFilter(rate=10))
+# 对吵闹的 azure.* logger 进行采样: 每 1 秒窗口保留最多 10 条记录
+# 附加到 logger 的过滤器不会对从子 logger 传播的记录运行，
+# 所以附加到根处理程序并按 logger 名称限定范围。
+for handler in logging.getLogger().handlers:
+    handler.addFilter(SamplingFilter(rate=10, name="azure"))
 
 # 在生产环境完全静默 urllib3
 logging.getLogger("urllib3").setLevel(logging.WARNING)


### PR DESCRIPTION
## Summary

Oracle iter-7 docs cleanup across `README.md`, `README.ko.md`, `README.ja.md`, `README.zh-CN.md`.

### Changes

- **Output examples scoped by environment** — clarify that the colorized line is what you see when running standalone (`python app.py`), and the NDJSON block is what `func start` / Azure produces because `functions_formatter` is active. Prevents the misread that the same setup yields both at once.
- **App Insights indexability claim softened** — `extra` fields are only directly indexable when the JSON is parsed into `customDimensions`. When the JSON stays in the `message` column, users need `parse_json(message)` first. Documented both paths.
- **SamplingFilter example fixed** — `logging.getLogger("azure").addFilter(...)` does not run for records propagated from descendant loggers. Updated example to attach the filter to root handlers with `name="azure"`, which is the correct way to sample the `azure.*` namespace.

### Verification

- Diff scoped to 4 README files (32 insertions, 20 deletions)
- No code changes, no test impact