### PR TITLE
fix(context): make cold-start detection thread-safe

### DIFF
--- a/src/azure_functions_logging/_context.py
+++ b/src/azure_functions_logging/_context.py
@@ -6,6 +6,7 @@ from collections.abc import Iterator
 from contextlib import contextmanager
 import contextvars
 import logging
+import threading
 from typing import Any
 
 # Type alias for the token mapping returned by inject_context()
@@ -23,16 +24,19 @@ cold_start_var: contextvars.ContextVar[bool | None] = contextvars.ContextVar(
     "cold_start", default=None
 )
 
-# Cold start detection
+# Cold start detection — lock ensures exactly one concurrent first invocation
+# sees cold_start=True even when multiple threads call inject_context() simultaneously.
 _cold_start: bool = True
+_cold_start_lock = threading.Lock()
 
 
 def _check_cold_start() -> bool:
-    """Check and consume the cold start flag. Returns True only on first call."""
+    """Check and consume the cold start flag atomically. Returns True only on first call."""
     global _cold_start
-    if _cold_start:
-        _cold_start = False
-        return True
+    with _cold_start_lock:
+        if _cold_start:
+            _cold_start = False
+            return True
     return False
 
 

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -122,6 +122,28 @@ def test_cold_start_first_true_then_false() -> None:
     assert _check_cold_start() is False
 
 
+def test_cold_start_thread_safe_exactly_one_true() -> None:
+    """Concurrent first calls: exactly one thread must observe cold_start=True."""
+    import threading
+
+    ctx_mod._cold_start = True  # reset for this test
+    results: list[bool] = []
+    barrier = threading.Barrier(10)
+
+    def worker() -> None:
+        barrier.wait()  # all threads start simultaneously
+        results.append(_check_cold_start())
+
+    threads = [threading.Thread(target=worker) for _ in range(10)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert results.count(True) == 1, f"Expected exactly one True, got: {results}"
+    assert results.count(False) == 9
+
+
 def test_context_filter_reads_contextvars_after_inject_context() -> None:
     context = SimpleNamespace(
         invocation_id="inv-z",


### PR DESCRIPTION
## Summary

- Wraps the `_cold_start` boolean and its check-then-flip in `_check_cold_start()` with a `threading.Lock`
- Exactly one concurrent first invocation per worker process will now observe `cold_start=True`
- Adds `test_cold_start_thread_safe_exactly_one_true` that launches 10 threads simultaneously and asserts only one gets `True`

Closes #136