### PR TITLE
fix(host_config): narrow host.json conflict warnings to user-relevant categories

### DIFF
--- a/src/azure_functions_logging/_host_config.py
+++ b/src/azure_functions_logging/_host_config.py
@@ -55,27 +55,38 @@ def discover_host_json(start: Path | None = None) -> Path | None:
     return None
 
 
+# Categories that directly affect user application logs.
+# Warnings are limited to these prefixes by default.
+# Host-internal categories (Host.Results, Host.Aggregator, etc.) are
+# excluded because they do not suppress user Python log output.
+_USER_RELEVANT_PREFIXES: tuple[str, ...] = ("default", "Function")
+
+
+def _is_user_relevant_category(category: str) -> bool:
+    """Return True for categories that can suppress user application logs."""
+    return category == "default" or category.startswith("Function")
+
+
 def warn_host_json_level_conflict(
     configured_level: int,
     *,
     host_json_path: Path | str | None = None,
+    strict: bool = False,
 ) -> None:
-    """Warn when any ``host.json`` ``logLevel`` entry suppresses logs below ``configured_level``.
+    """Warn when a ``host.json`` ``logLevel`` entry suppresses logs below ``configured_level``.
 
-    Azure Functions honors category-specific keys under ``logging.logLevel``
-    (e.g. ``Function``, ``Function.<name>``, ``Host.Results``,
-    ``Host.Aggregator``) in addition to ``default``. Inspecting only ``default``
-    misses the common case where ``default = Information`` while a specific
-    function category is set to ``Warning`` or ``None`` and silently drops the
-    user's logs.
-
-    This helper iterates every category and warns once per offending entry.
+    By default only user-relevant categories are checked (``default`` and anything
+    starting with ``Function``). Host-internal categories (``Host.Results``,
+    ``Host.Aggregator``, etc.) are skipped because they cannot suppress user Python
+    log output and generate false-positive warning fatigue.
 
     Args:
         configured_level: The numeric logging level configured by the app.
         host_json_path: Optional explicit path to a ``host.json`` file. When
             provided, auto-discovery is bypassed entirely. When ``None``,
             :func:`discover_host_json` is used.
+        strict: When ``True``, all categories are inspected (including
+            host-internal ones). Default: ``False``.
     """
     if host_json_path is not None:
         host_path = Path(host_json_path)
@@ -107,6 +118,8 @@ def warn_host_json_level_conflict(
 
     for category, raw_level in log_levels.items():
         if not isinstance(category, str):
+            continue
+        if not strict and not _is_user_relevant_category(category):
             continue
         resolved_level = _resolve_host_level(raw_level)
         if resolved_level is None:

--- a/tests/test_host_config.py
+++ b/tests/test_host_config.py
@@ -169,7 +169,8 @@ def test_warns_per_category_when_specific_category_is_more_restrictive(
 
     messages = [str(w.message) for w in warning_list]
     assert any("Function.MyFunction" in m and "'Warning'" in m for m in messages)
-    assert any("Host.Results" in m and "'Error'" in m for m in messages)
+    # Host.Results is a host-internal category and should NOT warn by default
+    assert not any("Host.Results" in m for m in messages)
     assert not any("default" in m for m in messages)
 
 
@@ -313,6 +314,48 @@ def test_warn_walks_parents_to_find_host_json(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Auto-discovery must reach host.json even when cwd is a subdirectory."""
+    nested = tmp_path / "src" / "functions"
+    nested.mkdir(parents=True)
+    _write_host_json(
+        tmp_path / "host.json",
+        {"logging": {"logLevel": {"default": "Warning"}}},
+    )
+    monkeypatch.chdir(nested)
+    with pytest.warns(UserWarning, match="more restrictive"):
+        warn_host_json_level_conflict(logging.INFO)
+
+
+def test_host_internal_category_not_warned_by_default(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Host-internal categories (Host.*) must not warn in default mode."""
+    _write_host_json(
+        tmp_path / "host.json",
+        {"logging": {"logLevel": {"Host.Results": "Error", "Host.Aggregator": "Error"}}},
+    )
+    monkeypatch.chdir(tmp_path)
+    with warnings.catch_warnings(record=True) as warning_list:
+        warnings.simplefilter("always")
+        warn_host_json_level_conflict(logging.INFO)
+    assert warning_list == [], "Expected no warnings for host-internal categories"
+
+
+def test_host_internal_category_warned_in_strict_mode(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """strict=True must include host-internal categories."""
+    _write_host_json(
+        tmp_path / "host.json",
+        {"logging": {"logLevel": {"Host.Results": "Error"}}},
+    )
+    monkeypatch.chdir(tmp_path)
+    with warnings.catch_warnings(record=True) as warning_list:
+        warnings.simplefilter("always")
+        warn_host_json_level_conflict(logging.INFO, strict=True)
+    messages = [str(w.message) for w in warning_list]
+    assert any("Host.Results" in m for m in messages)
     nested = tmp_path / "src" / "functions"
     nested.mkdir(parents=True)
     _write_host_json(


### PR DESCRIPTION
## Summary

- `warn_host_json_level_conflict()` now skips host-internal categories (`Host.Results`, `Host.Aggregator`, etc.) by default — they cannot suppress user Python logs and generated false-positive warnings
- Only `default` and categories starting with `Function` are checked by default
- New `strict: bool = False` parameter restores the previous all-categories behavior for users who opt in
- Updates existing test to reflect narrowed default, adds two new tests: one asserting no warning for host-internal categories in default mode, one asserting warning in `strict=True` mode

Closes #134