### PR TITLE
feat(json): truncate oversized fallback values in JsonFormatter

### DIFF
--- a/src/azure_functions_logging/_json_formatter.py
+++ b/src/azure_functions_logging/_json_formatter.py
@@ -39,6 +39,16 @@ _CONTEXT_FIELDS: set[str] = {
 }
 
 
+# Maximum length (in characters) of the string produced by the ``json.dumps``
+# ``default=`` fallback path. A single very large object (e.g. a SQLAlchemy
+# result row, a deeply nested config, a full HTTP body) can otherwise bloat
+# every log record it appears in and risk hitting Application Insights
+# per-record size limits. Natively serializable values (strings, numbers,
+# booleans, lists, dicts) are NOT affected by this limit.
+_MAX_SERIALIZED_EXTRA_LENGTH = 2048
+_TRUNCATION_SUFFIX = "...<truncated>"
+
+
 def _json_default(value: Any) -> str:
     """Fallback serializer for ``json.dumps``.
 
@@ -47,11 +57,17 @@ def _json_default(value: Any) -> str:
     objects, etc.). This callable coerces unknown values to ``str(value)`` and
     returns a sentinel string if even ``str()`` raises, so the formatter always
     produces a valid JSON document.
+
+    Strings longer than :data:`_MAX_SERIALIZED_EXTRA_LENGTH` are truncated and
+    suffixed with :data:`_TRUNCATION_SUFFIX` to bound per-record growth.
     """
     try:
-        return str(value)
+        text = str(value)
     except Exception:
         return f"<unserializable:{type(value).__name__}>"
+    if len(text) > _MAX_SERIALIZED_EXTRA_LENGTH:
+        return text[:_MAX_SERIALIZED_EXTRA_LENGTH] + _TRUNCATION_SUFFIX
+    return text
 
 
 class JsonFormatter(logging.Formatter):

--- a/tests/test_json_formatter.py
+++ b/tests/test_json_formatter.py
@@ -162,6 +162,73 @@ def test_unserializable_extra_where_str_raises_returns_sentinel() -> None:
     assert payload["extra"]["bad"] == "<unserializable:Hostile>"
 
 
+# ---- Fallback truncation (#82) ------------------------------------------
+
+
+def test_fallback_value_at_max_length_is_not_truncated() -> None:
+    """#82 boundary: str(value) at exactly _MAX_SERIALIZED_EXTRA_LENGTH passes through."""
+    from azure_functions_logging._json_formatter import _MAX_SERIALIZED_EXTRA_LENGTH
+
+    class Boundary:
+        def __str__(self) -> str:
+            return "x" * _MAX_SERIALIZED_EXTRA_LENGTH
+
+    formatter = JsonFormatter()
+    record = _make_record(msg="boundary")
+    record.payload = Boundary()
+
+    output = formatter.format(record)
+    payload = json.loads(output)
+
+    assert payload["extra"]["payload"] == "x" * _MAX_SERIALIZED_EXTRA_LENGTH
+    assert "<truncated>" not in payload["extra"]["payload"]
+
+
+def test_fallback_value_over_max_length_is_truncated_with_suffix() -> None:
+    """Issue #82: str(value) longer than the limit is truncated and suffixed."""
+    from azure_functions_logging._json_formatter import (
+        _MAX_SERIALIZED_EXTRA_LENGTH,
+        _TRUNCATION_SUFFIX,
+    )
+
+    class Huge:
+        def __str__(self) -> str:
+            return "a" * (_MAX_SERIALIZED_EXTRA_LENGTH + 500)
+
+    formatter = JsonFormatter()
+    record = _make_record(msg="huge")
+    record.payload = Huge()
+
+    output = formatter.format(record)
+    # Output must remain a valid JSON document.
+    payload = json.loads(output)
+
+    rendered = payload["extra"]["payload"]
+    assert rendered.endswith(_TRUNCATION_SUFFIX)
+    assert len(rendered) == _MAX_SERIALIZED_EXTRA_LENGTH + len(_TRUNCATION_SUFFIX)
+    # The first _MAX_SERIALIZED_EXTRA_LENGTH chars are the original prefix.
+    assert rendered[:_MAX_SERIALIZED_EXTRA_LENGTH] == "a" * _MAX_SERIALIZED_EXTRA_LENGTH
+
+
+def test_truncation_does_not_apply_to_native_serializable_values() -> None:
+    """Issue #82 scope: the limit only applies to the json.dumps default= path.
+
+    Plain strings/ints/lists/dicts are serialized natively by json and must
+    pass through untouched even if they exceed the limit.
+    """
+    from azure_functions_logging._json_formatter import _MAX_SERIALIZED_EXTRA_LENGTH
+
+    big_string = "z" * (_MAX_SERIALIZED_EXTRA_LENGTH + 100)
+    formatter = JsonFormatter()
+    record = _make_record(msg="native")
+    record.payload = big_string
+
+    payload = json.loads(formatter.format(record))
+
+    # Native string must not be touched by the fallback truncation.
+    assert payload["extra"]["payload"] == big_string
+    assert "<truncated>" not in payload["extra"]["payload"]
+
 
 # ---- Fail-safe tests (#101) ---------------------------------------------
 


### PR DESCRIPTION
Closes #82

## Context
When `JsonFormatter` encounters a non-JSON-serializable extra, it falls back to `str(value)`. Without bounds, a hostile or large `__str__` could produce arbitrarily large log payloads.

## Changes
- Add `_MAX_SERIALIZED_EXTRA_LENGTH = 2048` and `_TRUNCATION_SUFFIX = "...<truncated>"` to `_json_formatter.py`.
- Update `_json_default` to truncate fallback strings exceeding the limit, appending the suffix.
- Native JSON-serializable types are unaffected.

## Tests
- Boundary: value exactly at limit passes through unchanged.
- Over-limit: value truncated and suffixed.
- Native types not affected.

## Validation
- `make test` — 202 passed, coverage 95.30%
- `make lint` — clean
- `make typecheck` — clean