### PR TITLE
fix(setup): preserve factory-injected context when use_record_factory=True

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -273,9 +273,14 @@ Invocation-scoped metadata (`invocation_id`, `function_name`, `trace_id`, `cold_
 
 Cold start detection uses a module-level boolean that starts `True` and flips to `False` after the first `inject_context()` call. This maps directly to the Azure Functions worker process lifecycle without requiring external state.
 
-### 6. Filter-based context enrichment
+### 6. Context enrichment: filter or factory
 
-`ContextFilter` copies context variable values onto each `LogRecord` during the filter phase, before the formatter runs. This keeps the enrichment mechanism orthogonal to formatter choice — the same filter works with both `ColorFormatter` and `JsonFormatter`.
+Two complementary mechanisms inject context variable values onto each `LogRecord`:
+
+- **`ContextFilter` (default)** runs during the filter phase, before the formatter, and reads context variables at handler-dispatch time. It works with both `ColorFormatter` and `JsonFormatter` but reflects the *current* contextvar state when the handler runs — not when the record was created.
+- **`install_context_factory()` (opt-in via `setup_logging(use_record_factory=True)`)** swaps the global `logging.LogRecordFactory` so context fields are captured at record-creation time. This snapshot survives thread hops, queued/delayed handlers, and contextvar resets between record creation and handler dispatch.
+
+When `use_record_factory=True`, `ContextFilter` is intentionally **not** attached to handlers, so the factory snapshot is the single source of truth and cannot be overwritten downstream.
 
 ## Module Boundaries
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -117,9 +117,16 @@ Behavior details:
 
 - Default is `False` to preserve the existing handler-filter-only behavior.
 - When `True`, `install_context_factory()` is called once; repeated calls are no-ops.
+- When `True`, `ContextFilter` is **not** attached to handlers. The global
+  `LogRecordFactory` is the sole source of context fields, so values captured at
+  record-creation time survive thread hops, queued handlers, and delayed flushes
+  (no filter runs at handler dispatch time to overwrite the snapshot).
 - Modifies the **global** `LogRecordFactory` and affects all loggers in the process.
-- The four context field names become reserved on the LogRecord; prefer
-  `FunctionLogger` (which sanitizes `extra` keys) when this option is enabled.
+- The four context field names (`invocation_id`, `function_name`, `trace_id`,
+  `cold_start`) become reserved on every LogRecord; prefer `FunctionLogger`
+  (which sanitizes `extra` keys) when this option is enabled.
+- Input validation (e.g. `format`) runs **before** the factory is installed, so
+  invalid arguments raise `ValueError` without any global side effects.
 ## Idempotency and Reconfiguration
 
 `setup_logging()` uses internal setup state to guarantee idempotency.
@@ -152,14 +159,14 @@ Execution behavior by environment:
 
 - Sets logger level.
 - Adds `StreamHandler` if no handlers exist.
-- Installs `ContextFilter` on handlers.
+- Installs `ContextFilter` on handlers (skipped when `use_record_factory=True`).
 - Uses selected formatter (`ColorFormatter` or `JsonFormatter`).
 
 ### Azure Functions / Core Tools
 
 - Does not add new handlers.
 - Does not override host-managed handler strategy.
-- Installs `ContextFilter` to enrich records with invocation fields.
+- Installs `ContextFilter` to enrich records with invocation fields (skipped when `use_record_factory=True`).
 - Emits host-level conflict warning checks.
 
 !!! tip

--- a/docs/index.md
+++ b/docs/index.md
@@ -81,7 +81,7 @@ This combines context-managed invocation context and request binding in a safe, 
 Behavior changes intentionally by runtime:
 
 - Local standalone process: sets the target/root logger level; adds a `StreamHandler` (`color` or `json`) only if no handlers exist, otherwise just attaches filters to existing handlers.
-- Azure/Core Tools runtime: installs `ContextFilter` on existing root handlers **and on the root logger itself** (so direct calls on the root logger carry context); does not add handlers or change root level. To guarantee context on records that propagate from named child loggers to handlers attached later, call `install_context_factory()`.
+- Azure/Core Tools runtime: installs `ContextFilter` on existing root handlers **and on the root logger itself** (so direct calls on the root logger carry context); does not add handlers or change root level. To guarantee context on records that propagate from named child loggers to handlers attached later, pass `use_record_factory=True` to `setup_logging()` (preferred) or call `install_context_factory()` directly.
 
 !!! warning
     In Azure-hosted execution, host-level `host.json` settings can still suppress logs even when application-level setup appears correct.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -232,13 +232,13 @@ Recommended baseline:
 
 - Sets logger level.
 - Adds stream handler if missing.
-- Installs context filter.
+- Installs context filter (skipped when `use_record_factory=True`; the global LogRecordFactory injects context instead).
 - Applies selected formatter.
 
 ### Azure Functions / Core Tools
 
 - Does not add handlers.
-- Installs context filter for metadata enrichment.
+- Installs context filter for metadata enrichment (skipped when `use_record_factory=True`; the global LogRecordFactory injects context instead).
 - Leaves host handler pipeline intact.
 
 This design prevents duplicate logs in runtime-managed environments.

--- a/src/azure_functions_logging/_setup.py
+++ b/src/azure_functions_logging/_setup.py
@@ -68,24 +68,41 @@ def setup_logging(
             ``host.json`` is auto-discovered by walking up from the current
             working directory (bounded). Pass an explicit path to disable
             auto-discovery in environments where it might pick the wrong file.
-        use_record_factory: When True, also call :func:`install_context_factory`
-            so context fields are injected at LogRecord creation time. This is
-            an opt-in global hook that guarantees context propagation even if
-            handler filters are missing or bypassed. Defaults to False to
-            preserve the existing handler-filter-only behavior.
-    """
-    if use_record_factory:
-        install_context_factory()
+        use_record_factory: When True, install :func:`install_context_factory`
+            so context fields are injected at LogRecord creation time and are
+            preserved through queued, delayed, or cross-thread handling. When
+            this option is enabled, ``ContextFilter`` is **not** attached to
+            handlers, because the global ``LogRecordFactory`` would be
+            overwritten by the filter at handler dispatch time. Defaults to
+            False to preserve the existing handler-filter-only behavior.
 
+    .. warning::
+
+        ``use_record_factory=True`` modifies the **global**
+        ``logging.LogRecordFactory``, which affects all loggers in the process
+        (including third-party libraries). The four context field names
+        (``invocation_id``, ``function_name``, ``trace_id``, ``cold_start``)
+        become reserved LogRecord attributes — passing them via ``extra=`` to
+        stdlib loggers will raise ``KeyError``. Prefer :class:`FunctionLogger`
+        (which sanitizes ``extra`` keys automatically) when this option is on.
+    """
     if format not in {"color", "json"}:
         msg = "format must be 'color' or 'json'"
         raise ValueError(msg)
+
+    # Install the global LogRecordFactory only after argument validation,
+    # so an invalid call does not leave persistent global side effects.
+    if use_record_factory:
+        install_context_factory()
 
     with _configured_lock:
         if logger_name in _configured_loggers:
             return
 
-        context_filter = ContextFilter()
+        # When the LogRecordFactory is active, attaching ContextFilter would
+        # overwrite factory-injected fields with current contextvar values at
+        # handler dispatch time, defeating the record-creation-time guarantee.
+        context_filter: ContextFilter | None = None if use_record_factory else ContextFilter()
         is_functions_env = _is_functions_environment()
 
         if is_functions_env:
@@ -100,9 +117,11 @@ def setup_logging(
             for handler in root.handlers:
                 if functions_formatter is not None:
                     handler.setFormatter(functions_formatter)
-                handler.addFilter(context_filter)
+                if context_filter is not None:
+                    handler.addFilter(context_filter)
             # Also install on any future handlers via the logger itself
-            root.addFilter(context_filter)
+            if context_filter is not None:
+                root.addFilter(context_filter)
         else:
             # Standalone local development
             target = logging.getLogger(logger_name)
@@ -112,9 +131,10 @@ def setup_logging(
             if not target.handlers:
                 handler = logging.StreamHandler()
                 handler.setFormatter(ColorFormatter() if format == "color" else JsonFormatter())
-                handler.addFilter(context_filter)
+                if context_filter is not None:
+                    handler.addFilter(context_filter)
                 target.addHandler(handler)
-            else:
+            elif context_filter is not None:
                 # Add filter to existing handlers
                 for handler in target.handlers:
                     handler.addFilter(context_filter)

--- a/tests/test_json_formatter.py
+++ b/tests/test_json_formatter.py
@@ -384,3 +384,19 @@ def test_format_truncates_extra_at_max_recursion_depth() -> None:
     output = formatter.format(record)
     payload = json.loads(output)
     assert f"<max-depth:{_MAX_RECURSION_DEPTH}>" in json.dumps(payload["extra"]["deep"])
+
+
+def test_format_does_not_misclassify_dag_as_cycle() -> None:
+    """A shared (non-cyclic) child appearing in two sibling positions must be
+    expanded twice, not replaced with the cyclic sentinel."""
+    formatter = JsonFormatter()
+    record = _make_record(logging.INFO, "dag")
+    shared = {"name": "shared"}
+    record.payload = {"a": shared, "b": shared}
+
+    output = formatter.format(record)
+    payload = json.loads(output)
+    assert payload["extra"]["payload"] == {
+        "a": {"name": "shared"},
+        "b": {"name": "shared"},
+    }

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -269,3 +269,79 @@ def test_setup_logging_use_record_factory_is_idempotent() -> None:
         lg = logging.getLogger(name)
         lg.handlers.clear()
         lg.filters.clear()
+
+
+def test_setup_logging_use_record_factory_skips_context_filter() -> None:
+    """With use_record_factory=True, ContextFilter must NOT be attached.
+
+    Otherwise the filter would overwrite factory-injected fields with current
+    contextvar values at handler dispatch time, defeating the record-creation-
+    time guarantee under queued / cross-thread / delayed handling.
+    """
+    logger_name = "afl.test.factory.no_filter"
+    logger = logging.getLogger(logger_name)
+    logger.handlers.clear()
+    logger.filters.clear()
+
+    with patch.dict(os.environ, {}, clear=True):
+        setup_logging(logger_name=logger_name, use_record_factory=True)
+
+    assert not any(isinstance(f, ContextFilter) for f in logger.filters)
+    for handler in logger.handlers:
+        assert not any(isinstance(f, ContextFilter) for f in handler.filters)
+
+    logger.handlers.clear()
+    logger.filters.clear()
+
+
+def test_setup_logging_factory_record_survives_contextvar_reset() -> None:
+    """Regression: factory-injected fields must survive contextvar reset.
+
+    Simulates queued/delayed handling: a record is created inside a context,
+    then the context is reset before the handler runs. With use_record_factory,
+    the snapshot must be preserved (no ContextFilter to overwrite it).
+    """
+    from azure_functions_logging._context import invocation_id_var
+
+    logger_name = "afl.test.factory.snapshot"
+    logger = logging.getLogger(logger_name)
+    logger.handlers.clear()
+    logger.filters.clear()
+
+    with patch.dict(os.environ, {}, clear=True):
+        setup_logging(logger_name=logger_name, use_record_factory=True)
+
+    token = invocation_id_var.set("test-invocation-123")
+    try:
+        record = logger.makeRecord(
+            logger_name, logging.INFO, "f.py", 1, "msg", (), None,
+        )
+    finally:
+        invocation_id_var.reset(token)
+
+    # Context reset — but record was already created.
+    invocation_id_var.set(None)
+
+    # Run any handler filters (there should be none, but if any existed
+    # they must not overwrite the snapshot).
+    for handler in logger.handlers:
+        for flt in handler.filters:
+            if isinstance(flt, logging.Filter):
+                flt.filter(record)
+
+    assert getattr(record, "invocation_id", None) == "test-invocation-123"
+
+    logger.handlers.clear()
+    logger.filters.clear()
+
+
+def test_setup_logging_invalid_format_leaves_no_global_side_effects() -> None:
+    """Invalid `format` must raise BEFORE any global side effects (e.g. factory)."""
+    baseline_factory = logging.getLogRecordFactory()
+
+    with patch.dict(os.environ, {}, clear=True):
+        with pytest.raises(ValueError, match="format must be"):
+            setup_logging(format="bogus", use_record_factory=True)
+
+    # Factory must not have been swapped despite use_record_factory=True
+    assert logging.getLogRecordFactory() is baseline_factory


### PR DESCRIPTION
## Context

Post-merge Oracle review of #131 found a Critical bug: `use_record_factory=True` did not behave as documented because `ContextFilter` was still attached to handlers and overwrote the factory-injected snapshot at handler dispatch time. This defeated the "guaranteed record-creation-time injection" promise that motivates the option (queued handlers, cross-thread dispatch, delayed flushes).

Oracle also flagged that the global `LogRecordFactory` was installed *before* `format` validation, leaking global side effects on `ValueError`.

## Changes

**Critical fix**
- Skip `ContextFilter` installation when `use_record_factory=True` so the factory snapshot is the single source of truth for context fields.

**Should-fix**
- Move `install_context_factory()` call to run **after** `format` validation. Invalid arguments now raise without touching the global `LogRecordFactory`.
- Update `setup_logging` docstring with the new behavior + a `.. warning::` covering the global factory and reserved attribute names.
- Sync `docs/architecture.md`, `docs/configuration.md`, `docs/index.md`, `docs/usage.md` with the filter-vs-factory split.

**Regression tests**
- `test_setup_logging_use_record_factory_skips_context_filter`
- `test_setup_logging_factory_record_survives_contextvar_reset` (simulates queued/delayed handling)
- `test_setup_logging_invalid_format_leaves_no_global_side_effects`
- `test_format_does_not_misclassify_dag_as_cycle` (JsonFormatter DAG safety regression)

## Validation

- `make lint` ✅
- `make typecheck` ✅
- `make test` ✅ — 215 passed, 4 skipped, coverage 95.37%
- `make build` ✅

## References
- Follow-up to #131
- Post-merge Oracle review: addresses 1 Critical + 3 Should-fix items