### PR TITLE
feat: implement host override detection and per-logger sampling

### DIFF
--- a/README.md
+++ b/README.md
@@ -438,6 +438,10 @@ set by the Azure Functions host; only the directory itself is probed (no ancesto
 The first existing file wins. To bypass auto-discovery (e.g. in tests or
 non-standard layouts), pass an explicit path:
 
+The warning also considers Azure Functions app setting overrides that use the
+`AzureFunctionsJobHost__logging__logLevel__...` convention, for example
+`AzureFunctionsJobHost__logging__logLevel__Function__MyFunction=Warning`.
+
 ```python
 from pathlib import Path
 from azure_functions_logging import setup_logging
@@ -455,11 +459,11 @@ import logging
 
 setup_logging()
 
-# Sample noisy azure.* loggers: keep up to 10 records per 1-second window.
+# Sample noisy azure.* loggers: keep up to 10 records per logger per 1-second window.
 # Filters attached to a logger don't run for records propagated from
 # descendants, so attach to the root handlers and scope by logger name.
 for handler in logging.getLogger().handlers:
-    handler.addFilter(SamplingFilter(rate=10, name="azure"))
+    handler.addFilter(SamplingFilter(rate=10, name="azure", per_logger=True))
 
 # Silence urllib3 completely in production
 logging.getLogger("urllib3").setLevel(logging.WARNING)

--- a/docs/api.md
+++ b/docs/api.md
@@ -164,6 +164,31 @@ logger = get_logger("manual")
 logger.info("manual formatter configured")
 ```
 
+## SamplingFilter
+
+::: azure_functions_logging.SamplingFilter
+
+### Usage Notes
+
+- `WARNING` and above always pass.
+- `name=` scopes sampling to matching logger names; non-matching records bypass sampling.
+- `per_logger=False` shares one bucket across all matching records on the filter instance.
+- `per_logger=True` gives each `record.name` an independent bucket/window.
+
+### Example: Per-Logger Buckets for Azure SDK Logs
+
+```python
+import logging
+from azure_functions_logging import SamplingFilter
+
+for handler in logging.getLogger().handlers:
+    handler.addFilter(SamplingFilter(rate=10, window=1.0, name="azure", per_logger=True))
+```
+
+## RedactionFilter
+
+::: azure_functions_logging.RedactionFilter
+
 ## inject_context
 
 ::: azure_functions_logging.inject_context

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -186,6 +186,8 @@ Why this matters:
 
 - You may set `level=logging.INFO` in code.
 - Host config can still suppress `INFO` lines.
+- App settings such as `AzureFunctionsJobHost__logging__logLevel__default`
+  can override the deployed `host.json` file.
 - Without a warning, this looks like missing logs.
 
 Recommended `host.json` baseline:
@@ -199,6 +201,12 @@ Recommended `host.json` baseline:
   }
 }
 ```
+
+The warning checks both file-based `host.json` and Azure Functions app setting
+overrides using the `AzureFunctionsJobHost__logging__logLevel__...` naming
+convention. Function-specific overrides such as
+`AzureFunctionsJobHost__logging__logLevel__Function__MyFunction=Warning` are
+reported as category `Function.MyFunction`.
 
 ## Color vs JSON Format Selection
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -78,6 +78,8 @@ The library detected host policy that can suppress lower log levels than your co
 ### Action
 
 - Review `host.json` log level defaults.
+- Review `AzureFunctionsJobHost__logging__logLevel__...` app settings that
+  override `host.json` in Azure.
 - Align defaults with operational visibility needs.
 - Keep stricter per-category levels only where justified.
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -51,6 +51,8 @@ def setup_logging(
         host_json_path: Explicit path to host.json. When None, discovery order is:
                         1) AzureWebJobsScriptRoot env var (directory itself, no walk),
                         2) cwd walk up to 5 parent levels.
+                        Warnings also consider AzureFunctionsJobHost__logging__logLevel__...
+                        app setting overrides.
 
     Raises:
         ValueError: If format not in {"color", "json"}.
@@ -161,6 +163,8 @@ class SamplingFilter(logging.Filter):
         rate: Max records per window (must be >= 1, default: 100).
         window: Rolling time window in seconds (default: 1.0).
         name: Logger name filter. Empty string = all (default).
+        per_logger: False = one shared bucket per filter instance;
+                    True = independent buckets per record.name.
     
     Raises:
         ValueError: If rate < 1 or window <= 0.
@@ -171,6 +175,8 @@ class SamplingFilter(logging.Filter):
         rate: int = 100,
         window: float = 1.0,
         name: str = "",
+        *,
+        per_logger: bool = False,
     ) -> None:
         ...
     

--- a/llms.txt
+++ b/llms.txt
@@ -30,7 +30,7 @@ Key features:
 - `FunctionLogger` — Enhanced logger wrapper with `bind()`, `log()`, `hasHandlers()`, `setLevel()`, `isEnabledFor()`, `getEffectiveLevel()` for stdlib parity
 - `JsonFormatter(*, max_string_length=2048, truncate_native_strings=False)` — JSON log formatter (NDJSON). Set `truncate_native_strings=True` to clip string values in `extra` at `max_string_length` chars.
 - `RedactionFilter` — Filter to redact sensitive fields (password, token, api_key, etc.)
-- `SamplingFilter` — Filter for log sampling/rate-limiting noisy loggers
+- `SamplingFilter(rate=100, window=1.0, name="", per_logger=False)` — Filter for log sampling/rate-limiting noisy loggers. Set `per_logger=True` for independent buckets per logger name.
 - `logging_context(context)` — **Recommended** context manager: injects on enter, always restores on exit
 - `inject_context(context)` → `ContextTokens` — Set contextvars; returns tokens for paired restore
 - `restore_context(tokens)` — Restore previous contextvars from tokens (paired with `inject_context`)

--- a/src/azure_functions_logging/_filters.py
+++ b/src/azure_functions_logging/_filters.py
@@ -79,9 +79,7 @@ def _redact_value(
                 key: (
                     mask
                     if isinstance(key, str) and key.lower() in sensitive_keys
-                    else _redact_value(
-                        item, sensitive_keys, mask, _seen=seen, _depth=_depth + 1
-                    )
+                    else _redact_value(item, sensitive_keys, mask, _seen=seen, _depth=_depth + 1)
                 )
                 for key, item in value.items()
             }
@@ -100,8 +98,6 @@ def _redact_value(
         return value
 
 
-
-
 class SamplingFilter(logging.Filter):
     """Rate-limit a logger to emit at most ``rate`` records per ``window`` seconds.
 
@@ -117,6 +113,9 @@ class SamplingFilter(logging.Filter):
         name: Optional logger-name scope. When set, only matching loggers are
             subject to sampling; non-matching records pass through unchanged.
             Empty string matches all loggers (default).
+        per_logger: When False (default), all matching records share one rate
+            bucket per filter instance. When True, each ``record.name`` has an
+            independent bucket/window.
 
     Example::
 
@@ -124,7 +123,14 @@ class SamplingFilter(logging.Filter):
         handler.addFilter(filter)
     """
 
-    def __init__(self, rate: int = 100, window: float = 1.0, name: str = "") -> None:
+    def __init__(
+        self,
+        rate: int = 100,
+        window: float = 1.0,
+        name: str = "",
+        *,
+        per_logger: bool = False,
+    ) -> None:
         super().__init__(name)
         if rate < 1:
             msg = "rate must be >= 1"
@@ -132,11 +138,14 @@ class SamplingFilter(logging.Filter):
         if window <= 0:
             msg = "window must be > 0"
             raise ValueError(msg)
-        self._rate = rate
-        self._window = window
-        self._lock = threading.Lock()
+        self._rate: int = rate
+        self._window: float = window
+        self._lock: threading.Lock = threading.Lock()
+        self._per_logger: bool = per_logger
         self._count: int = 0
         self._window_start: float = time.monotonic()
+        self._counts: dict[str, int] = {}
+        self._window_starts: dict[str, float] = {}
 
     def filter(self, record: logging.LogRecord) -> bool:
         """Return True to emit the record, False to drop it."""
@@ -150,6 +159,15 @@ class SamplingFilter(logging.Filter):
 
         now = time.monotonic()
         with self._lock:
+            if self._per_logger:
+                window_start = self._window_starts.get(record.name)
+                if window_start is None or now - window_start >= self._window:
+                    self._window_starts[record.name] = now
+                    self._counts[record.name] = 1
+                    return True
+                self._counts[record.name] = self._counts.get(record.name, 0) + 1
+                return self._counts[record.name] <= self._rate
+
             if now - self._window_start >= self._window:
                 self._count = 0
                 self._window_start = now

--- a/src/azure_functions_logging/_host_config.py
+++ b/src/azure_functions_logging/_host_config.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 import json
 import logging
 import os
@@ -21,6 +22,7 @@ _HOST_LEVEL_TO_LOGGING: dict[str, int] = {
 # Maximum number of parent directories to walk when auto-discovering host.json.
 # Bounded to avoid scanning the entire filesystem on misconfigured environments.
 _HOST_JSON_DISCOVERY_MAX_DEPTH = 5
+_HOST_JSON_ENV_PREFIX = "AzureFunctionsJobHost__logging__logLevel__"
 
 
 def _resolve_host_level(value: object) -> int | None:
@@ -87,6 +89,62 @@ def _is_user_relevant_category(category: str) -> bool:
     return category == "default" or category.startswith("Function")
 
 
+def _iter_app_setting_log_levels() -> dict[str, str]:
+    levels: dict[str, str] = {}
+    prefix_len = len(_HOST_JSON_ENV_PREFIX)
+    for key, value in os.environ.items():
+        if not key.startswith(_HOST_JSON_ENV_PREFIX):
+            continue
+        category_parts = [part for part in key[prefix_len:].split("__") if part]
+        if not category_parts:
+            continue
+        category = ".".join(category_parts)
+        levels[category] = value
+    return levels
+
+
+def _warn_for_log_levels(
+    log_levels: Mapping[str, object],
+    configured_level: int,
+    *,
+    strict: bool,
+    source: str,
+    stacklevel: int,
+) -> None:
+    configured_level_name = logging.getLevelName(configured_level)
+
+    for category, raw_level in log_levels.items():
+        if not strict and not _is_user_relevant_category(category):
+            continue
+        resolved_level = _resolve_host_level(raw_level)
+        if resolved_level is None:
+            continue
+        if resolved_level <= configured_level:
+            continue
+
+        scope = "default" if category == "default" else f"category '{category}'"
+        warnings.warn(
+            (
+                f"{source} logLevel for {scope} is set to '{raw_level}' which is more "
+                f"restrictive than the configured level '{configured_level_name}'. Logs "
+                f"below '{raw_level}' will be suppressed by the Azure Functions host."
+            ),
+            stacklevel=stacklevel,
+        )
+
+
+def _string_key_mapping(value: object) -> dict[str, object] | None:
+    if not isinstance(value, dict):
+        return None
+    result: dict[str, object] = {}
+    for raw_key, raw_value in value.items():
+        key: object = raw_key
+        item: object = raw_value
+        if isinstance(key, str):
+            result[key] = item
+    return result
+
+
 def warn_host_json_level_conflict(
     configured_level: int,
     *,
@@ -108,51 +166,46 @@ def warn_host_json_level_conflict(
         strict: When ``True``, all categories are inspected (including
             host-internal ones). Default: ``False``.
     """
+    host_path: Path | None
     if host_json_path is not None:
         host_path = Path(host_json_path)
         try:
             if not host_path.is_file():
-                return
+                host_path = None
         except OSError:
-            return
+            host_path = None
     else:
         discovered = discover_host_json()
-        if discovered is None:
-            return
         host_path = discovered
 
-    try:
-        host_config = json.loads(host_path.read_text(encoding="utf-8"))
-    except Exception:
-        return
+    if host_path is not None:
+        log_levels: object = None
+        try:
+            host_config: object = json.loads(host_path.read_text(encoding="utf-8"))
+            host_mapping = _string_key_mapping(host_config)
+            if host_mapping is not None:
+                logging_mapping = _string_key_mapping(host_mapping.get("logging"))
+                if logging_mapping is not None:
+                    log_levels = logging_mapping.get("logLevel")
+        except Exception:
+            log_levels = None
 
-    try:
-        log_levels = host_config["logging"]["logLevel"]
-    except Exception:
-        return
+        normalized_log_levels = _string_key_mapping(log_levels)
+        if normalized_log_levels is not None:
+            _warn_for_log_levels(
+                normalized_log_levels,
+                configured_level,
+                strict=strict,
+                source="host.json",
+                stacklevel=3,
+            )
 
-    if not isinstance(log_levels, dict):
-        return
-
-    configured_level_name = logging.getLevelName(configured_level)
-
-    for category, raw_level in log_levels.items():
-        if not isinstance(category, str):
-            continue
-        if not strict and not _is_user_relevant_category(category):
-            continue
-        resolved_level = _resolve_host_level(raw_level)
-        if resolved_level is None:
-            continue
-        if resolved_level <= configured_level:
-            continue
-
-        scope = "default" if category == "default" else f"category '{category}'"
-        warnings.warn(
-            (
-                f"host.json logLevel for {scope} is set to '{raw_level}' which is more "
-                f"restrictive than the configured level '{configured_level_name}'. Logs "
-                f"below '{raw_level}' will be suppressed by the Azure Functions host."
-            ),
+    app_setting_log_levels = _iter_app_setting_log_levels()
+    if app_setting_log_levels:
+        _warn_for_log_levels(
+            app_setting_log_levels,
+            configured_level,
+            strict=strict,
+            source="AzureFunctionsJobHost app setting",
             stacklevel=3,
         )

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -69,6 +69,59 @@ def test_sampling_filter_invalid_window_raises() -> None:
         SamplingFilter(rate=1, window=0.0)
 
 
+def test_sampling_filter_default_shared_bucket_across_logger_names() -> None:
+    flt = SamplingFilter(rate=1, window=10.0)
+    first = _make_record(msg="first")
+    second = _make_record(msg="second")
+    first.name = "app.alpha"
+    second.name = "app.beta"
+
+    assert flt.filter(first) is True
+    assert flt.filter(second) is False
+
+
+def test_sampling_filter_per_logger_tracks_counts_independently() -> None:
+    flt = SamplingFilter(rate=1, window=10.0, name="app", per_logger=True)
+    alpha_1 = _make_record(msg="alpha-1")
+    alpha_2 = _make_record(msg="alpha-2")
+    beta_1 = _make_record(msg="beta-1")
+    alpha_1.name = "app.alpha"
+    alpha_2.name = "app.alpha"
+    beta_1.name = "app.beta"
+
+    assert flt.filter(alpha_1) is True
+    assert flt.filter(alpha_2) is False
+    assert flt.filter(beta_1) is True
+
+
+def test_sampling_filter_per_logger_resets_each_logger_after_window() -> None:
+    flt = SamplingFilter(rate=1, window=0.05, name="app", per_logger=True)
+    alpha = _make_record(msg="alpha")
+    beta = _make_record(msg="beta")
+    alpha.name = "app.alpha"
+    beta.name = "app.beta"
+
+    assert flt.filter(alpha) is True
+    assert flt.filter(alpha) is False
+    assert flt.filter(beta) is True
+    assert flt.filter(beta) is False
+    time.sleep(0.06)
+    assert flt.filter(alpha) is True
+    assert flt.filter(beta) is True
+
+
+def test_sampling_filter_per_logger_always_passes_warning_and_above() -> None:
+    flt = SamplingFilter(rate=1, window=10.0, name="app", per_logger=True)
+    info = _make_record(logging.INFO)
+    warning = _make_record(logging.WARNING)
+    info.name = "app.alpha"
+    warning.name = "app.alpha"
+
+    assert flt.filter(info) is True
+    assert flt.filter(info) is False
+    assert flt.filter(warning) is True
+
+
 # ---------------------------------------------------------------------------
 # RedactionFilter tests
 # ---------------------------------------------------------------------------
@@ -284,8 +337,13 @@ class TestRedactionFilterHardening:
     def test_cyclic_dict_does_not_raise(self) -> None:
         flt = RedactionFilter()
         record = logging.LogRecord(
-            name="test", level=logging.INFO, pathname="", lineno=0,
-            msg="msg", args=(), exc_info=None,
+            name="test",
+            level=logging.INFO,
+            pathname="",
+            lineno=0,
+            msg="msg",
+            args=(),
+            exc_info=None,
         )
         cyclic: dict[str, object] = {"a": 1}
         cyclic["self"] = cyclic  # self-reference
@@ -298,8 +356,13 @@ class TestRedactionFilterHardening:
 
         flt = RedactionFilter()
         record = logging.LogRecord(
-            name="test", level=logging.INFO, pathname="", lineno=0,
-            msg="msg", args=(), exc_info=None,
+            name="test",
+            level=logging.INFO,
+            pathname="",
+            lineno=0,
+            msg="msg",
+            args=(),
+            exc_info=None,
         )
         # Build a dict nested deeper than the limit
         deep: dict[str, object] = {}
@@ -314,8 +377,13 @@ class TestRedactionFilterHardening:
     def test_cyclic_list_does_not_raise(self) -> None:
         flt = RedactionFilter()
         record = logging.LogRecord(
-            name="test", level=logging.INFO, pathname="", lineno=0,
-            msg="msg", args=(), exc_info=None,
+            name="test",
+            level=logging.INFO,
+            pathname="",
+            lineno=0,
+            msg="msg",
+            args=(),
+            exc_info=None,
         )
         cyclic_list: list[object] = [1, 2]
         cyclic_list.append(cyclic_list)  # self-reference
@@ -332,8 +400,13 @@ class TestRedactionFilterHardening:
 
         flt = RedactionFilter()
         record = logging.LogRecord(
-            name="test", level=logging.INFO, pathname="", lineno=0,
-            msg="msg", args=(), exc_info=None,
+            name="test",
+            level=logging.INFO,
+            pathname="",
+            lineno=0,
+            msg="msg",
+            args=(),
+            exc_info=None,
         )
         record.__dict__["broken"] = ExplodingDict({"password": "secret"})
         assert flt.filter(record) is True  # catch-all must swallow the error
@@ -407,8 +480,13 @@ def test_redaction_filter_field_setattr_error_does_not_stop_subsequent_field_red
 
     flt = RedactionFilter()
     record = _RecordWithReadOnlyToken(
-        name="test", level=logging.INFO, pathname="", lineno=0,
-        msg="msg", args=(), exc_info=None,
+        name="test",
+        level=logging.INFO,
+        pathname="",
+        lineno=0,
+        msg="msg",
+        args=(),
+        exc_info=None,
     )
     # Bypass the descriptor to seed 'token' into __dict__ so the filter iterates it
     record.__dict__["token"] = "secret_token_value"
@@ -463,13 +541,17 @@ def test_redaction_filter_masks_new_keys_inside_nested_dict() -> None:
     """New default keys must be redacted inside nested dicts, not just at top level."""
     flt = RedactionFilter()
     record = _make_record()
-    setattr(record, "credentials", {
-        "access_token": "tok-1",
-        "refresh_token": "rt-1",
-        "client_secret": "cs-1",
-        "connection_string": "conn-1",
-        "safe_field": "visible",
-    })
+    setattr(
+        record,
+        "credentials",
+        {
+            "access_token": "tok-1",
+            "refresh_token": "rt-1",
+            "client_secret": "cs-1",
+            "connection_string": "conn-1",
+            "safe_field": "visible",
+        },
+    )
     flt.filter(record)
     assert getattr(record, "credentials") == {
         "access_token": "***",
@@ -484,11 +566,15 @@ def test_redaction_filter_masks_new_keys_inside_list_of_dicts() -> None:
     """New default keys must be redacted inside lists of dicts."""
     flt = RedactionFilter()
     record = _make_record()
-    setattr(record, "items", [
-        {"access_token": "tok-a", "user": "alice"},
-        {"refresh_token": "rt-b", "client_secret": "cs-b"},
-        {"connection_string": "conn-c", "safe": "ok"},
-    ])
+    setattr(
+        record,
+        "items",
+        [
+            {"access_token": "tok-a", "user": "alice"},
+            {"refresh_token": "rt-b", "client_secret": "cs-b"},
+            {"connection_string": "conn-c", "safe": "ok"},
+        ],
+    )
     flt.filter(record)
     assert getattr(record, "items") == [
         {"access_token": "***", "user": "alice"},
@@ -613,27 +699,40 @@ def test_redaction_filter_azure_keys_in_nested_dict() -> None:
     """All 12 new Azure keys must be redacted inside nested dicts."""
     flt = RedactionFilter()
     record = _make_record()
-    setattr(record, "azure_ctx", {
-        "pwd": "p",
-        "id_token": "t",
-        "auth": "a",
-        "secret_key": "sk",
-        "subscription_key": "subk",
-        "conn_str": "cs",
-        "sas_token": "sas",
-        "x_functions_key": "xfk",
-        "function_key": "fk",
-        "master_key": "mk",
-        "private_key": "pk",
-        "credential": "cred",
-        "safe_field": "visible",
-    })
+    setattr(
+        record,
+        "azure_ctx",
+        {
+            "pwd": "p",
+            "id_token": "t",
+            "auth": "a",
+            "secret_key": "sk",
+            "subscription_key": "subk",
+            "conn_str": "cs",
+            "sas_token": "sas",
+            "x_functions_key": "xfk",
+            "function_key": "fk",
+            "master_key": "mk",
+            "private_key": "pk",
+            "credential": "cred",
+            "safe_field": "visible",
+        },
+    )
     flt.filter(record)
     result = getattr(record, "azure_ctx")
     for key in (
-        "pwd", "id_token", "auth", "secret_key", "subscription_key",
-        "conn_str", "sas_token", "x_functions_key", "function_key",
-        "master_key", "private_key", "credential",
+        "pwd",
+        "id_token",
+        "auth",
+        "secret_key",
+        "subscription_key",
+        "conn_str",
+        "sas_token",
+        "x_functions_key",
+        "function_key",
+        "master_key",
+        "private_key",
+        "credential",
     ):
         assert result[key] == "***", f"{key!r} was not redacted"
     assert result["safe_field"] == "visible"

--- a/tests/test_host_config.py
+++ b/tests/test_host_config.py
@@ -463,3 +463,113 @@ def test_discover_falls_through_when_env_root_resolve_raises_runtime_error(
     # Must not raise; must fall back to cwd walk and find tmp_path/host.json
     found = discover_host_json()
     assert found == (tmp_path / "host.json").resolve()
+
+
+# ---------------------------------------------------------------------------
+# AzureFunctionsJobHost app setting logLevel overrides (issue #171)
+# ---------------------------------------------------------------------------
+
+
+def test_warns_when_app_setting_override_sets_default_more_restrictive(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv(
+        "AzureFunctionsJobHost__logging__logLevel__default",
+        "Warning",
+    )
+
+    with pytest.warns(UserWarning, match="more restrictive") as warning_list:
+        warn_host_json_level_conflict(logging.INFO)
+
+    message = str(warning_list[0].message)
+    assert "AzureFunctionsJobHost app setting" in message
+    assert "default" in message
+    assert "'Warning'" in message
+    assert "'INFO'" in message
+
+
+def test_warns_when_app_setting_override_sets_function_category(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv(
+        "AzureFunctionsJobHost__logging__logLevel__Function__MyFunction",
+        "Error",
+    )
+
+    with warnings.catch_warnings(record=True) as warning_list:
+        warnings.simplefilter("always")
+        warn_host_json_level_conflict(logging.INFO)
+
+    messages = [str(w.message) for w in warning_list]
+    assert any("Function.MyFunction" in message and "'Error'" in message for message in messages)
+
+
+def test_app_setting_override_ignores_host_internal_categories_by_default(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv(
+        "AzureFunctionsJobHost__logging__logLevel__Host__Results",
+        "Error",
+    )
+
+    with warnings.catch_warnings(record=True) as warning_list:
+        warnings.simplefilter("always")
+        warn_host_json_level_conflict(logging.INFO)
+
+    assert len(warning_list) == 0
+
+
+def test_app_setting_override_warns_for_host_internal_categories_in_strict_mode(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv(
+        "AzureFunctionsJobHost__logging__logLevel__Host__Results",
+        "Error",
+    )
+
+    with warnings.catch_warnings(record=True) as warning_list:
+        warnings.simplefilter("always")
+        warn_host_json_level_conflict(logging.INFO, strict=True)
+
+    messages = [str(w.message) for w in warning_list]
+    assert any("Host.Results" in message for message in messages)
+
+
+def test_app_setting_override_ignores_unrecognized_level(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv(
+        "AzureFunctionsJobHost__logging__logLevel__default",
+        "SuperVerbose",
+    )
+
+    with warnings.catch_warnings(record=True) as warning_list:
+        warnings.simplefilter("always")
+        warn_host_json_level_conflict(logging.INFO)
+
+    assert len(warning_list) == 0
+
+
+def test_app_setting_override_is_checked_even_when_host_json_is_malformed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    (tmp_path / "host.json").write_text("not valid json", encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv(
+        "AzureFunctionsJobHost__logging__logLevel__default",
+        "Warning",
+    )
+
+    with pytest.warns(UserWarning, match="AzureFunctionsJobHost app setting"):
+        warn_host_json_level_conflict(logging.INFO)


### PR DESCRIPTION
## Summary
- Detect `AzureFunctionsJobHost__logging__logLevel__...` app setting overrides when warning about restrictive Functions host log levels
- Add `SamplingFilter(per_logger=True)` for independent rate buckets per `record.name` while preserving the shared-bucket default
- Update README, API/config/troubleshooting docs, and LLM references for both behaviors

## Verification
- `hatch run pytest tests/test_host_config.py tests/test_filters.py --no-cov -q` ✅
- `make lint` ✅
- `make typecheck` ✅
- `make build` ✅
- `hatch run pytest --cov --cov-report=term-missing -q` reaches 96.04% coverage; local run still has the pre-existing editable-env version metadata mismatch (`__version__` 0.7.6 vs installed distribution 0.7.5), which predates this branch and is expected to pass in fresh CI installs.

Closes #171
Closes #172