### PR TITLE
fix(filters): expand default sensitive key set

### DIFF
--- a/README.md
+++ b/README.md
@@ -448,10 +448,25 @@ setup_logging()
 root = logging.getLogger()
 # Attach the filter to handlers so records from named child loggers are also redacted.
 for handler in root.handlers:
-    handler.addFilter(RedactionFilter(sensitive_keys=["password", "token", "secret"]))
+    handler.addFilter(RedactionFilter())
 ```
 
 Any log record with extra fields whose keys match a sensitive key will have those values replaced with `***`.
+
+**Default sensitive keys** (case-insensitive, applied to nested dicts and lists too):
+
+| Key | Key | Key |
+|-----|-----|-----|
+| `password` | `passwd` | `token` |
+| `access_token` | `refresh_token` | `authorization` |
+| `secret` | `client_secret` | `api_key` |
+| `apikey` | `connection_string` | |
+
+Pass `sensitive_keys=[...]` to override with your own list:
+
+```python
+handler.addFilter(RedactionFilter(sensitive_keys=["account_number", "ssn"]))
+```
 
 ## Local vs Cloud
 

--- a/src/azure_functions_logging/_filters.py
+++ b/src/azure_functions_logging/_filters.py
@@ -156,7 +156,7 @@ class RedactionFilter(logging.Filter):
     ``JsonFormatter`` see redacted values.
 
     Args:
-        sensitive_keys: Iterable of lowercase key names to redact. When None,
+        sensitive_keys: Iterable of key names to redact (case-insensitive). When None,
             uses the built-in default set:
             ``password``, ``passwd``, ``token``, ``access_token``,
             ``refresh_token``, ``authorization``, ``secret``,

--- a/src/azure_functions_logging/_filters.py
+++ b/src/azure_functions_logging/_filters.py
@@ -20,10 +20,14 @@ _DEFAULT_SENSITIVE_KEYS: frozenset[str] = frozenset(
         "password",
         "passwd",
         "token",
+        "access_token",
+        "refresh_token",
         "authorization",
         "secret",
+        "client_secret",
         "api_key",
         "apikey",
+        "connection_string",
     }
 )
 
@@ -153,8 +157,10 @@ class RedactionFilter(logging.Filter):
 
     Args:
         sensitive_keys: Iterable of lowercase key names to redact. When None,
-            uses the built-in default set (password, passwd, token,
-            authorization, secret, api_key, apikey).
+            uses the built-in default set:
+            ``password``, ``passwd``, ``token``, ``access_token``,
+            ``refresh_token``, ``authorization``, ``secret``,
+            ``client_secret``, ``api_key``, ``apikey``, ``connection_string``.
         name: Optional logger-name scope. When set, only matching loggers are
             subject to redaction; non-matching records pass through unchanged.
     Example::

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -423,7 +423,7 @@ def test_redaction_filter_field_setattr_error_does_not_stop_subsequent_field_red
 
 
 # ---------------------------------------------------------------------------
-# PR 2: expanded default sensitive key set
+# RedactionFilter — default sensitive keys: Azure credential fields
 # ---------------------------------------------------------------------------
 
 

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -420,3 +420,89 @@ def test_redaction_filter_field_setattr_error_does_not_stop_subsequent_field_red
         f"Expected password to be redacted after broken token field; "
         f"got: {record.__dict__.get('password')!r}"
     )
+
+
+# ---------------------------------------------------------------------------
+# PR 2: expanded default sensitive key set
+# ---------------------------------------------------------------------------
+
+
+def test_redaction_filter_masks_access_token() -> None:
+    flt = RedactionFilter()
+    record = _make_record()
+    setattr(record, "access_token", "eyJ...")
+    flt.filter(record)
+    assert getattr(record, "access_token") == "***"
+
+
+def test_redaction_filter_masks_refresh_token() -> None:
+    flt = RedactionFilter()
+    record = _make_record()
+    setattr(record, "refresh_token", "rt_abc")
+    flt.filter(record)
+    assert getattr(record, "refresh_token") == "***"
+
+
+def test_redaction_filter_masks_client_secret() -> None:
+    flt = RedactionFilter()
+    record = _make_record()
+    setattr(record, "client_secret", "cs_xyz")
+    flt.filter(record)
+    assert getattr(record, "client_secret") == "***"
+
+
+def test_redaction_filter_masks_connection_string() -> None:
+    flt = RedactionFilter()
+    record = _make_record()
+    setattr(record, "connection_string", "DefaultEndpointsProtocol=https;AccountName=...")
+    flt.filter(record)
+    assert getattr(record, "connection_string") == "***"
+
+
+def test_redaction_filter_masks_new_keys_inside_nested_dict() -> None:
+    """New default keys must be redacted inside nested dicts, not just at top level."""
+    flt = RedactionFilter()
+    record = _make_record()
+    setattr(record, "credentials", {
+        "access_token": "tok-1",
+        "refresh_token": "rt-1",
+        "client_secret": "cs-1",
+        "connection_string": "conn-1",
+        "safe_field": "visible",
+    })
+    flt.filter(record)
+    assert getattr(record, "credentials") == {
+        "access_token": "***",
+        "refresh_token": "***",
+        "client_secret": "***",
+        "connection_string": "***",
+        "safe_field": "visible",
+    }
+
+
+def test_redaction_filter_masks_new_keys_inside_list_of_dicts() -> None:
+    """New default keys must be redacted inside lists of dicts."""
+    flt = RedactionFilter()
+    record = _make_record()
+    setattr(record, "items", [
+        {"access_token": "tok-a", "user": "alice"},
+        {"refresh_token": "rt-b", "client_secret": "cs-b"},
+        {"connection_string": "conn-c", "safe": "ok"},
+    ])
+    flt.filter(record)
+    assert getattr(record, "items") == [
+        {"access_token": "***", "user": "alice"},
+        {"refresh_token": "***", "client_secret": "***"},
+        {"connection_string": "***", "safe": "ok"},
+    ]
+
+
+def test_redaction_filter_new_keys_case_insensitive() -> None:
+    """New default keys must match case-insensitively."""
+    flt = RedactionFilter()
+    record = _make_record()
+    setattr(record, "Access_Token", "tok")
+    setattr(record, "CONNECTION_STRING", "cs")
+    flt.filter(record)
+    assert getattr(record, "Access_Token") == "***"
+    assert getattr(record, "CONNECTION_STRING") == "***"


### PR DESCRIPTION
## Summary

- Add `access_token`, `refresh_token`, `client_secret`, `connection_string` to `_DEFAULT_SENSITIVE_KEYS` (11 keys total, up from 7)
- Update `RedactionFilter` docstring to list all default keys
- Update README PII Redaction section with a full key table and corrected example (showing `RedactionFilter()` with no args to use defaults)
- Add 7 regression tests covering each new key at top-level, inside nested dicts, inside lists-of-dicts, and case-insensitively

## Why

The previous default set did not cover common Azure SDK credential fields. A user calling `RedactionFilter()` with no arguments would not have `access_token`, `refresh_token`, `client_secret`, or `connection_string` masked — all of which appear frequently in Azure SDK responses, service principal configs, and storage connection strings.

## Tests added

| Test | What it proves |
|---|---|
| `test_redaction_filter_masks_access_token` | `access_token` redacted at top level |
| `test_redaction_filter_masks_refresh_token` | `refresh_token` redacted at top level |
| `test_redaction_filter_masks_client_secret` | `client_secret` redacted at top level |
| `test_redaction_filter_masks_connection_string` | `connection_string` redacted at top level |
| `test_redaction_filter_masks_new_keys_inside_nested_dict` | All 4 new keys redacted inside a nested dict |
| `test_redaction_filter_masks_new_keys_inside_list_of_dicts` | All 4 new keys redacted inside list-of-dicts |
| `test_redaction_filter_new_keys_case_insensitive` | `Access_Token`, `CONNECTION_STRING` matched case-insensitively |

## Coverage

Total: **96%** (above 95% threshold).

Closes #161