### PR TITLE
fix: post-v0.7.5 Oracle review — factory isolation, azure_state key, handler WeakSet, redaction fail-closed

### DIFF
--- a/src/azure_functions_logging/_filters.py
+++ b/src/azure_functions_logging/_filters.py
@@ -45,12 +45,14 @@ def _redact_value(
 
     Guarded against:
     - Cyclic references (via id-based seen set)
-    - Pathologically deep structures (via _depth / _REDACT_MAX_DEPTH)
+    - Pathologically deep structures (via _depth / _REDACT_MAX_DEPTH);
+      over-limit values are masked (fail-closed) to prevent leaking sensitive
+      data buried in unexpectedly deep payloads
     - All exceptions (returns value unmodified on any error)
     """
     try:
         if _depth >= _REDACT_MAX_DEPTH:
-            return value
+            return mask  # treat over-deep structures as potentially sensitive
         if isinstance(value, dict):
             seen = _seen if _seen is not None else set()
             obj_id = id(value)
@@ -181,14 +183,17 @@ class RedactionFilter(logging.Filter):
 
         try:
             for key in list(record.__dict__.keys()):
-                if key in _RESERVED_LOG_RECORD_KEYS:
-                    continue
-                if key.lower() in self._sensitive_keys:
-                    setattr(record, key, _MASK)
-                else:
-                    value = record.__dict__[key]
-                    if isinstance(value, (dict, list)):
-                        setattr(record, key, _redact_value(value, self._sensitive_keys))
+                try:
+                    if key in _RESERVED_LOG_RECORD_KEYS:
+                        continue
+                    if key.lower() in self._sensitive_keys:
+                        setattr(record, key, _MASK)
+                    else:
+                        value = record.__dict__[key]
+                        if isinstance(value, (dict, list)):
+                            setattr(record, key, _redact_value(value, self._sensitive_keys))
+                except Exception:  # nosec B110 — one broken field must not stop others
+                    pass
         except Exception:  # nosec B110 — filter must never raise
             pass
         return True

--- a/src/azure_functions_logging/_logger.py
+++ b/src/azure_functions_logging/_logger.py
@@ -17,10 +17,12 @@ _LIBRARY_RESERVED_KEYS: frozenset[str] = frozenset(
     }
 )
 
-# Derive the stdlib LogRecord attribute set at import time from a fresh record.
-# This keeps the contract aligned with whatever Python version is running
-# (e.g. CPython added `taskName` in 3.12). `message` and `asctime` are computed
-# lazily by `LogRecord.getMessage()` / formatters and so are not present in
+# Derive the stdlib LogRecord attribute set at import time from a pristine record
+# created directly via the base class, bypassing the global LogRecordFactory.
+# Using logging.makeLogRecord({}) would pick up any custom factory already
+# installed by third-party libraries, misclassifying their injected fields as
+# reserved stdlib attributes and breaking extra-key sanitization and redaction.
+# `message` and `asctime` are computed lazily by formatters and absent from
 # `__dict__`; we add them explicitly to preserve the original guarantee.
 #
 # `taskName` is also kept in the explicit forward-compat set so that user code
@@ -30,7 +32,7 @@ _FORWARD_COMPAT_RECORD_KEYS: frozenset[str] = frozenset({"message", "asctime", "
 # stdlib LogRecord fields only (no library context keys).
 # Use this in formatters that need to distinguish stdlib from application-added fields.
 _STDLIB_RECORD_KEYS: frozenset[str] = (
-    frozenset(logging.makeLogRecord({}).__dict__) | _FORWARD_COMPAT_RECORD_KEYS
+    frozenset(logging.LogRecord("", 0, "", 0, "", (), None).__dict__) | _FORWARD_COMPAT_RECORD_KEYS
 )
 
 _RESERVED_LOG_RECORD_KEYS: frozenset[str] = _STDLIB_RECORD_KEYS | _LIBRARY_RESERVED_KEYS

--- a/src/azure_functions_logging/_setup.py
+++ b/src/azure_functions_logging/_setup.py
@@ -7,6 +7,7 @@ import os
 from pathlib import Path
 import threading
 import warnings
+import weakref
 
 from ._context import ContextFilter, install_context_factory
 from ._formatter import ColorFormatter
@@ -17,12 +18,15 @@ from ._json_formatter import JsonFormatter
 _configured_loggers: set[str | None] = set()
 _configured_lock = threading.Lock()
 
-# Azure mode: track which handler ids have been configured and whether the
-# root-level ContextFilter has been installed for a given call signature.
-# Maps logger_name -> (ContextFilter | None, set[handler_id])
-# The ContextFilter is reused across calls to preserve identity and avoid
-# adding duplicate filter objects to root.filters.
-_azure_state: dict[str | None, tuple[ContextFilter | None, set[int]]] = {}
+# Azure mode: track which handlers have been configured for a given call
+# signature. Keyed by (logger_name, use_record_factory) so that a later call
+# with different factory semantics gets its own ContextFilter instance.
+# WeakSet is used for handlers so stale references are cleaned up automatically
+# when the host replaces a handler — preventing both false 'already configured'
+# hits from id reuse and unbounded set growth in long-lived workers.
+_AzureStateKey = tuple[str | None, bool]
+_AzureStateValue = tuple[ContextFilter | None, "weakref.WeakSet[logging.Handler]"]
+_azure_state: dict[_AzureStateKey, _AzureStateValue] = {}
 
 def _is_functions_environment() -> bool:
     """Check if running inside Azure Functions (hosted or Core Tools)."""
@@ -120,24 +124,22 @@ def setup_logging(
                 )
 
             # Retrieve or create the per-call-signature state.
-            if logger_name not in _azure_state:
+            _state_key: _AzureStateKey = (logger_name, use_record_factory)
+            if _state_key not in _azure_state:
                 ctx_filter: ContextFilter | None = (
                     None if use_record_factory else ContextFilter()
                 )
-                _azure_state[logger_name] = (ctx_filter, set())
-            context_filter, configured_handler_ids = _azure_state[logger_name]
-
+                _azure_state[_state_key] = (ctx_filter, weakref.WeakSet())
+            context_filter, configured_handlers = _azure_state[_state_key]
             root = logging.getLogger()
             for handler in root.handlers:
-                h_id = id(handler)
-                if h_id in configured_handler_ids:
+                if handler in configured_handlers:
                     continue  # already configured — skip to avoid duplicates
                 if functions_formatter is not None:
                     handler.setFormatter(functions_formatter)
                 if context_filter is not None:
                     handler.addFilter(context_filter)
-                configured_handler_ids.add(h_id)
-
+                configured_handlers.add(handler)
             # Install filter on root logger itself so handlers attached later
             # (before the next setup_logging() call) also inherit it.
             if context_filter is not None and context_filter not in root.filters:

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -373,3 +373,50 @@ class TestRedactionFilterNameScoping:
         setattr(record, "password", "secret123")
         assert flt.filter(record) is True
         assert getattr(record, "password") == "***"
+
+
+def test_redact_value_at_depth_limit_is_masked_not_returned() -> None:
+    """At _REDACT_MAX_DEPTH the function must return the mask string (fail-closed)
+    rather than the original value, so sensitive data buried below the depth
+    limit cannot leak through unredacted."""
+    from azure_functions_logging._filters import _REDACT_MAX_DEPTH, _redact_value
+
+    sensitive: frozenset[str] = frozenset({"password"})
+    payload = {"safe_key": "safe_value"}  # non-sensitive; would pass through without limit
+    result = _redact_value(payload, sensitive, _depth=_REDACT_MAX_DEPTH)
+    assert result == "***", f"Expected mask at depth limit but got: {result!r}"
+
+
+def test_redaction_filter_field_setattr_error_does_not_stop_subsequent_field_redaction() -> None:
+    """If setattr() raises for one field (e.g. a read-only class descriptor), the
+    per-field try/except must catch the error so subsequent sensitive fields are still
+    redacted on the same record."""
+
+    class _RecordWithReadOnlyToken(logging.LogRecord):
+        """LogRecord subclass where setting 'token' raises AttributeError."""
+
+    class _ReadOnlyDescriptor:
+        def __get__(self, obj: object, objtype: object = None) -> str:
+            return "secret_token_value"
+
+        def __set__(self, obj: object, value: object) -> None:
+            msg = "token is read-only on this record subclass"
+            raise AttributeError(msg)
+
+    _RecordWithReadOnlyToken.token = _ReadOnlyDescriptor()  # type: ignore[attr-defined]
+
+    flt = RedactionFilter()
+    record = _RecordWithReadOnlyToken(
+        name="test", level=logging.INFO, pathname="", lineno=0,
+        msg="msg", args=(), exc_info=None,
+    )
+    # Bypass the descriptor to seed 'token' into __dict__ so the filter iterates it
+    record.__dict__["token"] = "secret_token_value"
+    # Place 'password' AFTER 'token' so it only gets redacted if the loop continues
+    record.__dict__["password"] = "should_be_redacted"
+
+    assert flt.filter(record) is True
+    assert record.__dict__.get("password") == "***", (
+        f"Expected password to be redacted after broken token field; "
+        f"got: {record.__dict__.get('password')!r}"
+    )

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -358,3 +358,37 @@ def test_has_handlers_false() -> None:
     underlying.hasHandlers.return_value = False
     logger = FunctionLogger(underlying)
     assert logger.hasHandlers() is False
+
+
+def test_stdlib_record_keys_are_immune_to_custom_logrecord_factory() -> None:
+    """_STDLIB_RECORD_KEYS must equal the base LogRecord fields regardless of any
+    LogRecordFactory currently installed.  It is derived from logging.LogRecord(...)
+    directly, not from logging.makeLogRecord({}) which respects the ambient factory.
+    A third-party factory installed before our module loads must not cause its
+    injected fields to be misclassified as reserved stdlib attributes."""
+    from azure_functions_logging._logger import _FORWARD_COMPAT_RECORD_KEYS, _STDLIB_RECORD_KEYS
+
+    original_factory = logging.getLogRecordFactory()
+
+    def polluting_factory(*args: object, **kwargs: object) -> logging.LogRecord:
+        record = original_factory(*args, **kwargs)
+        record._third_party_injected_field = "injected"
+        return record
+
+    logging.setLogRecordFactory(polluting_factory)
+    try:
+        # Confirm the factory is polluting makeLogRecord
+        factory_fields = set(logging.makeLogRecord({}).__dict__)
+        assert "_third_party_injected_field" in factory_fields, \
+            "Precondition failed: factory should inject field into makeLogRecord output"
+
+        # _STDLIB_RECORD_KEYS must match what the base class produces, not the factory
+        expected = (
+            frozenset(logging.LogRecord("", 0, "", 0, "", (), None).__dict__)
+            | _FORWARD_COMPAT_RECORD_KEYS
+        )
+        assert _STDLIB_RECORD_KEYS == expected
+        assert "_third_party_injected_field" not in _STDLIB_RECORD_KEYS, \
+            "Factory-injected fields must not appear in _STDLIB_RECORD_KEYS"
+    finally:
+        logging.setLogRecordFactory(original_factory)

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -403,3 +403,43 @@ def test_azure_setup_does_not_duplicate_filter_on_repeated_calls() -> None:
     finally:
         root.handlers[:] = original_handlers
         root.filters[:] = original_filters
+
+
+def test_azure_setup_different_use_record_factory_flags_have_isolated_filter_state() -> None:
+    """setup_logging(use_record_factory=True) must use separate state from
+    setup_logging(use_record_factory=False) so the factory-snapshot guarantee
+    is not undermined by reusing a ContextFilter created for a different mode."""
+    root = logging.getLogger()
+    original_handlers = root.handlers[:]
+    original_filters = root.filters[:]
+
+    try:
+        handler_no_factory = logging.StreamHandler()
+        handler_with_factory = logging.StreamHandler()
+
+        env = {"FUNCTIONS_WORKER_RUNTIME": "python"}
+        with patch.dict(os.environ, env, clear=True):
+            # Call with use_record_factory=False — should install ContextFilter
+            root.handlers[:] = [handler_no_factory]
+            setup_logging(use_record_factory=False)
+
+            # Call with use_record_factory=True — must NOT install ContextFilter
+            root.handlers[:] = [handler_with_factory]
+            setup_logging(use_record_factory=True)
+
+        filter_no_factory = next(
+            (f for f in handler_no_factory.filters if type(f).__name__ == "ContextFilter"), None
+        )
+        filter_with_factory = next(
+            (f for f in handler_with_factory.filters if type(f).__name__ == "ContextFilter"), None
+        )
+
+        assert filter_no_factory is not None, \
+            "use_record_factory=False should install a ContextFilter on the handler"
+        assert filter_with_factory is None, \
+            "use_record_factory=True must not install a ContextFilter (factory provides context)"
+        # The filter installed by the first call must not bleed onto the second handler
+        assert filter_no_factory not in handler_with_factory.filters
+    finally:
+        root.handlers[:] = original_handlers
+        root.filters[:] = original_filters


### PR DESCRIPTION
## Summary

Post-release Oracle review of v0.7.5 identified two critical bugs and two significant safety concerns. This PR addresses all four.

### Critical bugs fixed

- **`_logger.py`**: `_STDLIB_RECORD_KEYS` was derived from `logging.makeLogRecord({})` which respects the ambient `LogRecordFactory`. A third-party factory installed before this library is imported could inject extra fields into that set, causing those fields to be silently skipped during redaction and sanitization. Fixed by using `logging.LogRecord(...)` directly to bypass the factory.

- **`_setup.py`**: `_azure_state` was keyed only by `logger_name`, not by `use_record_factory`. Calling `setup_logging(use_record_factory=False)` followed by `setup_logging(use_record_factory=True)` reused the old `ContextFilter`, breaking the factory-snapshot guarantee. Fixed by keying on `(logger_name, use_record_factory)`.

### Significant concerns addressed

- **`_setup.py`**: Handler id set (`set[int]`) replaced with `weakref.WeakSet[logging.Handler]` to prevent stale id reuse (after GC) and unbounded growth in long-lived workers.

- **`_filters.py`**: `_redact_value` now returns `mask` at `_REDACT_MAX_DEPTH` (fail-closed) instead of the original value (fail-open), preventing sensitive data buried below the depth limit from leaking. `RedactionFilter.filter()` now wraps each field individually in `try/except` so one broken field cannot silently stop redaction of subsequent sensitive fields.

## Tests added

- `test_stdlib_record_keys_are_immune_to_custom_logrecord_factory` — verifies factory fields never appear in `_STDLIB_RECORD_KEYS`
- `test_azure_setup_different_use_record_factory_flags_have_isolated_filter_state` — verifies separate `ContextFilter` state per mode
- `test_redact_value_at_depth_limit_is_masked_not_returned` — verifies fail-closed behavior at depth limit
- `test_redaction_filter_field_setattr_error_does_not_stop_subsequent_field_redaction` — verifies per-field exception isolation

## Checklist

- [x] All tests pass (`hatch run pytest`)
- [x] Coverage ≥ 95% (95.99%)
- [x] Lint clean (`make lint`)
- [x] Typecheck clean (`make typecheck`)

Closes #155