### PR TITLE
docs: add pipeline diagram to READMEs and clarify injection modes

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -44,6 +44,26 @@ Azure Functions Python のロギングには、汎用的なロギングライブ
 
 > **スコープ免責事項。** このパッケージは Python `logging` / stdout に構造化 JSON を書き込みます。これらのフィールドが Application Insights にどう現れるかは、Azure Functions host、worker、ロギング設定、および ingestion パイプラインに依存します。ライブラリは ingestion やスキーマ マッピングを所有しません — `customDimensions` にパースされる形式と、生の `message` 内に残る形式の両方が本番環境で有効です。
 
+## パイプライン概要
+
+```mermaid
+flowchart TD
+    A["setup_logging()"] -->|Azure / Core Tools| B[Azure host handler]
+    A -->|local dev| C[Console/Color handler]
+    D["inject_context() / with_context / logging_context"] --> E[contextvars]
+    E --> F{injection mode}
+    F -->|"default"| G[ContextFilter]
+    F -->|"use_record_factory=True"| H[LogRecordFactory]
+    G --> I[FunctionLogger]
+    H --> I
+    B --> I
+    C --> I
+    I --> J[JsonFormatter / ColorFormatter]
+    J --> K[Host / stdout &rarr; Application Insights]
+```
+
+> The two injection modes are **mutually exclusive**: do not attach `ContextFilter` when `use_record_factory=True`.
+
 ## Before / After
 
 `azure-functions-logging` を **使わない場合** — 単純な `print()` 出力、コンテキストなし、構造なし:

--- a/README.ja.md
+++ b/README.ja.md
@@ -59,10 +59,10 @@ flowchart TD
     B --> I
     C --> I
     I --> J[JsonFormatter / ColorFormatter]
-    J --> K[Host / stdout &rarr; Application Insights]
+    J --> K[Host / stdout → Application Insights]
 ```
 
-> The two injection modes are **mutually exclusive**: do not attach `ContextFilter` when `use_record_factory=True`.
+> 2つの注入モードは**相互排他的**です。`use_record_factory=True` の場合は `ContextFilter` を付加しないでください。
 
 ## Before / After
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -59,10 +59,10 @@ flowchart TD
     B --> I
     C --> I
     I --> J[JsonFormatter / ColorFormatter]
-    J --> K[Host / stdout &rarr; Application Insights]
+    J --> K[Host / stdout → Application Insights]
 ```
 
-> The two injection modes are **mutually exclusive**: do not attach `ContextFilter` when `use_record_factory=True`.
+> 두 주입 모드는 **상호 배타적**입니다. `use_record_factory=True`일 때는 `ContextFilter`를 추가하지 마세요.
 
 ## Before / After
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -44,6 +44,26 @@ Azure Functions Python의 logging에는 일반 logging 라이브러리가 다루
 
 > **범위 면책.** 이 패키지는 Python `logging` / stdout으로 구조화된 JSON을 씁니다. Application Insights에서 어떻게 표시되는지는 Azure Functions host, worker, logging 구성, ingestion 파이프라인에 따라 달라집니다. 라이브러리는 ingestion이나 schema mapping을 책임지지 않습니다 — `customDimensions`로 파싱되는 형태와 raw `message`에 들어가는 형태 모두 프로덕션에서 유효합니다.
 
+## 파이프라인 개요
+
+```mermaid
+flowchart TD
+    A["setup_logging()"] -->|Azure / Core Tools| B[Azure host handler]
+    A -->|local dev| C[Console/Color handler]
+    D["inject_context() / with_context / logging_context"] --> E[contextvars]
+    E --> F{injection mode}
+    F -->|"default"| G[ContextFilter]
+    F -->|"use_record_factory=True"| H[LogRecordFactory]
+    G --> I[FunctionLogger]
+    H --> I
+    B --> I
+    C --> I
+    I --> J[JsonFormatter / ColorFormatter]
+    J --> K[Host / stdout &rarr; Application Insights]
+```
+
+> The two injection modes are **mutually exclusive**: do not attach `ContextFilter` when `use_record_factory=True`.
+
 ## Before / After
 
 `azure-functions-logging` **사용 전** — 단순 `print()` 출력, 컨텍스트 없음, 구조 없음:

--- a/README.md
+++ b/README.md
@@ -44,6 +44,26 @@ Azure Functions Python logging has specific failure modes that generic logging l
 
 > **Scope disclaimer.** This package writes structured JSON to Python `logging` / stdout. How those fields appear in Application Insights depends on the Azure Functions host, worker, logging configuration, and ingestion pipeline. The library does not own ingestion or schema mapping — both `customDimensions`-parsed and raw-`message` shapes are valid in production.
 
+## Pipeline at a glance
+
+```mermaid
+flowchart TD
+    A["setup_logging()"] -->|Azure / Core Tools| B[Azure host handler]
+    A -->|local dev| C[Console/Color handler]
+    D["inject_context() / with_context / logging_context"] --> E[contextvars]
+    E --> F{injection mode}
+    F -->|"default"| G[ContextFilter]
+    F -->|"use_record_factory=True"| H[LogRecordFactory]
+    G --> I[FunctionLogger]
+    H --> I
+    B --> I
+    C --> I
+    I --> J[JsonFormatter / ColorFormatter]
+    J --> K[Host / stdout &rarr; Application Insights]
+```
+
+> The two injection modes are **mutually exclusive**: do not attach `ContextFilter` when `use_record_factory=True`.
+
 ## Before / After
 
 **Without** `azure-functions-logging` — plain `print()` output, no context, no structure:

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ flowchart TD
     B --> I
     C --> I
     I --> J[JsonFormatter / ColorFormatter]
-    J --> K[Host / stdout &rarr; Application Insights]
+    J --> K[Host / stdout → Application Insights]
 ```
 
 > The two injection modes are **mutually exclusive**: do not attach `ContextFilter` when `use_record_factory=True`.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -59,10 +59,10 @@ flowchart TD
     B --> I
     C --> I
     I --> J[JsonFormatter / ColorFormatter]
-    J --> K[Host / stdout &rarr; Application Insights]
+    J --> K[Host / stdout → Application Insights]
 ```
 
-> The two injection modes are **mutually exclusive**: do not attach `ContextFilter` when `use_record_factory=True`.
+> 两种注入模式是**互斥的**：当 `use_record_factory=True` 时，请勿附加 `ContextFilter`。
 
 ## Before / After
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -44,6 +44,26 @@ Azure Functions Python 的日志记录有一些通用日志库无法处理的特
 
 > **范围免责声明。** 本包将结构化 JSON 写入 Python `logging` / stdout。这些字段在 Application Insights 中如何呈现取决于 Azure Functions host、worker、日志配置和 ingestion 管道。本库不拥有 ingestion 或 schema 映射 — `customDimensions` 解析形式和原始 `message` 形式在生产中都是有效的。
 
+## 流水线一览
+
+```mermaid
+flowchart TD
+    A["setup_logging()"] -->|Azure / Core Tools| B[Azure host handler]
+    A -->|local dev| C[Console/Color handler]
+    D["inject_context() / with_context / logging_context"] --> E[contextvars]
+    E --> F{injection mode}
+    F -->|"default"| G[ContextFilter]
+    F -->|"use_record_factory=True"| H[LogRecordFactory]
+    G --> I[FunctionLogger]
+    H --> I
+    B --> I
+    C --> I
+    I --> J[JsonFormatter / ColorFormatter]
+    J --> K[Host / stdout &rarr; Application Insights]
+```
+
+> The two injection modes are **mutually exclusive**: do not attach `ContextFilter` when `use_record_factory=True`.
+
 ## Before / After
 
 **未使用** `azure-functions-logging` — 简单的 `print()` 输出，无上下文，无结构:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -164,16 +164,24 @@ sequenceDiagram
     participant CTX as inject_context()
     participant Vars as contextvars
     participant CF as ContextFilter
+    participant LRF as LogRecordFactory
     participant Fmt as Formatter
 
     Trigger->>Handler: invoke with func.Context
     Handler->>CTX: inject_context(context)
     CTX->>Vars: set invocation_id, function_name, trace_id, cold_start
     Handler->>Handler: logger.info("Processing request")
-    Handler->>CF: LogRecord passes through filter
-    CF->>Vars: read context variable values
-    CF->>CF: copy values onto LogRecord attributes
-    CF->>Fmt: enriched LogRecord
+    alt default mode (ContextFilter)
+        Handler->>CF: LogRecord passes through filter
+        CF->>Vars: read context variable values
+        CF->>CF: copy values onto LogRecord attributes
+        CF->>Fmt: enriched LogRecord
+    else use_record_factory=True (LogRecordFactory)
+        Handler->>LRF: LogRecord created by factory
+        LRF->>Vars: read context variable values
+        LRF->>LRF: set context attributes at record creation
+        LRF->>Fmt: enriched LogRecord
+    end
     Fmt-->>Handler: formatted output with context fields
 ```
 


### PR DESCRIPTION
## Summary

Addresses the diagram items from #209:

- **README pipeline diagram** — adds a compact Mermaid flow (`setup_logging()` Azure/local branch → context injection → `ContextFilter` **or** `LogRecordFactory` → `FunctionLogger` → formatters → host/stdout) near Before/After in `README.md`.
- **i18n mirror** — same diagram block mirrored into `README.ja.md`, `README.ko.md`, `README.zh-CN.md`.
- **ContextFilter vs LogRecordFactory** — adds an `alt` branch to the per-invocation sequence diagram in `docs/architecture.md` making the two mutually exclusive modes explicit.

## Deferred

The CI mermaid render lint (item 4, adds a chromium-based dependency) is carved out to a follow-up issue to keep this PR docs-only. `#209` stays open until it lands.

## Verification

- `mkdocs build --strict` ✅

Part of #209