### PR TITLE
docs: document context helpers and add api-coverage guard

### DIFF
--- a/docs/agent-playbook.md
+++ b/docs/agent-playbook.md
@@ -16,7 +16,8 @@
 1. Confirm whether the change affects logging API, redaction behavior, configuration, or docs only.
 2. Update examples when they are used as public contract material.
 3. Keep tests and docs in lockstep for public behavior changes.
-4. Do not broaden supported Python versions or dependency ranges casually.
+4. When changing the public API or `README.md`, propagate the same updates to the i18n READMEs (`README.ja.md`, `README.ko.md`, `README.zh-CN.md`) and to `docs/api.md` in the same PR.
+5. Do not broaden supported Python versions or dependency ranges casually.
 
 ## Validation
 - `make test`

--- a/docs/api.md
+++ b/docs/api.md
@@ -234,6 +234,54 @@ inject_context(PartialContext())
 logger.info("partial context accepted")
 ```
 
+## with_context
+
+::: azure_functions_logging.with_context
+
+## get_logging_metadata
+
+::: azure_functions_logging.get_logging_metadata
+
+### Usage Notes
+
+- Returns the logging metadata dict attached by the `with_context` decorator, or `None` when the function was not decorated.
+- Signature: `get_logging_metadata(func: Any) -> dict[str, Any] | None`.
+
+### Example
+
+```python
+from azure_functions_logging import get_logging_metadata, with_context
+
+
+@with_context
+def handler(req, context=None):
+    ...
+
+
+metadata = get_logging_metadata(handler)
+# -> {"param": "context", ...} or None if not decorated
+```
+
+## logging_context
+
+::: azure_functions_logging.logging_context
+
+## install_context_factory
+
+::: azure_functions_logging.install_context_factory
+
+## reset_context
+
+::: azure_functions_logging.reset_context
+
+## restore_context
+
+::: azure_functions_logging.restore_context
+
+## ContextTokens
+
+::: azure_functions_logging.ContextTokens
+
 ## End-to-End API Example
 
 ```python

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -63,10 +63,15 @@ class TestDocsCoverage:
         from pathlib import Path
 
         api_doc = Path(__file__).resolve().parents[1] / "docs" / "api.md"
+        assert api_doc.exists(), f"API documentation file is missing: {api_doc}"
         text = api_doc.read_text(encoding="utf-8")
         missing = [
             name
             for name in azure_functions_logging.__all__
-            if name != "__version__" and name not in text
+            if name != "__version__"
+            and f"::: azure_functions_logging.{name}" not in text
         ]
-        assert not missing, f"Undocumented public symbols in docs/api.md: {missing}"
+        assert not missing, (
+            "Public symbols missing an mkdocstrings directive "
+            f"(`::: azure_functions_logging.<name>`) in docs/api.md: {missing}"
+        )

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -54,3 +54,19 @@ class TestAPISurface:
 
     def test_setup_logging_is_callable(self) -> None:
         assert callable(azure_functions_logging.setup_logging)
+
+
+class TestDocsCoverage:
+    """Guard: every public symbol in ``__all__`` is documented in docs/api.md."""
+
+    def test_every_public_symbol_documented(self) -> None:
+        from pathlib import Path
+
+        api_doc = Path(__file__).resolve().parents[1] / "docs" / "api.md"
+        text = api_doc.read_text(encoding="utf-8")
+        missing = [
+            name
+            for name in azure_functions_logging.__all__
+            if name != "__version__" and name not in text
+        ]
+        assert not missing, f"Undocumented public symbols in docs/api.md: {missing}"


### PR DESCRIPTION
## Summary

Addresses the low-risk items from #208 (docs-review pass):

- **Undocumented helpers →** documents the 7 public symbols missing from `docs/api.md` (`with_context`, `get_logging_metadata`, `logging_context`, `install_context_factory`, `reset_context`, `restore_context`, `ContextTokens`), with a dedicated `get_logging_metadata` section (signature, description, example) using the existing mkdocstrings style.
- **API-coverage CI guard →** adds `TestDocsCoverage` asserting every `__all__` symbol appears in `docs/api.md`, preventing future omissions.
- **i18n propagation note →** adds a rule to the agent-playbook change workflow requiring API/README changes to propagate to `README.ja/ko/zh-CN.md` and `docs/api.md`.

## Deferred

The larger README/docs de-duplication + i18n restructure is carved out to **#211** to keep this PR focused and low-risk. `#208` stays open until #211 lands.

## Verification

- `make lint` ✅  `make typecheck` ✅
- `hatch run pytest -q` ✅ (coverage 96%, above 95% floor)
- `mkdocs build --strict` ✅

Part of #208