### PR TITLE
docs: sync README and llms.txt with v0.7.x operational behavior

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -306,8 +306,9 @@ setup_logging()
 
 有効化されると、`invocation_id`, `function_name`, `trace_id`, `cold_start` は予約された `LogRecord` 属性となります。stdlib `extra=` 経由で渡すと `KeyError` が発生します。キーを自動的にサニタイズする `FunctionLogger` を使用するか、別のキー名を選択してください。
 
-> **`setup_logging()` との関係:** `setup_logging()` は引き続きデフォルトでハンドラに `ContextFilter` をインストールします。両方を呼び出しても問題ありません — 同じ値を設定するため衝突しません。`install_context_factory()` は、後で追加されたハンドラやフィルタチェーンをバイパスするロガーでもカバレッジを保証します。
-
+> **`setup_logging()` との関係:** `use_record_factory=False` (デフォルト) の場合、`setup_logging()` はハンドラに `ContextFilter` をインストールします。両方を呼び出しても問題ありません — 同じ値を設定するため衝突しません。`install_context_factory()` は後で追加されたハンドラやフィルタチェーンをバイパスするロガーでもカバレッジを保証します。
+>
+> `use_record_factory=True` の場合、`setup_logging()` はファクトリモードに切り替えます: 既存のルートハンドラから `ContextFilter` インスタンスを削除してから `LogRecordFactory` を登録します。これにより二重注入を防ぎながら、すべてのレコードにコンテキストが付与されることを保証します。
 ## 構造化 JSON 出力 (本番)
 
 ログが Application Insights や任意の集約システムに流れる場合は JSON フォーマットを使用してください:
@@ -339,7 +340,29 @@ setup_logging(functions_formatter=JsonFormatter())
  "extra": {"order_id": "o-999"}}
 ```
 
-追加フィールドは出力される JSON の `extra` に含まれます。Application Insights で直接インデックス可能かどうかは ingestion パイプラインに依存します: JSON が `customDimensions` にパースされる場合は直接クエリ可能ですが、JSON が `message` カラムに残る場合はまず `parse_json(message)` を通す必要があります。
+追加フィールドは出力される JSON の `extra` に含まれます。Application Insights で直接インデックス可能かどうかは ingestion パイプラインに依存します: JSON が `customDimensions` にパースされる場合は直接クエリ可能ですが、JSON が `message` カラムに残る場合はまず `parse_json(message)` を通す必要があります.
+
+```python
+logger.info("order accepted", order_id="o-999", tenant_id="t-1")
+```
+
+### 長い文字列値の切り詰め (オプトイン)
+
+デフォルトでは `JsonFormatter` は `extra` の文字列値を全長で保持します。
+`truncate_native_strings=True` を渡すと `max_string_length` 文字 (デフォルト 2048) でクリップします。
+切り詰められた文字列には `…` サフィックスが付加され、切り詰めを検出できます:
+
+```python
+from azure_functions_logging import JsonFormatter, setup_logging
+
+setup_logging(functions_formatter=JsonFormatter(
+    truncate_native_strings=True,
+    max_string_length=512,
+))
+```
+
+> **スコープ:** `extra` の文字列値のみが切り詰められます (dict と list を再帰的に探索)。
+> `message` フィールド、整数、浮動小数点数、ブール値は影響を受けません。
 
 ```python
 logger.info("order accepted", order_id="o-999", tenant_id="t-1")
@@ -369,10 +392,15 @@ host.json logLevel for default is set to 'Warning' which is more restrictive tha
 
 ### 探索順序
 
-`host.json` は現在の作業ディレクトリから上に向かって探索されます:
+`host.json` は現在の作業ディレクトリ (または `AzureWebJobsScriptRoot` 環境変数が設定されている場合はそのディレクトリ) から上に向かって探索されます:
 
-1. `cwd/host.json`
-2. 各親ディレクトリ、最大 5 階層まで。
+| 優先度 | ソース |
+|--------|--------|
+| 1 | `setup_logging()` に渡した明示的な `host_json_path` パラメータ |
+| 2 | `AzureWebJobsScriptRoot` 環境変数 |
+| 3 | `cwd/host.json` および各親ディレクトリ、最大 5 階層 |
+
+最初に存在する `host.json` が採用されます。`AzureWebJobsScriptRoot` はAzure Functions ホストが設定する公式の環境変数で、ディレクトリ自体のみを探索します (祖先ウォークなし)。
 
 最初に存在するファイルが採用されます。自動探索をバイパスするには (テストや非標準レイアウトなど)、明示的なパスを渡してください:
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -306,8 +306,9 @@ setup_logging()
 
 활성화되면 `invocation_id`, `function_name`, `trace_id`, `cold_start`는 예약된 `LogRecord` 속성이 됩니다. stdlib `extra=`를 통해 이들을 전달하면 `KeyError`가 발생합니다. 키를 자동으로 정제하는 `FunctionLogger`를 사용하거나 다른 키 이름을 선택하세요.
 
-> **`setup_logging()`과의 관계:** `setup_logging()`은 기본적으로 핸들러에 `ContextFilter`를 설치합니다. 둘 다 호출해도 됩니다 — 동일한 값을 설정하므로 충돌이 없습니다. `install_context_factory()`는 나중에 추가되는 핸들러나 필터 체인을 우회하는 로거에서도 적용됨을 보장합니다.
-
+> **`setup_logging()`과의 관계:** `use_record_factory=False` (기본값)일 때 `setup_logging()`은 핸들러에 `ContextFilter`를 설치합니다. 둘 다 호출해도 됩니다 — 동일한 값을 설정하므로 충돌이 없습니다. `install_context_factory()`는 나중에 추가되는 핸들러나 필터 체인을 우회하는 로거에서도 적용됨을 보장합니다.
+>
+> `use_record_factory=True`일 때 `setup_logging()`은 팩토리 모드로 전환합니다: 기존 루트 핸들러에서 `ContextFilter` 인스턴스를 제거한 후 `LogRecordFactory`를 등록합니다. 이중 주입을 방지하면서 모든 레코드에 컨텍스트가 실리도록 보장합니다.
 ## 구조화된 JSON 출력 (프로덕션)
 
 로그가 Application Insights나 어떤 집계 시스템으로 흘러갈 때는 JSON 포맷을 사용하세요:
@@ -345,6 +346,25 @@ setup_logging(functions_formatter=JsonFormatter())
 logger.info("order accepted", order_id="o-999", tenant_id="t-1")
 ```
 
+### 긴 문자열 값 자르기 (opt-in)
+
+기본적으로 `JsonFormatter`는 `extra`의 문자열 값을 전체 길이 그대로 유지합니다.
+`truncate_native_strings=True`를 전달하면 `max_string_length` 문자 (기본값 2048)로 잘립니다.
+잘린 문자열은 `…` 접미사가 붙어 잘림 여부를 감지할 수 있습니다:
+
+```python
+from azure_functions_logging import JsonFormatter, setup_logging
+
+setup_logging(functions_formatter=JsonFormatter(
+    truncate_native_strings=True,
+    max_string_length=512,
+))
+```
+
+> **범위:** `extra`의 문자열 값만 잘립니다 (dict와 list를 재귀적으로 탐색).
+> `message` 필드, 정수, 실수, 불리언은 영향을 받지 않습니다.
+```
+
 ## host.json 충돌 감지
 
 `host.json`이 앱이 발행하는 로그 레벨을 억제하면 시작 시 다음과 같은 경고가 표시됩니다:
@@ -369,10 +389,15 @@ host.json logLevel for default is set to 'Warning' which is more restrictive tha
 
 ### 발견 순서
 
-`host.json`은 현재 작업 디렉토리에서 위로 올라가며 탐색됩니다:
+`host.json`은 현재 작업 디렉토리 (또는 `AzureWebJobsScriptRoot` 환경 변수가 설정된 경우 해당 디렉토리)에서 위로 올라가며 탐색됩니다:
 
-1. `cwd/host.json`
-2. 각 상위 디렉토리, 최대 5단계 깊이까지.
+| 우선순위 | 소스 |
+|----------|------|
+| 1 | `setup_logging()`에 전달된 명시적 `host_json_path` 파라미터 |
+| 2 | `AzureWebJobsScriptRoot` 환경 변수 |
+| 3 | `cwd/host.json` 및 각 상위 디렉토리, 최대 5단계 |
+
+먼저 발견된 `host.json`이 사용됩니다. `AzureWebJobsScriptRoot`는 Azure Functions 호스트가 설정하는 공식 환경 변수이며, 해당 디렉토리 자체만 검사합니다 (상위 디렉토리 탐색 없음).
 
 먼저 발견된 파일이 사용됩니다. 자동 발견을 우회하려면 (예: 테스트 또는 비표준 레이아웃에서) 명시적 경로를 전달하세요:
 

--- a/README.md
+++ b/README.md
@@ -334,11 +334,15 @@ When enabled, `invocation_id`, `function_name`, `trace_id`, and `cold_start` bec
 reserved `LogRecord` attributes. Passing them via stdlib `extra=` will raise `KeyError`.
 Use `FunctionLogger` (which sanitizes keys automatically) or choose different key names.
 
-> **Relationship with `setup_logging()`:** `setup_logging()` still installs `ContextFilter`
-> on handlers by default. You can call both — they set the same values, so there is no
-> conflict. `install_context_factory()` ensures coverage even on handlers added later or
-> loggers that bypass the filter chain.
-
+> **Relationship with `setup_logging()`:** When `use_record_factory=False` (default),
+> `setup_logging()` installs `ContextFilter` on handlers. You can call both — they set the
+> same values, so there is no conflict. `install_context_factory()` ensures coverage even on
+> handlers added later or loggers that bypass the filter chain.
+>
+> When `use_record_factory=True`, `setup_logging()` switches to the factory mode: it actively
+> removes any `ContextFilter` instances from existing root handlers (cleanup), then registers
+> the `LogRecordFactory`. This avoids double-injection while ensuring all records carry context
+> regardless of handler/filter chain configuration.
 ## Structured JSON Output (Production)
 
 Use JSON format when logs feed Application Insights or any aggregation system:
@@ -377,6 +381,25 @@ Extra fields appear under `extra` in the emitted JSON. Whether they are directly
 logger.info("order accepted", order_id="o-999", tenant_id="t-1")
 ```
 
+### Truncating long string values (opt-in)
+
+By default, `JsonFormatter` leaves string values in `extra` at full length.
+Pass `truncate_native_strings=True` to clip them at `max_string_length` characters (default 2048).
+Truncated strings are suffixed with `…` so the cut-off is detectable:
+
+```python
+from azure_functions_logging import JsonFormatter, setup_logging
+
+setup_logging(functions_formatter=JsonFormatter(
+    truncate_native_strings=True,
+    max_string_length=512,  # clip strings longer than 512 chars
+))
+```
+
+> **Scope:** Only string values in `extra` are truncated (recursively through dicts and lists).
+> The `message` field, integers, floats, and booleans are not affected.
+> Unserializable objects fall through to the existing `_json_default` path which truncates
+> their `str()` representation to 2048 characters regardless of this setting.
 ## host.json Conflict Detection
 
 If your `host.json` suppresses log levels that your app emits, you get this warning at startup:
@@ -401,11 +424,17 @@ Recommended `host.json` baseline:
 
 ### Discovery order
 
-`host.json` is located by walking up from the current working directory:
+`host.json` is located by walking up from the current working directory (or from
+`AzureWebJobsScriptRoot` when that environment variable is set):
 
-1. `cwd/host.json`
-2. Each parent directory, up to 5 levels deep.
+| Priority | Source |
+|----------|--------|
+| 1 | Explicit `host_json_path` parameter passed to `setup_logging()` |
+| 2 | `AzureWebJobsScriptRoot` environment variable |
+| 3 | `cwd/host.json` and each parent directory, up to 5 levels |
 
+The first existing `host.json` wins. `AzureWebJobsScriptRoot` is the canonical env var
+set by the Azure Functions host; only the directory itself is probed (no ancestor walk).
 The first existing file wins. To bypass auto-discovery (e.g. in tests or
 non-standard layouts), pass an explicit path:
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -306,8 +306,9 @@ setup_logging()
 
 启用后，`invocation_id`、`function_name`、`trace_id` 和 `cold_start` 将成为保留的 `LogRecord` 属性。通过 stdlib `extra=` 传递它们将引发 `KeyError`。请使用 `FunctionLogger` (它会自动清理键名) 或选择不同的键名。
 
-> **与 `setup_logging()` 的关系:** `setup_logging()` 默认仍然在处理程序上安装 `ContextFilter`。两者可以同时调用 — 它们设置相同的值，因此不会冲突。`install_context_factory()` 确保在稍后添加的处理程序或绕过过滤器链的 logger 上也能覆盖。
-
+> **与 `setup_logging()` 的关系:** 当 `use_record_factory=False` (默认値) 时，`setup_logging()` 会在处理程序上安装 `ContextFilter`。两者可以同时调用 — 它们设置相同的値，因此不会冲突。`install_context_factory()` 确保在稍后添加的处理程序或绕过过滤器链的 logger 上也能覆盖。
+>
+> 当 `use_record_factory=True` 时，`setup_logging()` 切换到工厂模式: 先从现有 root 处理程序中删除所有 `ContextFilter` 实例，然后注册 `LogRecordFactory`。这样可以防止重复注入，同时确保所有记录都携带上下文。
 ## 结构化 JSON 输出 (生产)
 
 当日志流向 Application Insights 或任何聚合系统时，请使用 JSON 格式:
@@ -345,6 +346,28 @@ setup_logging(functions_formatter=JsonFormatter())
 logger.info("order accepted", order_id="o-999", tenant_id="t-1")
 ```
 
+### 裁剪长字符串値 (opt-in)
+
+默认情况下，`JsonFormatter` 对 `extra` 中的字符串値保持完整长度。
+传入 `truncate_native_strings=True` 可将它们裁剪到 `max_string_length` 个字符 (默认 2048)。
+被裁剪的字符串会以 `…` 后缀结尾，使调用者可以检测到裁剪:
+
+```python
+from azure_functions_logging import JsonFormatter, setup_logging
+
+setup_logging(functions_formatter=JsonFormatter(
+    truncate_native_strings=True,
+    max_string_length=512,
+))
+```
+
+> **范围:** 仅裁剪 `extra` 中的字符串値 (递归遍历 dict 和 list)。
+> `message` 字段、整数、浮点数和布尔子不受影响。
+
+```python
+logger.info("order accepted", order_id="o-999", tenant_id="t-1")
+```
+
 ## host.json 冲突检测
 
 如果您的 `host.json` 抑制了应用发出的日志级别，启动时会出现以下警告:
@@ -369,10 +392,15 @@ host.json logLevel for default is set to 'Warning' which is more restrictive tha
 
 ### 发现顺序
 
-`host.json` 通过从当前工作目录向上遍历来定位:
+`host.json` 通过从当前工作目录 (或 `AzureWebJobsScriptRoot` 环境变量指向的目录) 向上遍历来定位:
 
-1. `cwd/host.json`
-2. 每个父目录，最多 5 层深。
+| 优先级 | 来源 |
+|--------|------|
+| 1 | 传入 `setup_logging()` 的显式 `host_json_path` 参数 |
+| 2 | `AzureWebJobsScriptRoot` 环境变量 |
+| 3 | `cwd/host.json` 及各父目录，最多 5 层 |
+
+第一个存在的 `host.json` 被采用。`AzureWebJobsScriptRoot` 是 Azure Functions 主机设置的官方环境变量，仅探测该目录本身 (不进行祖先遍历)。
 
 第一个存在的文件被采用。要绕过自动发现 (例如在测试或非标准布局中)，请传递显式路径:
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -48,8 +48,9 @@ def setup_logging(
                 Passing format="json" in Azure without functions_formatter emits a warning.
         logger_name: Optional logger name to configure. None = root logger.
         functions_formatter: Custom formatter for Azure/Core Tools host-managed handlers.
-        host_json_path: Explicit path to host.json. When None, walks up from cwd up to 5
-                        levels deep to discover host.json automatically.
+        host_json_path: Explicit path to host.json. When None, discovery order is:
+                        1) AzureWebJobsScriptRoot env var (directory itself, no walk),
+                        2) cwd walk up to 5 parent levels.
 
     Raises:
         ValueError: If format not in {"color", "json"}.
@@ -120,6 +121,13 @@ class JsonFormatter(logging.Formatter):
     Output is newline-delimited JSON (NDJSON), one JSON object per line.
     Context fields (invocation_id, function_name, etc.) included when present.
     
+    Args:
+        max_string_length: Maximum chars per native string value in extra when
+            truncate_native_strings=True. Default: 2048.
+        truncate_native_strings: When True, recursively clips string values in extra
+            (dicts and lists walked) to max_string_length chars, appending '…' suffix.
+            Non-string scalars unaffected. Default: False.
+    
     Example output:
         {"timestamp": "2024-01-15T10:30:00+00:00", "level": "INFO", 
          "logger": "my_app", "message": "Request received",
@@ -127,7 +135,8 @@ class JsonFormatter(logging.Formatter):
          "extra": {"user_id": "123"}}
     """
     
-    def __init__(self) -> None:
+    def __init__(self, *, max_string_length: int = 2048, truncate_native_strings: bool = False) -> None:
+        """Initialize JSON formatter. max_string_length must be >= 0."""
         """Initialize JSON formatter (no args)."""
         ...
     
@@ -341,8 +350,8 @@ helpers above instead of importing them directly.
    include trailing fields, which are ignored after validating the first four:
    2/32/16/2 hex; version `ff` and all-zero trace/span ids are rejected;
    forward-compatible with future versions)
-9. **Bounded host.json discovery** — walks up from cwd, max 5 parent levels;
-   override with host_json_path= for tests / non-standard layouts
+9. **Bounded host.json discovery** — priority: AzureWebJobsScriptRoot env var > cwd walk
+   (max 5 parent levels); override with host_json_path= for tests / non-standard layouts
 
 ## Common Patterns
 

--- a/llms.txt
+++ b/llms.txt
@@ -28,7 +28,7 @@ Key features:
 - `setup_logging(*, level=logging.INFO, format="color", logger_name=None, functions_formatter=None, host_json_path=None)` — Keyword-only. One-call logging setup for local or Azure (pass `logger_name=None` for root logger configuration in standalone mode).
 - `get_logger(name)` → `FunctionLogger` — Create a logger with context binding support
 - `FunctionLogger` — Enhanced logger wrapper with `bind()`, `log()`, `hasHandlers()`, `setLevel()`, `isEnabledFor()`, `getEffectiveLevel()` for stdlib parity
-- `JsonFormatter` — JSON log formatter (NDJSON), use with `functions_formatter=` in Azure
+- `JsonFormatter(*, max_string_length=2048, truncate_native_strings=False)` — JSON log formatter (NDJSON). Set `truncate_native_strings=True` to clip string values in `extra` at `max_string_length` chars.
 - `RedactionFilter` — Filter to redact sensitive fields (password, token, api_key, etc.)
 - `SamplingFilter` — Filter for log sampling/rate-limiting noisy loggers
 - `logging_context(context)` — **Recommended** context manager: injects on enter, always restores on exit


### PR DESCRIPTION
## Summary

Syncs all user-facing documentation with behaviors introduced across PRs #160–#166.

## Changes per file

### README.md + README.ko.md + README.ja.md + README.zh-CN.md

| Section | Change |
|---------|--------|
| **host.json Discovery order** | Replaces prose list with priority table: explicit `host_json_path` → `AzureWebJobsScriptRoot` env var → cwd walk. Clarifies env-var probes only the directory itself (no ancestor walk). |
| **Structured JSON Output** | Adds "Truncating long string values (opt-in)" subsection documenting `truncate_native_strings` / `max_string_length` with usage example. |
| **Global LogRecordFactory** | Clarifies `use_record_factory=True` cleanup: removes `ContextFilter` instances before registering the factory; explains `use_record_factory=False` (default) remains unchanged. |

### llms.txt

- `JsonFormatter` entry updated with new constructor signature and truncation opt-in description.

### llms-full.txt

- `JsonFormatter` class docstring updated with `max_string_length` / `truncate_native_strings` params.
- `host_json_path` param description updated with three-step discovery priority.
- Design principle #9 updated to reflect `AzureWebJobsScriptRoot` step.

## No code changes

Docs-only PR. No source/test modifications.

Closes #167