### PR TITLE
feat(host_config): discover host.json from AzureWebJobsScriptRoot env var

### DIFF
--- a/src/azure_functions_logging/_host_config.py
+++ b/src/azure_functions_logging/_host_config.py
@@ -34,13 +34,14 @@ def discover_host_json(start: Path | None = None) -> Path | None:
 
     Discovery order:
 
-    1. ``start`` (when supplied).
+    1. ``start`` (when supplied). If ``start.resolve()`` fails, returns ``None``
+       immediately; env var and cwd fallback are not attempted.
     2. ``AzureWebJobsScriptRoot`` environment variable (only when ``start`` is
-       ``None``).
+       ``None``). Only the directory itself is probed — no ancestor walk. Relative
+       values are resolved against cwd (Azure always sets an absolute path).
     3. :func:`Path.cwd` and each ancestor up to
        :data:`_HOST_JSON_DISCOVERY_MAX_DEPTH` levels (fallback when neither
        ``start`` nor the env var resolves to a file).
-
     Returns the first existing ``host.json`` path or ``None``. Never raises:
     filesystem errors are swallowed so callers stay silent on broken setups.
     """
@@ -56,7 +57,7 @@ def discover_host_json(start: Path | None = None) -> Path | None:
                 env_candidate = Path(env_root).resolve() / "host.json"
                 if env_candidate.is_file():
                     return env_candidate
-            except OSError:
+            except (OSError, RuntimeError):
                 pass  # invalid path — fall through to cwd walk
         try:
             base = Path.cwd().resolve()

--- a/src/azure_functions_logging/_host_config.py
+++ b/src/azure_functions_logging/_host_config.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 import logging
 from pathlib import Path
 import warnings
@@ -33,16 +34,34 @@ def discover_host_json(start: Path | None = None) -> Path | None:
 
     Discovery order:
 
-    1. ``start`` (defaults to :func:`Path.cwd`).
-    2. Each ancestor up to :data:`_HOST_JSON_DISCOVERY_MAX_DEPTH` levels.
+    1. ``start`` (when supplied).
+    2. ``AzureWebJobsScriptRoot`` environment variable (only when ``start`` is
+       ``None``).
+    3. :func:`Path.cwd` and each ancestor up to
+       :data:`_HOST_JSON_DISCOVERY_MAX_DEPTH` levels (fallback when neither
+       ``start`` nor the env var resolves to a file).
 
     Returns the first existing ``host.json`` path or ``None``. Never raises:
     filesystem errors are swallowed so callers stay silent on broken setups.
     """
     try:
-        base = (start or Path.cwd()).resolve()
+        base = start.resolve() if start is not None else None
     except Exception:
         return None
+
+    if base is None:
+        env_root = os.environ.get("AzureWebJobsScriptRoot")
+        if env_root:
+            try:
+                env_candidate = Path(env_root).resolve() / "host.json"
+                if env_candidate.is_file():
+                    return env_candidate
+            except OSError:
+                pass  # invalid path — fall through to cwd walk
+        try:
+            base = Path.cwd().resolve()
+        except Exception:
+            return None
 
     candidates = [base, *list(base.parents)[:_HOST_JSON_DISCOVERY_MAX_DEPTH]]
     for directory in candidates:

--- a/src/azure_functions_logging/_host_config.py
+++ b/src/azure_functions_logging/_host_config.py
@@ -3,8 +3,8 @@
 from __future__ import annotations
 
 import json
-import os
 import logging
+import os
 from pathlib import Path
 import warnings
 

--- a/tests/test_host_config.py
+++ b/tests/test_host_config.py
@@ -365,3 +365,78 @@ def test_host_internal_category_warned_in_strict_mode(
     monkeypatch.chdir(nested)
     with pytest.warns(UserWarning, match="more restrictive"):
         warn_host_json_level_conflict(logging.INFO)
+
+
+# ---------------------------------------------------------------------------
+# discover_host_json — AzureWebJobsScriptRoot env var (issue #163)
+# ---------------------------------------------------------------------------
+
+
+def test_discover_uses_azurewebjobsscriptroot_when_set(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When AzureWebJobsScriptRoot is set, discover_host_json prefers that directory."""
+    _write_host_json(tmp_path / "host.json", {"version": "2.0"})
+    monkeypatch.setenv("AzureWebJobsScriptRoot", str(tmp_path))
+    # cwd is a different dir that has no host.json
+    other = tmp_path / "other"
+    other.mkdir()
+    monkeypatch.chdir(other)
+
+    found = discover_host_json()
+    assert found == (tmp_path / "host.json").resolve()
+
+
+def test_discover_falls_through_when_azurewebjobsscriptroot_has_no_host_json(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Env var set but no host.json inside — falls back to cwd walk."""
+    env_dir = tmp_path / "func_root"
+    env_dir.mkdir()
+    # no host.json in env_dir
+    monkeypatch.setenv("AzureWebJobsScriptRoot", str(env_dir))
+
+    # cwd has host.json via parent walk
+    cwd = tmp_path / "cwd"
+    cwd.mkdir()
+    _write_host_json(tmp_path / "host.json", {"version": "2.0"})
+    monkeypatch.chdir(cwd)
+
+    found = discover_host_json()
+    assert found == (tmp_path / "host.json").resolve()
+
+
+def test_discover_falls_through_when_azurewebjobsscriptroot_path_does_not_exist(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Env var set to a non-existent directory — falls back to cwd walk."""
+    monkeypatch.setenv("AzureWebJobsScriptRoot", "/nonexistent/path/that/does/not/exist")
+
+    _write_host_json(tmp_path / "host.json", {"version": "2.0"})
+    monkeypatch.chdir(tmp_path)
+
+    found = discover_host_json()
+    assert found == (tmp_path / "host.json").resolve()
+
+
+def test_discover_explicit_start_ignores_azurewebjobsscriptroot(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Explicit start param takes priority over AzureWebJobsScriptRoot env var."""
+    env_dir = tmp_path / "env_root"
+    env_dir.mkdir()
+    _write_host_json(env_dir / "host.json", {"version": "env"})
+    monkeypatch.setenv("AzureWebJobsScriptRoot", str(env_dir))
+
+    explicit_dir = tmp_path / "explicit"
+    explicit_dir.mkdir()
+    _write_host_json(explicit_dir / "host.json", {"version": "explicit"})
+
+    found = discover_host_json(start=explicit_dir)
+    assert found == (explicit_dir / "host.json").resolve()
+    # confirm the env dir's host.json was NOT returned
+    assert found != (env_dir / "host.json").resolve()

--- a/tests/test_host_config.py
+++ b/tests/test_host_config.py
@@ -440,3 +440,26 @@ def test_discover_explicit_start_ignores_azurewebjobsscriptroot(
     assert found == (explicit_dir / "host.json").resolve()
     # confirm the env dir's host.json was NOT returned
     assert found != (env_dir / "host.json").resolve()
+
+
+def test_discover_falls_through_when_env_root_resolve_raises_runtime_error(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """RuntimeError (e.g. symlink loop) from Path.resolve() is swallowed; cwd walk used."""
+    monkeypatch.setenv("AzureWebJobsScriptRoot", "/some/path")
+    _write_host_json(tmp_path / "host.json", {"version": "2.0"})
+    monkeypatch.chdir(tmp_path)
+
+    original_resolve = Path.resolve
+
+    def _raise_on_some_path(self: Path, **kwargs: object) -> Path:
+        if str(self) == "/some/path":
+            raise RuntimeError("Too many levels of symbolic links")
+        return original_resolve(self, **kwargs)
+
+    monkeypatch.setattr(Path, "resolve", _raise_on_some_path)
+
+    # Must not raise; must fall back to cwd walk and find tmp_path/host.json
+    found = discover_host_json()
+    assert found == (tmp_path / "host.json").resolve()

--- a/tests/test_host_config.py
+++ b/tests/test_host_config.py
@@ -453,10 +453,10 @@ def test_discover_falls_through_when_env_root_resolve_raises_runtime_error(
 
     original_resolve = Path.resolve
 
-    def _raise_on_some_path(self: Path, **kwargs: object) -> Path:
+    def _raise_on_some_path(self: Path, *, strict: bool = False) -> Path:
         if str(self) == "/some/path":
             raise RuntimeError("Too many levels of symbolic links")
-        return original_resolve(self, **kwargs)
+        return original_resolve(self, strict=strict)
 
     monkeypatch.setattr(Path, "resolve", _raise_on_some_path)
 


### PR DESCRIPTION
## Summary

- Adds `AzureWebJobsScriptRoot` env-var lookup as step 2 in `discover_host_json()` discovery, between explicit `start` and the existing cwd walk.
- Fixes silent host.json miss in deployed Azure Functions where cwd is a system/temp path, not the function app root.
- Falls through silently (to cwd walk) when the env var points to a non-existent or unreadable path.

## Discovery priority (unchanged contract for callers)

| Priority | Source |
|----------|--------|
| 1 | Explicit `start` parameter |
| 2 | `AzureWebJobsScriptRoot` env var (**new**) |
| 3 | `Path.cwd()` walk (existing fallback) |

## Tests added

- Env var set → env dir's `host.json` is returned (cwd is a different dir)
- Env dir exists but contains no `host.json` → falls back to cwd walk
- Env var points to non-existent path → falls back to cwd walk
- Explicit `start` arg → env var is ignored

## Coverage

Total: 95.62% (≥ 95% threshold) · 25 host_config tests all pass

Closes #163