### PR TITLE
fix(filters): expand RedactionFilter default sensitive key set

### DIFF
--- a/README.md
+++ b/README.md
@@ -486,10 +486,14 @@ Any log record with extra fields whose keys match a sensitive key will have thos
 
 | Key | Key | Key |
 |-----|-----|-----|
-| `password` | `passwd` | `token` |
-| `access_token` | `refresh_token` | `authorization` |
-| `secret` | `client_secret` | `api_key` |
-| `apikey` | `connection_string` | |
+| `password` | `passwd` | `pwd` |
+| `token` | `access_token` | `refresh_token` |
+| `id_token` | `authorization` | `auth` |
+| `secret` | `client_secret` | `secret_key` |
+| `api_key` | `apikey` | `subscription_key` |
+| `connection_string` | `conn_str` | `sas_token` |
+| `x_functions_key` | `function_key` | `master_key` |
+| `private_key` | `credential` | |
 
 Pass `sensitive_keys=[...]` to override with your own list:
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -186,8 +186,11 @@ class RedactionFilter(logging.Filter):
     lowercase name is in sensitive_keys. Both ColorFormatter and
     JsonFormatter see redacted values.
     
-    Default sensitive keys: password, passwd, token, authorization,
-    secret, api_key, apikey.
+    Default sensitive keys (23): password, passwd, pwd, token,
+    access_token, refresh_token, id_token, authorization, auth,
+    secret, client_secret, secret_key, api_key, apikey,
+    subscription_key, connection_string, conn_str, sas_token,
+    x_functions_key, function_key, master_key, private_key, credential.
     
     Args:
         sensitive_keys: Iterable of lowercase key names to redact.

--- a/src/azure_functions_logging/_filters.py
+++ b/src/azure_functions_logging/_filters.py
@@ -19,15 +19,27 @@ _DEFAULT_SENSITIVE_KEYS: frozenset[str] = frozenset(
     {
         "password",
         "passwd",
+        "pwd",
         "token",
         "access_token",
         "refresh_token",
+        "id_token",
         "authorization",
+        "auth",
         "secret",
         "client_secret",
+        "secret_key",
         "api_key",
         "apikey",
+        "subscription_key",
         "connection_string",
+        "conn_str",
+        "sas_token",
+        "x_functions_key",
+        "function_key",
+        "master_key",
+        "private_key",
+        "credential",
     }
 )
 
@@ -157,10 +169,13 @@ class RedactionFilter(logging.Filter):
 
     Args:
         sensitive_keys: Iterable of key names to redact (case-insensitive). When None,
-            uses the built-in default set:
-            ``password``, ``passwd``, ``token``, ``access_token``,
-            ``refresh_token``, ``authorization``, ``secret``,
-            ``client_secret``, ``api_key``, ``apikey``, ``connection_string``.
+            uses the built-in default set (23 keys):
+            ``password``, ``passwd``, ``pwd``, ``token``, ``access_token``,
+            ``refresh_token``, ``id_token``, ``authorization``, ``auth``,
+            ``secret``, ``client_secret``, ``secret_key``, ``api_key``, ``apikey``,
+            ``subscription_key``, ``connection_string``, ``conn_str``,
+            ``sas_token``, ``x_functions_key``, ``function_key``, ``master_key``,
+            ``private_key``, ``credential``.
         name: Optional logger-name scope. When set, only matching loggers are
             subject to redaction; non-matching records pass through unchanged.
     Example::

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -506,3 +506,134 @@ def test_redaction_filter_new_keys_case_insensitive() -> None:
     flt.filter(record)
     assert getattr(record, "Access_Token") == "***"
     assert getattr(record, "CONNECTION_STRING") == "***"
+
+
+# ---------------------------------------------------------------------------
+# RedactionFilter — Azure-specific keys added in issue #169
+# ---------------------------------------------------------------------------
+
+
+def test_redaction_filter_masks_pwd() -> None:
+    flt = RedactionFilter()
+    record = _make_record()
+    setattr(record, "pwd", "hunter2")
+    flt.filter(record)
+    assert getattr(record, "pwd") == "***"
+
+
+def test_redaction_filter_masks_id_token() -> None:
+    flt = RedactionFilter()
+    record = _make_record()
+    setattr(record, "id_token", "eyJ...")
+    flt.filter(record)
+    assert getattr(record, "id_token") == "***"
+
+
+def test_redaction_filter_masks_auth() -> None:
+    flt = RedactionFilter()
+    record = _make_record()
+    setattr(record, "auth", "Basic abc123")
+    flt.filter(record)
+    assert getattr(record, "auth") == "***"
+
+
+def test_redaction_filter_masks_secret_key() -> None:
+    flt = RedactionFilter()
+    record = _make_record()
+    setattr(record, "secret_key", "sk_live_xxx")
+    flt.filter(record)
+    assert getattr(record, "secret_key") == "***"
+
+
+def test_redaction_filter_masks_subscription_key() -> None:
+    flt = RedactionFilter()
+    record = _make_record()
+    setattr(record, "subscription_key", "abc123")
+    flt.filter(record)
+    assert getattr(record, "subscription_key") == "***"
+
+
+def test_redaction_filter_masks_conn_str() -> None:
+    flt = RedactionFilter()
+    record = _make_record()
+    setattr(record, "conn_str", "Server=tcp:...")
+    flt.filter(record)
+    assert getattr(record, "conn_str") == "***"
+
+
+def test_redaction_filter_masks_sas_token() -> None:
+    flt = RedactionFilter()
+    record = _make_record()
+    setattr(record, "sas_token", "sv=2021-12-02&ss=b...")
+    flt.filter(record)
+    assert getattr(record, "sas_token") == "***"
+
+
+def test_redaction_filter_masks_x_functions_key() -> None:
+    flt = RedactionFilter()
+    record = _make_record()
+    setattr(record, "x_functions_key", "host_key_abc")
+    flt.filter(record)
+    assert getattr(record, "x_functions_key") == "***"
+
+
+def test_redaction_filter_masks_function_key() -> None:
+    flt = RedactionFilter()
+    record = _make_record()
+    setattr(record, "function_key", "func_key_xyz")
+    flt.filter(record)
+    assert getattr(record, "function_key") == "***"
+
+
+def test_redaction_filter_masks_master_key() -> None:
+    flt = RedactionFilter()
+    record = _make_record()
+    setattr(record, "master_key", "_master_abc")
+    flt.filter(record)
+    assert getattr(record, "master_key") == "***"
+
+
+def test_redaction_filter_masks_private_key() -> None:
+    flt = RedactionFilter()
+    record = _make_record()
+    setattr(record, "private_key", "-----BEGIN RSA PRIVATE KEY-----")
+    flt.filter(record)
+    assert getattr(record, "private_key") == "***"
+
+
+def test_redaction_filter_masks_credential() -> None:
+    flt = RedactionFilter()
+    record = _make_record()
+    setattr(record, "credential", "client_id:client_secret")
+    flt.filter(record)
+    assert getattr(record, "credential") == "***"
+
+
+def test_redaction_filter_azure_keys_in_nested_dict() -> None:
+    """All 12 new Azure keys must be redacted inside nested dicts."""
+    flt = RedactionFilter()
+    record = _make_record()
+    setattr(record, "azure_ctx", {
+        "pwd": "p",
+        "id_token": "t",
+        "auth": "a",
+        "secret_key": "sk",
+        "subscription_key": "subk",
+        "conn_str": "cs",
+        "sas_token": "sas",
+        "x_functions_key": "xfk",
+        "function_key": "fk",
+        "master_key": "mk",
+        "private_key": "pk",
+        "credential": "cred",
+        "safe_field": "visible",
+    })
+    flt.filter(record)
+    result = getattr(record, "azure_ctx")
+    for key in (
+        "pwd", "id_token", "auth", "secret_key", "subscription_key",
+        "conn_str", "sas_token", "x_functions_key", "function_key",
+        "master_key", "private_key", "credential",
+    ):
+        assert result[key] == "***", f"{key!r} was not redacted"
+    assert result["safe_field"] == "visible"


### PR DESCRIPTION
## Summary
- Adds 12 Azure-specific keys to `_DEFAULT_SENSITIVE_KEYS`: `pwd`, `id_token`, `auth`, `secret_key`, `subscription_key`, `conn_str`, `sas_token`, `x_functions_key`, `function_key`, `master_key`, `private_key`, `credential`
- Default set grows from 11 → 23 keys; nested dict/list redaction and case-insensitive matching already handled by existing `_redact_value()` — no logic change required
- Updates `RedactionFilter` class docstring, README sensitive-keys table, and `llms-full.txt`
- Adds 13 new tests (one per key + one combined nested-dict test)

Coverage: 96% (threshold: 95%)

> **Note:** `test_version_matches_distribution_metadata` fails in the local hatch env due to a pre-existing `0.7.5` vs `0.7.6` version mismatch. This failure predates this branch and passes in CI where the package is freshly installed from source.

Closes #169