### PR TITLE
fix(filters): normalize hyphenated keys in RedactionFilter and expand default set

### DIFF
--- a/llms-full.txt
+++ b/llms-full.txt
@@ -189,18 +189,28 @@ class RedactionFilter(logging.Filter):
     """Mask PII / sensitive values on LogRecord extra attributes.
     
     Mutates record in-place, redacting any non-standard field whose
-    lowercase name is in sensitive_keys. Both ColorFormatter and
-    JsonFormatter see redacted values.
+    *normalized* name (lowercased, hyphens → underscores) is in
+    sensitive_keys. Both ColorFormatter and JsonFormatter see redacted values.
     
-    Default sensitive keys (23): password, passwd, pwd, token,
+    Key normalization: keys are lowercased and hyphens are replaced with
+    underscores before comparison, so ``X-Functions-Key`` in the log record
+    matches ``x_functions_key`` in the sensitive set. The same normalization
+    applies to keys passed via the ``sensitive_keys`` constructor argument.
+    
+    Default sensitive keys (25): password, passwd, pwd, token,
     access_token, refresh_token, id_token, authorization, auth,
     secret, client_secret, secret_key, api_key, apikey,
     subscription_key, connection_string, conn_str, sas_token,
-    x_functions_key, function_key, master_key, private_key, credential.
+    x_functions_key, function_key, master_key, private_key,
+    credential, account_key, access_key.
+    
+    Note: The default set includes ``credential`` which may over-redact in
+    codebases that use generic attribute names. Pass an explicit
+    ``sensitive_keys`` set if false positives occur.
     
     Args:
-        sensitive_keys: Iterable of lowercase key names to redact.
-                       None = uses default set.
+        sensitive_keys: Iterable of key names to redact (case-insensitive,
+                       hyphen-insensitive). None = uses default set (25 keys).
         name: Logger name filter. Empty string = all (default).
     """
     

--- a/src/azure_functions_logging/_filters.py
+++ b/src/azure_functions_logging/_filters.py
@@ -40,6 +40,8 @@ _DEFAULT_SENSITIVE_KEYS: frozenset[str] = frozenset(
         "master_key",
         "private_key",
         "credential",
+        "account_key",
+        "access_key",
     }
 )
 
@@ -47,6 +49,16 @@ _MASK = "***"
 
 
 _REDACT_MAX_DEPTH = 10  # default depth limit for recursive redaction
+
+
+def _normalize_key(key: str) -> str:
+    """Normalize a key for sensitive-key lookup: lowercase and replace hyphens with underscores.
+
+    This ensures that HTTP header forms like ``X-Functions-Key`` match the
+    underscore-based entries in the sensitive keys set.
+    """
+    return key.lower().replace("-", "_")
+
 
 
 def _redact_value(
@@ -78,7 +90,7 @@ def _redact_value(
             return {
                 key: (
                     mask
-                    if isinstance(key, str) and key.lower() in sensitive_keys
+                    if isinstance(key, str) and _normalize_key(key) in sensitive_keys
                     else _redact_value(item, sensitive_keys, mask, _seen=seen, _depth=_depth + 1)
                 )
                 for key, item in value.items()
@@ -179,21 +191,26 @@ class RedactionFilter(logging.Filter):
     """Mask PII / sensitive values on LogRecord extra attributes in-place.
 
     Iterates over all non-standard attributes on the ``LogRecord`` and
-    replaces the value of any key whose *lowercased* name is in
-    ``sensitive_keys`` with ``"***"``.
+    replaces the value of any key whose *normalized* name is in
+    ``sensitive_keys`` with ``\"***\"``.
+
+    Key normalization: lowercased, hyphens replaced with underscores.
+    This means ``X-Functions-Key`` matches the entry ``x_functions_key``.
 
     This filter mutates the record in-place so both ``ColorFormatter`` and
     ``JsonFormatter`` see redacted values.
 
     Args:
-        sensitive_keys: Iterable of key names to redact (case-insensitive). When None,
-            uses the built-in default set (23 keys):
+        sensitive_keys: Iterable of key names to redact (case-insensitive,
+            hyphen-insensitive). When None, uses the built-in default set
+            (25 keys):
             ``password``, ``passwd``, ``pwd``, ``token``, ``access_token``,
             ``refresh_token``, ``id_token``, ``authorization``, ``auth``,
-            ``secret``, ``client_secret``, ``secret_key``, ``api_key``, ``apikey``,
-            ``subscription_key``, ``connection_string``, ``conn_str``,
-            ``sas_token``, ``x_functions_key``, ``function_key``, ``master_key``,
-            ``private_key``, ``credential``.
+            ``secret``, ``client_secret``, ``secret_key``, ``api_key``,
+            ``apikey``, ``subscription_key``, ``connection_string``,
+            ``conn_str``, ``sas_token``, ``x_functions_key``,
+            ``function_key``, ``master_key``, ``private_key``,
+            ``credential``, ``account_key``, ``access_key``.
         name: Optional logger-name scope. When set, only matching loggers are
             subject to redaction; non-matching records pass through unchanged.
     Example::
@@ -225,7 +242,7 @@ class RedactionFilter(logging.Filter):
                 try:
                     if key in _RESERVED_LOG_RECORD_KEYS:
                         continue
-                    if key.lower() in self._sensitive_keys:
+                    if _normalize_key(key) in self._sensitive_keys:
                         setattr(record, key, _MASK)
                     else:
                         value = record.__dict__[key]

--- a/src/azure_functions_logging/_filters.py
+++ b/src/azure_functions_logging/_filters.py
@@ -192,7 +192,7 @@ class RedactionFilter(logging.Filter):
 
     Iterates over all non-standard attributes on the ``LogRecord`` and
     replaces the value of any key whose *normalized* name is in
-    ``sensitive_keys`` with ``\"***\"``.
+    ``sensitive_keys`` with ``"***"``.
 
     Key normalization: lowercased, hyphens replaced with underscores.
     This means ``X-Functions-Key`` matches the entry ``x_functions_key``.
@@ -213,6 +213,11 @@ class RedactionFilter(logging.Filter):
             ``credential``, ``account_key``, ``access_key``.
         name: Optional logger-name scope. When set, only matching loggers are
             subject to redaction; non-matching records pass through unchanged.
+
+    Note:
+        The default set includes ``credential`` which may over-redact
+        in codebases that use generic attribute names. Pass an explicit
+        ``sensitive_keys`` set if false positives occur.
     Example::
 
         filter = RedactionFilter()
@@ -226,7 +231,7 @@ class RedactionFilter(logging.Filter):
     ) -> None:
         super().__init__(name)
         self._sensitive_keys: frozenset[str] = (
-            frozenset(k.lower() for k in sensitive_keys)
+            frozenset(_normalize_key(k) for k in sensitive_keys)
             if sensitive_keys is not None
             else _DEFAULT_SENSITIVE_KEYS
         )

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -801,3 +801,22 @@ def test_redaction_filter_masks_access_key() -> None:
     setattr(record, "access_key", "AKIAIOSFODNN7EXAMPLE")
     flt.filter(record)
     assert getattr(record, "access_key") == "***"
+
+
+def test_redaction_filter_constructor_normalizes_hyphenated_sensitive_keys() -> None:
+    """Hyphenated keys passed via sensitive_keys constructor arg are normalized.
+
+    Passing 'X-Functions-Key' should redact a record attribute named
+    'x_functions_key' because __init__ applies _normalize_key to user input.
+    """
+    flt = RedactionFilter(sensitive_keys=["X-Functions-Key", "Ocp-Apim-Subscription-Key"])
+    record = _make_record()
+    setattr(record, "x_functions_key", "secret-func-key")
+    setattr(record, "ocp_apim_subscription_key", "sub-key-value")
+    setattr(record, "safe_attr", "visible")
+
+    flt.filter(record)
+
+    assert getattr(record, "x_functions_key") == "***"
+    assert getattr(record, "ocp_apim_subscription_key") == "***"
+    assert getattr(record, "safe_attr") == "visible"

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -736,3 +736,68 @@ def test_redaction_filter_azure_keys_in_nested_dict() -> None:
     ):
         assert result[key] == "***", f"{key!r} was not redacted"
     assert result["safe_field"] == "visible"
+
+
+# ---------------------------------------------------------------------------
+# RedactionFilter — key normalization: hyphens treated as underscores (issue #175)
+# ---------------------------------------------------------------------------
+
+
+def test_redaction_filter_normalizes_hyphenated_key_x_functions_key() -> None:
+    """X-Functions-Key (HTTP header form) matches x_functions_key."""
+    flt = RedactionFilter()
+    record = _make_record()
+    setattr(record, "X-Functions-Key", "host_key_abc")
+    flt.filter(record)
+    assert getattr(record, "X-Functions-Key") == "***"
+
+
+def test_redaction_filter_normalizes_hyphenated_key_lowercase() -> None:
+    """x-functions-key (lowercase hyphenated) matches x_functions_key."""
+    flt = RedactionFilter()
+    record = _make_record()
+    setattr(record, "x-functions-key", "host_key_abc")
+    flt.filter(record)
+    assert getattr(record, "x-functions-key") == "***"
+
+
+def test_redaction_filter_normalizes_ocp_apim_subscription_key() -> None:
+    """Ocp-Apim-Subscription-Key normalizes to ocp_apim_subscription_key."""
+    flt = RedactionFilter(sensitive_keys=["ocp_apim_subscription_key"])
+    record = _make_record()
+    setattr(record, "Ocp-Apim-Subscription-Key", "sub_key_123")
+    flt.filter(record)
+    assert getattr(record, "Ocp-Apim-Subscription-Key") == "***"
+
+
+def test_redaction_filter_hyphenated_key_in_nested_dict() -> None:
+    """Hyphenated keys inside nested dicts are also normalized."""
+    flt = RedactionFilter()
+    record = _make_record()
+    setattr(
+        record,
+        "headers",
+        {"X-Functions-Key": "secret", "Content-Type": "application/json"},
+    )
+    flt.filter(record)
+    result = getattr(record, "headers")
+    assert result["X-Functions-Key"] == "***"
+    assert result["Content-Type"] == "application/json"  # not sensitive
+
+
+def test_redaction_filter_masks_account_key() -> None:
+    """account_key is in the default sensitive keys set."""
+    flt = RedactionFilter()
+    record = _make_record()
+    setattr(record, "account_key", "base64encodedkey==")
+    flt.filter(record)
+    assert getattr(record, "account_key") == "***"
+
+
+def test_redaction_filter_masks_access_key() -> None:
+    """access_key is in the default sensitive keys set."""
+    flt = RedactionFilter()
+    record = _make_record()
+    setattr(record, "access_key", "AKIAIOSFODNN7EXAMPLE")
+    flt.filter(record)
+    assert getattr(record, "access_key") == "***"


### PR DESCRIPTION
## Summary
- Add key normalization (`lowercase + hyphen→underscore`) so HTTP header forms like `X-Functions-Key` match the underscore entry `x_functions_key`
- Add `account_key` and `access_key` to the default sensitive keys set (25 total)
- Update docstring to document normalization behavior

## Tests Added
- `test_redaction_filter_normalizes_hyphenated_key_x_functions_key`
- `test_redaction_filter_normalizes_hyphenated_key_lowercase`
- `test_redaction_filter_normalizes_ocp_apim_subscription_key`
- `test_redaction_filter_hyphenated_key_in_nested_dict`
- `test_redaction_filter_masks_account_key`
- `test_redaction_filter_masks_access_key`

## Verification
- `make lint` ✅
- `make typecheck` ✅
- `pytest --cov` → 96.05% (threshold 95%) ✅
- All 56 filter tests pass

Closes #175