### PR TITLE
fix(setup): remove ContextFilter when enabling record factory

### DIFF
--- a/src/azure_functions_logging/_setup.py
+++ b/src/azure_functions_logging/_setup.py
@@ -28,6 +28,21 @@ _AzureStateKey = tuple[str | None, bool]
 _AzureStateValue = tuple[ContextFilter | None, "weakref.WeakSet[logging.Handler]"]
 _azure_state: dict[_AzureStateKey, _AzureStateValue] = {}
 
+
+def _remove_context_filters(logger: logging.Logger) -> None:
+    """Remove all package-owned ContextFilter instances from *logger* and its handlers.
+
+    Uses ``type(f) is ContextFilter`` so user subclasses with additional behaviour
+    are preserved.
+    """
+    for f in tuple(logger.filters):
+        if type(f) is ContextFilter:
+            logger.removeFilter(f)
+    for handler in logger.handlers:
+        for f in tuple(handler.filters):
+            if type(f) is ContextFilter:
+                handler.removeFilter(f)
+
 def _is_functions_environment() -> bool:
     """Check if running inside Azure Functions (hosted or Core Tools)."""
     return bool(os.environ.get("FUNCTIONS_WORKER_RUNTIME"))
@@ -104,6 +119,18 @@ def setup_logging(
     # so an invalid call does not leave persistent global side effects.
     if use_record_factory:
         install_context_factory()
+
+    # When switching to record-factory mode, strip any previously-installed
+    # ContextFilter from the target logger and root logger.  This must happen
+    # BEFORE the idempotency guards so even a re-entry (same logger_name called
+    # twice) removes stale filters that would overwrite factory-injected fields
+    # at handler dispatch time.
+    if use_record_factory:
+        target_logger = logging.getLogger(logger_name)
+        root_logger = logging.getLogger()
+        _remove_context_filters(target_logger)
+        if root_logger is not target_logger:
+            _remove_context_filters(root_logger)
 
     with _configured_lock:
         is_functions_env = _is_functions_environment()

--- a/src/azure_functions_logging/_setup.py
+++ b/src/azure_functions_logging/_setup.py
@@ -120,19 +120,19 @@ def setup_logging(
     if use_record_factory:
         install_context_factory()
 
-    # When switching to record-factory mode, strip any previously-installed
-    # ContextFilter from the target logger and root logger.  This must happen
-    # BEFORE the idempotency guards so even a re-entry (same logger_name called
-    # twice) removes stale filters that would overwrite factory-injected fields
-    # at handler dispatch time.
-    if use_record_factory:
-        target_logger = logging.getLogger(logger_name)
-        root_logger = logging.getLogger()
-        _remove_context_filters(target_logger)
-        if root_logger is not target_logger:
-            _remove_context_filters(root_logger)
-
     with _configured_lock:
+        # When switching to record-factory mode, strip any previously-installed
+        # ContextFilter from the target logger and root logger.  Must run BEFORE
+        # the idempotency guards (so re-entry for the same logger_name still
+        # removes stale filters), and UNDER _configured_lock (so concurrent
+        # setup_logging() calls cannot race on the filter lists).
+        if use_record_factory:
+            _target = logging.getLogger(logger_name)
+            _root = logging.getLogger()
+            _remove_context_filters(_target)
+            if _root is not _target:
+                _remove_context_filters(_root)
+
         is_functions_env = _is_functions_environment()
 
         if is_functions_env:

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -443,3 +443,129 @@ def test_azure_setup_different_use_record_factory_flags_have_isolated_filter_sta
     finally:
         root.handlers[:] = original_handlers
         root.filters[:] = original_filters
+
+
+# ---------------------------------------------------------------------------
+# PR 1 regression tests: remove ContextFilter when enabling record factory
+# ---------------------------------------------------------------------------
+
+
+def test_upgrade_to_record_factory_removes_existing_context_filter_local() -> None:
+    """Regression: switching same logger from filter-mode to factory-mode removes stale filter.
+
+    Scenario:
+    1. setup_logging() installs ContextFilter on handler.
+    2. setup_logging(use_record_factory=True) must strip that filter.
+    3. Record created under context A, contextvar reset to B, handler filters run.
+    4. Record must still carry context A (factory snapshot, not overwritten).
+    """
+    from azure_functions_logging._context import invocation_id_var
+
+    logger_name = "afl.test.upgrade.local"
+    logger = logging.getLogger(logger_name)
+    logger.handlers.clear()
+    logger.filters.clear()
+
+    with patch.dict(os.environ, {}, clear=True):
+        # Step 1: install ContextFilter mode
+        setup_logging(logger_name=logger_name)
+        assert any(isinstance(f, ContextFilter) for h in logger.handlers for f in h.filters), \
+            "precondition: ContextFilter should be on handler"
+
+        # Step 2: upgrade to factory mode — must remove the filter
+        setup_mod._configured_loggers.discard(logger_name)  # allow re-entry
+        setup_logging(logger_name=logger_name, use_record_factory=True)
+
+    # Assert filter is gone
+    for handler in logger.handlers:
+        assert not any(isinstance(f, ContextFilter) for f in handler.filters), \
+            "ContextFilter must be removed after switching to use_record_factory=True"
+
+    # Step 3: create record under context A
+    token = invocation_id_var.set("context-A")
+    try:
+        record = logger.makeRecord(logger_name, logging.INFO, "f.py", 1, "msg", (), None)
+    finally:
+        invocation_id_var.reset(token)
+
+    # Step 4: reset contextvar to a different value
+    invocation_id_var.set("context-B")
+
+    # Run handler filters (there should be none — assert snapshot is preserved)
+    for handler in logger.handlers:
+        for f in handler.filters:
+            if hasattr(f, "filter"):
+                f.filter(record)
+
+    # Factory snapshot must survive
+    assert getattr(record, "invocation_id", None) == "context-A", \
+        f"Factory snapshot overwritten — got {getattr(record, 'invocation_id', None)!r}"
+
+    logger.handlers.clear()
+    logger.filters.clear()
+    invocation_id_var.set(None)
+
+
+def test_upgrade_to_record_factory_removes_context_filter_before_idempotency_guard() -> None:
+    """Regression: cleanup must run even when logger_name is already in _configured_loggers.
+
+    The early-return guard must NOT block filter removal.
+    """
+    logger_name = "afl.test.upgrade.idempotency"
+    logger = logging.getLogger(logger_name)
+    logger.handlers.clear()
+    logger.filters.clear()
+
+    handler = logging.StreamHandler()
+    cf = ContextFilter()
+    handler.addFilter(cf)
+    logger.addHandler(handler)
+
+    # Simulate: logger was already configured in filter-mode
+    setup_mod._configured_loggers.add(logger_name)
+
+    with patch.dict(os.environ, {}, clear=True):
+        # Even though logger_name is in _configured_loggers, cleanup must run
+        setup_logging(logger_name=logger_name, use_record_factory=True)
+
+    assert not any(isinstance(f, ContextFilter) for f in handler.filters), \
+        "ContextFilter must be removed even when re-entering via idempotency guard"
+
+    logger.handlers.clear()
+    logger.filters.clear()
+
+
+def test_upgrade_to_record_factory_removes_context_filter_azure_mode() -> None:
+    """Regression: Azure mode — root handlers must have no ContextFilter after factory upgrade.
+
+    When setup_logging(use_record_factory=False) is called first (adds ContextFilter),
+    then setup_logging(use_record_factory=True) is called, the stale filter must be
+    removed from all root handlers and root.filters.
+    """
+    root = logging.getLogger()
+    original_handlers = root.handlers[:]
+    original_filters = root.filters[:]
+
+    try:
+        env = {"FUNCTIONS_WORKER_RUNTIME": "python"}
+        test_handler = logging.StreamHandler()
+        root.handlers[:] = [test_handler]
+        root.filters.clear()
+
+        with patch.dict(os.environ, env, clear=True):
+            # First call — installs ContextFilter
+            setup_logging(use_record_factory=False)
+            assert any(isinstance(f, ContextFilter) for f in test_handler.filters), \
+                "precondition: ContextFilter must be on handler after filter-mode call"
+
+            # Second call — must remove ContextFilter
+            setup_logging(use_record_factory=True)
+
+        # After factory upgrade: no ContextFilter on handler or root logger
+        assert not any(isinstance(f, ContextFilter) for f in test_handler.filters), \
+            "ContextFilter must be removed from root handler after use_record_factory=True"
+        assert not any(isinstance(f, ContextFilter) for f in root.filters), \
+            "ContextFilter must be removed from root.filters after use_record_factory=True"
+    finally:
+        root.handlers[:] = original_handlers
+        root.filters[:] = original_filters


### PR DESCRIPTION
## Summary

- Add `_remove_context_filters(logger)` helper that strips package-owned `ContextFilter` instances from a logger and all attached handler filters, using strict type identity (`type(f) is ContextFilter`) to preserve user subclasses
- Call it **before** `_configured_loggers` / `_azure_state` idempotency guards so even a re-entry for the same `logger_name` removes stale filters that would overwrite factory-injected record fields at handler dispatch time
- Add three targeted regression tests

## Why

When `setup_logging()` is first called without `use_record_factory` (default `False`), a `ContextFilter` is installed on handlers. If a subsequent call enables `use_record_factory=True`, `install_context_factory()` is installed globally but the existing `ContextFilter` is **never removed**. At handler dispatch time, `ContextFilter.filter()` overwrites the context fields on the record with the **current** contextvar values — defeating the factory's record-creation-time snapshot guarantee for delayed/queued/cross-thread dispatch.

Three affected scenarios fixed:
1. **Local mode, same logger**: re-entry via `_configured_loggers` early-returns before cleanup
2. **Local mode, different logger**: stale `ContextFilter` on root handlers cleaned up
3. **Azure mode**: stale `_azure_state[(logger_name, False)]` filter on root handlers removed

## Tests added

| Test | What it proves |
|---|---|
| `test_upgrade_to_record_factory_removes_existing_context_filter_local` | Filter removed; factory snapshot (context A) survives contextvar reset to B |
| `test_upgrade_to_record_factory_removes_context_filter_before_idempotency_guard` | Cleanup runs even when `logger_name in _configured_loggers` |
| `test_upgrade_to_record_factory_removes_context_filter_azure_mode` | Root handlers and `root.filters` cleared after factory upgrade in Azure env |

## Coverage

Total: **96%** (above 95% threshold). `_setup.py` at 98%.

> Note: `test_version_matches_distribution_metadata` fails pre-existing on `main` (installed 0.7.5 vs source 0.7.6) — unrelated to this PR.

Closes #159