### PR TITLE
test: assert ContextFilter and LogRecordFactory enrich records at parity

### DIFF
--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from collections.abc import Iterator
 import logging
 import os
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
@@ -579,10 +580,17 @@ class TestInjectionModeParity:
 
     CONTEXT_FIELDS = ("invocation_id", "function_name", "trace_id", "cold_start")
 
+    _TRACE_PARENT = "00-" + "a" * 32 + "-" + "b" * 16 + "-01"
+
     class _Ctx:
         invocation_id = "inv-parity-1"
         function_name = "parity_fn"
-        trace_parent = "00-" + "a" * 32 + "-" + "b" * 16 + "-01"
+        trace_context = SimpleNamespace(
+            trace_parent="00-" + "a" * 32 + "-" + "b" * 16 + "-01"
+        )
+
+    # trace_id extracted from the W3C traceparent above.
+    EXPECTED_TRACE_ID = "a" * 32
 
     def _fields(self, record: logging.LogRecord) -> dict[str, object]:
         return {f: getattr(record, f, "<<missing>>") for f in self.CONTEXT_FIELDS}
@@ -627,5 +635,15 @@ class TestInjectionModeParity:
             "Injection modes diverged: "
             f"ContextFilter={filter_fields} LogRecordFactory={factory_fields}"
         )
+        # Assert the extracted values match the injected context in BOTH modes,
+        # so the parity check cannot pass by both modes failing identically
+        # (e.g. all context-derived fields being None).
+        expected = {
+            "invocation_id": self._Ctx.invocation_id,
+            "function_name": self._Ctx.function_name,
+            "trace_id": self.EXPECTED_TRACE_ID,
+        }
+        assert {k: filter_fields[k] for k in context_derived} == expected, filter_fields
+        assert {k: factory_fields[k] for k in context_derived} == expected, factory_fields
         assert isinstance(filter_fields["cold_start"], bool)
         assert isinstance(factory_fields["cold_start"], bool)

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -569,3 +569,63 @@ def test_upgrade_to_record_factory_removes_context_filter_azure_mode() -> None:
     finally:
         root.handlers[:] = original_handlers
         root.filters[:] = original_filters
+
+
+class TestInjectionModeParity:
+    """Guard: ContextFilter and LogRecordFactory modes enrich records with
+    identical context fields, so neither mode implicitly relies on the other
+    for coverage (design-review #210).
+    """
+
+    CONTEXT_FIELDS = ("invocation_id", "function_name", "trace_id", "cold_start")
+
+    class _Ctx:
+        invocation_id = "inv-parity-1"
+        function_name = "parity_fn"
+        trace_parent = "00-" + "a" * 32 + "-" + "b" * 16 + "-01"
+
+    def _fields(self, record: logging.LogRecord) -> dict[str, object]:
+        return {f: getattr(record, f, "<<missing>>") for f in self.CONTEXT_FIELDS}
+
+    def test_both_modes_enrich_identical_fields(self) -> None:
+        from azure_functions_logging import inject_context, reset_context
+
+        # --- ContextFilter mode ---
+        reset_context()
+        inject_context(self._Ctx())
+        cf_record = logging.makeLogRecord({"msg": "m"})
+        assert ContextFilter().filter(cf_record) is True
+        filter_fields = self._fields(cf_record)
+        reset_context()
+
+        # --- LogRecordFactory mode ---
+        logger_name = "afl.test.parity.factory"
+        logger = logging.getLogger(logger_name)
+        logger.handlers.clear()
+        logger.filters.clear()
+        with patch.dict(os.environ, {}, clear=True):
+            setup_logging(logger_name=logger_name, use_record_factory=True)
+        reset_context()
+        inject_context(self._Ctx())
+        factory_record = logger.makeRecord(
+            logger_name, logging.INFO, "f.py", 1, "m", (), None,
+        )
+        factory_fields = self._fields(factory_record)
+        reset_context()
+        logger.handlers.clear()
+        logger.filters.clear()
+
+        # Every context field must be present (not the missing sentinel).
+        assert "<<missing>>" not in filter_fields.values(), filter_fields
+        assert "<<missing>>" not in factory_fields.values(), factory_fields
+        # cold_start is a one-shot process-global, so compare the context-derived
+        # fields for equality and assert cold_start is a bool in both modes.
+        context_derived = ("invocation_id", "function_name", "trace_id")
+        assert {k: filter_fields[k] for k in context_derived} == {
+            k: factory_fields[k] for k in context_derived
+        }, (
+            "Injection modes diverged: "
+            f"ContextFilter={filter_fields} LogRecordFactory={factory_fields}"
+        )
+        assert isinstance(filter_fields["cold_start"], bool)
+        assert isinstance(factory_fields["cold_start"], bool)


### PR DESCRIPTION
## Summary

Addresses #210 (test-suite quality pass): the suite already exercises both injection modes and the Azure-vs-local `setup_logging` branches, but nothing asserted the two modes are at **parity**.

- Adds `TestInjectionModeParity`, which injects the same context and verifies the default `ContextFilter` path and the `use_record_factory=True` `LogRecordFactory` path enrich a `LogRecord` with identical context-derived fields (`invocation_id`, `function_name`, `trace_id`), plus a boolean `cold_start` in each mode.
- Prevents one mode from implicitly covering the other.

## Verification

- `make lint` ✅  `make typecheck` ✅
- `hatch run pytest -q` ✅ (coverage 96.08%, above 95% floor)

Closes #210