### PR TITLE
refactor(logger): centralize standard LogRecord field definitions

### DIFF
--- a/src/azure_functions_logging/_filters.py
+++ b/src/azure_functions_logging/_filters.py
@@ -12,6 +12,8 @@ import threading
 import time
 from typing import Any, Iterable
 
+from ._logger import _RESERVED_LOG_RECORD_KEYS
+
 # Default set of sensitive keys masked by RedactionFilter
 _DEFAULT_SENSITIVE_KEYS: frozenset[str] = frozenset(
     {
@@ -47,38 +49,6 @@ def _redact_value(
     return value
 
 
-# Standard LogRecord fields that RedactionFilter should never touch
-_STANDARD_RECORD_FIELDS: frozenset[str] = frozenset(
-    {
-        "args",
-        "created",
-        "exc_info",
-        "exc_text",
-        "filename",
-        "funcName",
-        "levelname",
-        "levelno",
-        "lineno",
-        "message",
-        "module",
-        "msecs",
-        "msg",
-        "name",
-        "pathname",
-        "process",
-        "processName",
-        "relativeCreated",
-        "stack_info",
-        "taskName",
-        "thread",
-        "threadName",
-        # Context fields
-        "invocation_id",
-        "function_name",
-        "trace_id",
-        "cold_start",
-    }
-)
 
 
 class SamplingFilter(logging.Filter):
@@ -177,7 +147,7 @@ class RedactionFilter(logging.Filter):
             return True  # bypass redaction for non-matching loggers
 
         for key in list(record.__dict__.keys()):
-            if key in _STANDARD_RECORD_FIELDS:
+            if key in _RESERVED_LOG_RECORD_KEYS:
                 continue
             if key.lower() in self._sensitive_keys:
                 setattr(record, key, _MASK)

--- a/src/azure_functions_logging/_formatter.py
+++ b/src/azure_functions_logging/_formatter.py
@@ -6,6 +6,8 @@ import logging
 import sys
 from typing import Iterable
 
+from ._logger import _LIBRARY_RESERVED_KEYS, _STDLIB_RECORD_KEYS
+
 # ANSI color codes
 _COLORS: dict[int, str] = {
     logging.DEBUG: "\033[90m",  # Gray
@@ -21,36 +23,8 @@ _SENSITIVE_KEYS: frozenset[str] = frozenset(
     {"password", "token", "authorization", "secret", "api_key", "apikey", "passwd"}
 )
 
-_STANDARD_RECORD_FIELDS: frozenset[str] = frozenset(
-    {
-        "args",
-        "created",
-        "exc_info",
-        "exc_text",
-        "filename",
-        "funcName",
-        "levelname",
-        "levelno",
-        "lineno",
-        "message",
-        "module",
-        "msecs",
-        "msg",
-        "name",
-        "pathname",
-        "process",
-        "processName",
-        "relativeCreated",
-        "stack_info",
-        "taskName",
-        "thread",
-        "threadName",
-    }
-)
-
-_CONTEXT_FIELDS: frozenset[str] = frozenset(
-    {"invocation_id", "function_name", "trace_id", "cold_start"}
-)
+_STANDARD_RECORD_FIELDS: frozenset[str] = _STDLIB_RECORD_KEYS
+_CONTEXT_FIELDS: frozenset[str] = _LIBRARY_RESERVED_KEYS
 
 
 class ColorFormatter(logging.Formatter):

--- a/src/azure_functions_logging/_json_formatter.py
+++ b/src/azure_functions_logging/_json_formatter.py
@@ -7,36 +7,10 @@ import json
 import logging
 from typing import Any
 
-_STANDARD_RECORD_FIELDS: set[str] = {
-    "args",
-    "created",
-    "exc_info",
-    "exc_text",
-    "filename",
-    "funcName",
-    "levelname",
-    "levelno",
-    "lineno",
-    "message",
-    "module",
-    "msecs",
-    "msg",
-    "name",
-    "pathname",
-    "process",
-    "processName",
-    "relativeCreated",
-    "stack_info",
-    "taskName",
-    "thread",
-    "threadName",
-}
-_CONTEXT_FIELDS: set[str] = {
-    "invocation_id",
-    "function_name",
-    "trace_id",
-    "cold_start",
-}
+from ._logger import _LIBRARY_RESERVED_KEYS, _STDLIB_RECORD_KEYS
+
+_STANDARD_RECORD_FIELDS: frozenset[str] = _STDLIB_RECORD_KEYS
+_CONTEXT_FIELDS: frozenset[str] = _LIBRARY_RESERVED_KEYS
 
 
 # Maximum length (in characters) of the string produced by the ``json.dumps``

--- a/src/azure_functions_logging/_logger.py
+++ b/src/azure_functions_logging/_logger.py
@@ -27,11 +27,13 @@ _LIBRARY_RESERVED_KEYS: frozenset[str] = frozenset(
 # passing it as `extra` is sanitized identically across 3.10 / 3.11 / 3.12+.
 _FORWARD_COMPAT_RECORD_KEYS: frozenset[str] = frozenset({"message", "asctime", "taskName"})
 
-_RESERVED_LOG_RECORD_KEYS: frozenset[str] = (
-    frozenset(logging.makeLogRecord({}).__dict__)
-    | _FORWARD_COMPAT_RECORD_KEYS
-    | _LIBRARY_RESERVED_KEYS
+# stdlib LogRecord fields only (no library context keys).
+# Use this in formatters that need to distinguish stdlib from application-added fields.
+_STDLIB_RECORD_KEYS: frozenset[str] = (
+    frozenset(logging.makeLogRecord({}).__dict__) | _FORWARD_COMPAT_RECORD_KEYS
 )
+
+_RESERVED_LOG_RECORD_KEYS: frozenset[str] = _STDLIB_RECORD_KEYS | _LIBRARY_RESERVED_KEYS
 
 
 def _sanitize_extra(extra: dict[str, Any]) -> dict[str, Any]:


### PR DESCRIPTION
## Summary

- Adds `_STDLIB_RECORD_KEYS` to `_logger.py` using the existing dynamic derivation (`logging.makeLogRecord({})` + forward-compat set)
- Removes three static copies of `_STANDARD_RECORD_FIELDS` from `_filters.py`, `_formatter.py`, and `_json_formatter.py`
- All three modules now import `_STDLIB_RECORD_KEYS` and `_LIBRARY_RESERVED_KEYS` from `_logger.py`
- No behaviour change; no public API change; all 220 tests pass

Closes #137