### PR TITLE
fix(filters): harden RedactionFilter with cycle guard and depth limit

### DIFF
--- a/src/azure_functions_logging/_filters.py
+++ b/src/azure_functions_logging/_filters.py
@@ -30,23 +30,56 @@ _DEFAULT_SENSITIVE_KEYS: frozenset[str] = frozenset(
 _MASK = "***"
 
 
+_REDACT_MAX_DEPTH = 10  # default depth limit for recursive redaction
+
+
 def _redact_value(
     value: Any,
     sensitive_keys: frozenset[str],
     mask: str = _MASK,
+    *,
+    _seen: set[int] | None = None,
+    _depth: int = 0,
 ) -> Any:
-    if isinstance(value, dict):
-        return {
-            key: (
-                mask
-                if isinstance(key, str) and key.lower() in sensitive_keys
-                else _redact_value(item, sensitive_keys, mask)
-            )
-            for key, item in value.items()
-        }
-    if isinstance(value, list):
-        return [_redact_value(item, sensitive_keys, mask) for item in value]
-    return value
+    """Recursively redact sensitive keys from dicts/lists.
+
+    Guarded against:
+    - Cyclic references (via id-based seen set)
+    - Pathologically deep structures (via _depth / _REDACT_MAX_DEPTH)
+    - All exceptions (returns value unmodified on any error)
+    """
+    try:
+        if _depth >= _REDACT_MAX_DEPTH:
+            return value
+        if isinstance(value, dict):
+            seen = _seen if _seen is not None else set()
+            obj_id = id(value)
+            if obj_id in seen:
+                return mask  # cyclic reference detected
+            seen = seen | {obj_id}  # copy to avoid cross-branch pollution
+            return {
+                key: (
+                    mask
+                    if isinstance(key, str) and key.lower() in sensitive_keys
+                    else _redact_value(
+                        item, sensitive_keys, mask, _seen=seen, _depth=_depth + 1
+                    )
+                )
+                for key, item in value.items()
+            }
+        if isinstance(value, list):
+            seen = _seen if _seen is not None else set()
+            obj_id = id(value)
+            if obj_id in seen:
+                return mask
+            seen = seen | {obj_id}
+            return [
+                _redact_value(item, sensitive_keys, mask, _seen=seen, _depth=_depth + 1)
+                for item in value
+            ]
+        return value
+    except Exception:  # nosec B110 — filter must never raise
+        return value
 
 
 
@@ -146,13 +179,16 @@ class RedactionFilter(logging.Filter):
         if not super().filter(record):
             return True  # bypass redaction for non-matching loggers
 
-        for key in list(record.__dict__.keys()):
-            if key in _RESERVED_LOG_RECORD_KEYS:
-                continue
-            if key.lower() in self._sensitive_keys:
-                setattr(record, key, _MASK)
-            else:
-                value = record.__dict__[key]
-                if isinstance(value, (dict, list)):
-                    setattr(record, key, _redact_value(value, self._sensitive_keys))
+        try:
+            for key in list(record.__dict__.keys()):
+                if key in _RESERVED_LOG_RECORD_KEYS:
+                    continue
+                if key.lower() in self._sensitive_keys:
+                    setattr(record, key, _MASK)
+                else:
+                    value = record.__dict__[key]
+                    if isinstance(value, (dict, list)):
+                        setattr(record, key, _redact_value(value, self._sensitive_keys))
+        except Exception:  # nosec B110 — filter must never raise
+            pass
         return True

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -278,6 +278,67 @@ class TestSamplingFilterNameScoping:
         assert flt.filter(record) is False  # second is rate-limited
 
 
+class TestRedactionFilterHardening:
+    """Tests for cycle guard, depth limit, and catch-all exception handling."""
+
+    def test_cyclic_dict_does_not_raise(self) -> None:
+        flt = RedactionFilter()
+        record = logging.LogRecord(
+            name="test", level=logging.INFO, pathname="", lineno=0,
+            msg="msg", args=(), exc_info=None,
+        )
+        cyclic: dict[str, object] = {"a": 1}
+        cyclic["self"] = cyclic  # self-reference
+        record.__dict__["payload"] = cyclic
+        # Must not raise, must return True
+        assert flt.filter(record) is True
+
+    def test_deeply_nested_dict_is_handled_gracefully(self) -> None:
+        from azure_functions_logging._filters import _REDACT_MAX_DEPTH
+
+        flt = RedactionFilter()
+        record = logging.LogRecord(
+            name="test", level=logging.INFO, pathname="", lineno=0,
+            msg="msg", args=(), exc_info=None,
+        )
+        # Build a dict nested deeper than the limit
+        deep: dict[str, object] = {}
+        node = deep
+        for _ in range(_REDACT_MAX_DEPTH + 5):
+            child: dict[str, object] = {}
+            node["next"] = child
+            node = child
+        record.__dict__["deep"] = deep
+        assert flt.filter(record) is True  # must not raise
+
+    def test_cyclic_list_does_not_raise(self) -> None:
+        flt = RedactionFilter()
+        record = logging.LogRecord(
+            name="test", level=logging.INFO, pathname="", lineno=0,
+            msg="msg", args=(), exc_info=None,
+        )
+        cyclic_list: list[object] = [1, 2]
+        cyclic_list.append(cyclic_list)  # self-reference
+        record.__dict__["items"] = cyclic_list
+        assert flt.filter(record) is True
+
+    def test_malformed_payload_does_not_crash_filter(self) -> None:
+        """A __iter__ that raises must not crash the filter."""
+
+        class ExplodingDict(dict[str, object]):
+            def items(self) -> object:  # type: ignore[override]
+                msg = "boom"
+                raise RuntimeError(msg)
+
+        flt = RedactionFilter()
+        record = logging.LogRecord(
+            name="test", level=logging.INFO, pathname="", lineno=0,
+            msg="msg", args=(), exc_info=None,
+        )
+        record.__dict__["broken"] = ExplodingDict({"password": "secret"})
+        assert flt.filter(record) is True  # catch-all must swallow the error
+
+
 class TestRedactionFilterNameScoping:
     """Tests for name-based filter scoping in RedactionFilter."""
 


### PR DESCRIPTION
## Summary

- `_redact_value()` now carries an `id()`-based seen set to detect cyclic dict/list references — returns the mask string instead of infinite recursion
- Recursion is capped at `_REDACT_MAX_DEPTH = 10` (configurable constant); values beyond the limit are returned unmodified
- Both `_redact_value()` and `RedactionFilter.filter()` are now wrapped in broad `except Exception` so no exception ever escapes from logging infrastructure
- 4 new hardening tests: cyclic dict, cyclic list, deeply nested dict, and a dict whose `.items()` raises

Closes #135