### PR TITLE
docs(setup): clarify root logger interaction contract

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@
 - Maintain test coverage at **95% or above** for committed changes and PRs.
 - Run `hatch run pytest --cov --cov-report=term-missing -q` to verify before submitting changes.
 - Any PR that drops coverage below 95% must include additional tests to compensate.
-- In Azure/Core Tools mode, `setup_logging()` installs `ContextFilter` on the root logger's existing handlers (and the root logger itself for late-attaching handlers) but never adds new handlers or changes the root level. In standalone local mode, the root logger is configured by default (`logger_name=None`); pass an explicit `logger_name` to avoid modifying the root logger.
+- In Azure/Core Tools mode, `setup_logging()` installs `ContextFilter` on the root logger's existing handlers (and the root logger itself for late-attaching handlers) but never adds new handlers or changes the root level. When `use_record_factory=True`, no `ContextFilter` is attached; context is injected via the global `LogRecordFactory` instead. In standalone local mode, the root logger is configured by default (`logger_name=None`); pass an explicit `logger_name` to avoid modifying the root logger.
 - No runtime dependency on `azure-functions` — it is an optional import only.
 - Runtime code must remain compatible with Python 3.10+.
 - Public APIs must be fully typed.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@
 - Maintain test coverage at **95% or above** for committed changes and PRs.
 - Run `hatch run pytest --cov --cov-report=term-missing -q` to verify before submitting changes.
 - Any PR that drops coverage below 95% must include additional tests to compensate.
-- The root logger is never modified by this library — only named loggers are configured.
+- In Azure/Core Tools mode, `setup_logging()` installs `ContextFilter` on the root logger's existing handlers (and the root logger itself for late-attaching handlers) but never adds new handlers or changes the root level. In standalone local mode, the root logger is configured by default (`logger_name=None`); pass an explicit `logger_name` to avoid modifying the root logger.
 - No runtime dependency on `azure-functions` — it is an optional import only.
 - Runtime code must remain compatible with Python 3.10+.
 - Public APIs must be fully typed.

--- a/src/azure_functions_logging/_setup.py
+++ b/src/azure_functions_logging/_setup.py
@@ -43,6 +43,7 @@ def _remove_context_filters(logger: logging.Logger) -> None:
             if type(f) is ContextFilter:
                 handler.removeFilter(f)
 
+
 def _is_functions_environment() -> bool:
     """Check if running inside Azure Functions (hosted or Core Tools)."""
     return bool(os.environ.get("FUNCTIONS_WORKER_RUNTIME"))
@@ -66,12 +67,15 @@ def setup_logging(
     Behavior depends on the detected environment:
 
     - **Azure / Core Tools**: Installs ``ContextFilter`` on the root logger's
-      handlers only. Does NOT add handlers or modify the root logger level
-      (respects ``host.json`` configuration). If ``functions_formatter`` is
-      provided, it is applied to every root handler before the filter is added.
+      existing handlers **and** on the root logger itself (so handlers attached
+      later also receive context fields). Does NOT add new handlers or modify
+      the root logger level (respects ``host.json`` configuration). If
+      ``functions_formatter`` is provided, it is applied to every root handler
+      before the filter is added.
     - **Standalone local development**: Adds a ``StreamHandler`` with
       ``ColorFormatter`` or ``JsonFormatter`` to the specified logger
       (or root logger if ``logger_name`` is None). Sets the level.
+      Pass an explicit ``logger_name`` to avoid modifying the root logger.
 
     This function is idempotent per ``logger_name`` — calling it multiple times
     for the same logger has no additional effect.
@@ -153,9 +157,7 @@ def setup_logging(
             # Retrieve or create the per-call-signature state.
             _state_key: _AzureStateKey = (logger_name, use_record_factory)
             if _state_key not in _azure_state:
-                ctx_filter: ContextFilter | None = (
-                    None if use_record_factory else ContextFilter()
-                )
+                ctx_filter: ContextFilter | None = None if use_record_factory else ContextFilter()
                 _azure_state[_state_key] = (ctx_filter, weakref.WeakSet())
             context_filter, configured_handlers = _azure_state[_state_key]
             root = logging.getLogger()

--- a/src/azure_functions_logging/_setup.py
+++ b/src/azure_functions_logging/_setup.py
@@ -66,12 +66,14 @@ def setup_logging(
     """Configure logging for the current environment.
     Behavior depends on the detected environment:
 
-    - **Azure / Core Tools**: Installs ``ContextFilter`` on the root logger's
-      existing handlers **and** on the root logger itself (so handlers attached
-      later also receive context fields). Does NOT add new handlers or modify
-      the root logger level (respects ``host.json`` configuration). If
-      ``functions_formatter`` is provided, it is applied to every root handler
-      before the filter is added.
+    - **Azure / Core Tools** (``use_record_factory=False``, default): Installs
+      ``ContextFilter`` on the root logger's existing handlers **and** on the
+      root logger itself (so handlers attached later also receive context
+      fields). Does NOT add new handlers or modify the root logger level
+      (respects ``host.json`` configuration). If ``functions_formatter`` is
+      provided, it is applied to every root handler before the filter is added.
+      When ``use_record_factory=True``, no ``ContextFilter`` is attached;
+      context injection happens via the global ``LogRecordFactory`` instead.
     - **Standalone local development**: Adds a ``StreamHandler`` with
       ``ColorFormatter`` or ``JsonFormatter`` to the specified logger
       (or root logger if ``logger_name`` is None). Sets the level.


### PR DESCRIPTION
## Summary

- Replaces the inaccurate AGENTS.md rule "root logger is never modified" with a precise description of actual behavior
- Updates `setup_logging()` docstring to clarify that ContextFilter is installed on both root handlers AND the root logger itself in Azure mode
- Documents that passing `logger_name` avoids root logger modification in local mode

Closes #180

## Context

The previous AGENTS.md rule stated the library never modifies the root logger, but `_setup.py` intentionally:
- **Azure mode**: Installs `ContextFilter` on root logger's handlers + root logger itself (for late-attaching handlers)
- **Local mode** (`logger_name=None`): Configures root logger with handler + level

This is correct design (ensures context reaches all log output including third-party), but the documentation was misleading.