### PR TITLE
refactor(context): de-duplicate reserved keys and redaction logic

### DIFF
--- a/src/azure_functions_logging/_constants.py
+++ b/src/azure_functions_logging/_constants.py
@@ -1,0 +1,41 @@
+"""Centralized reserved/excluded LogRecord key sets.
+
+Single source of truth for the reserved-key frozensets shared across
+``_logger``, ``_formatter``, and ``_filters``. Keeping them here prevents the
+sets from drifting independently between modules.
+"""
+
+from __future__ import annotations
+
+import logging
+
+# Custom keys this library injects via the logger context (factory). They must be
+# treated as reserved alongside stdlib LogRecord attributes so that user-supplied
+# `extra` does not silently overwrite Azure Functions runtime metadata.
+_LIBRARY_RESERVED_KEYS: frozenset[str] = frozenset(
+    {
+        "cold_start",
+        "function_name",
+        "invocation_id",
+        "trace_id",
+    }
+)
+
+# `message` and `asctime` are computed lazily by formatters and absent from
+# `__dict__`; we add them explicitly to preserve the original guarantee.
+#
+# `taskName` is also kept in the explicit forward-compat set so that user code
+# passing it as `extra` is sanitized identically across 3.10 / 3.11 / 3.12+.
+_FORWARD_COMPAT_RECORD_KEYS: frozenset[str] = frozenset({"message", "asctime", "taskName"})
+
+# stdlib LogRecord fields only (no library context keys).
+# Derive the stdlib LogRecord attribute set at import time from a pristine record
+# created directly via the base class, bypassing the global LogRecordFactory.
+# Using logging.makeLogRecord({}) would pick up any custom factory already
+# installed by third-party libraries, misclassifying their injected fields as
+# reserved stdlib attributes and breaking extra-key sanitization and redaction.
+_STDLIB_RECORD_KEYS: frozenset[str] = (
+    frozenset(logging.LogRecord("", 0, "", 0, "", (), None).__dict__) | _FORWARD_COMPAT_RECORD_KEYS
+)
+
+_RESERVED_LOG_RECORD_KEYS: frozenset[str] = _STDLIB_RECORD_KEYS | _LIBRARY_RESERVED_KEYS

--- a/src/azure_functions_logging/_filters.py
+++ b/src/azure_functions_logging/_filters.py
@@ -12,53 +12,12 @@ import threading
 import time
 from typing import Any, Iterable
 
-from ._logger import _RESERVED_LOG_RECORD_KEYS
-
-# Default set of sensitive keys masked by RedactionFilter
-_DEFAULT_SENSITIVE_KEYS: frozenset[str] = frozenset(
-    {
-        "password",
-        "passwd",
-        "pwd",
-        "token",
-        "access_token",
-        "refresh_token",
-        "id_token",
-        "authorization",
-        "auth",
-        "secret",
-        "client_secret",
-        "secret_key",
-        "api_key",
-        "apikey",
-        "subscription_key",
-        "connection_string",
-        "conn_str",
-        "sas_token",
-        "x_functions_key",
-        "function_key",
-        "master_key",
-        "private_key",
-        "credential",
-        "account_key",
-        "access_key",
-    }
-)
-
-_MASK = "***"
-
+from ._constants import _RESERVED_LOG_RECORD_KEYS
+from ._redaction import MASK as _MASK
+from ._redaction import SENSITIVE_KEYS as _DEFAULT_SENSITIVE_KEYS
+from ._redaction import normalize_key as _normalize_key
 
 _REDACT_MAX_DEPTH = 10  # default depth limit for recursive redaction
-
-
-def _normalize_key(key: str) -> str:
-    """Normalize a key for sensitive-key lookup: lowercase and replace hyphens with underscores.
-
-    This ensures that HTTP header forms like ``X-Functions-Key`` match the
-    underscore-based entries in the sensitive keys set.
-    """
-    return key.lower().replace("-", "_")
-
 
 
 def _redact_value(
@@ -176,9 +135,7 @@ class SamplingFilter(logging.Filter):
         """
         stale_cutoff = now - self._window
         self._buckets = {
-            name: entry
-            for name, entry in self._buckets.items()
-            if entry[0] > stale_cutoff
+            name: entry for name, entry in self._buckets.items() if entry[0] > stale_cutoff
         }
         # Hard cap: if still over limit after stale removal, drop oldest buckets
         if len(self._buckets) > self._MAX_BUCKETS:
@@ -210,9 +167,7 @@ class SamplingFilter(logging.Filter):
                         elif len(self._buckets) > self._MAX_BUCKETS:
                             # Throttle blocked full sweep; enforce hard cap
                             # by dropping the single oldest bucket
-                            oldest_name = min(
-                                self._buckets, key=lambda k: self._buckets[k][0]
-                            )
+                            oldest_name = min(self._buckets, key=lambda k: self._buckets[k][0])
                             del self._buckets[oldest_name]
                     return True
                 count = bucket[1] + 1
@@ -224,6 +179,7 @@ class SamplingFilter(logging.Filter):
                 self._window_start = now
             self._count += 1
             return self._count <= self._rate
+
 
 class RedactionFilter(logging.Filter):
     """Mask PII / sensitive values on LogRecord extra attributes in-place.

--- a/src/azure_functions_logging/_formatter.py
+++ b/src/azure_functions_logging/_formatter.py
@@ -6,7 +6,8 @@ import logging
 import sys
 from typing import Iterable
 
-from ._logger import _LIBRARY_RESERVED_KEYS, _STDLIB_RECORD_KEYS
+from ._constants import _LIBRARY_RESERVED_KEYS, _STDLIB_RECORD_KEYS
+from ._redaction import mask_value
 
 # ANSI color codes
 _COLORS: dict[int, str] = {
@@ -18,10 +19,6 @@ _COLORS: dict[int, str] = {
 }
 _RESET = "\033[0m"
 
-# Keys whose values are masked in extra output
-_SENSITIVE_KEYS: frozenset[str] = frozenset(
-    {"password", "token", "authorization", "secret", "api_key", "apikey", "passwd"}
-)
 
 _STANDARD_RECORD_FIELDS: frozenset[str] = _STDLIB_RECORD_KEYS
 _CONTEXT_FIELDS: frozenset[str] = _LIBRARY_RESERVED_KEYS
@@ -92,7 +89,7 @@ class ColorFormatter(logging.Formatter):
                     continue
                 if self._extra_allowlist is not None and key not in self._extra_allowlist:
                     continue
-                masked_value = "***" if key.lower() in _SENSITIVE_KEYS else value
+                masked_value = mask_value(key, value)
                 context_parts.append(f"{key}={masked_value}")
 
         # Build output

--- a/src/azure_functions_logging/_formatter.py
+++ b/src/azure_functions_logging/_formatter.py
@@ -35,8 +35,13 @@ class ColorFormatter(logging.Formatter):
     Args:
         include_extra: When True, appends ``bind()`` context fields (extra
             attributes on the LogRecord) to the formatted output. Sensitive
-            keys (password, token, secret, authorization, api_key, passwd,
-            apikey) are replaced with ``"***"``. Default: False.
+            values are masked with ``"***"`` using the shared redaction rules
+            (see ``mask_value``), which cover the full default sensitive-key
+            set (e.g. ``password``, ``token``, ``access_token``,
+            ``refresh_token``, ``authorization``, ``secret``, ``api_key``,
+            ``connection_string``, ``x_functions_key``, ...) and normalize
+            hyphenated header forms, so keys like ``X-Functions-Key`` also
+            match. Default: False.
         extra_allowlist: Optional set of extra field names to include. When
             provided, only keys in this set are shown (sensitive keys are
             still masked). When None (default), all non-standard fields are

--- a/src/azure_functions_logging/_logger.py
+++ b/src/azure_functions_logging/_logger.py
@@ -5,37 +5,10 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-# Custom keys this library injects via the logger context (factory). They must be
-# treated as reserved alongside stdlib LogRecord attributes so that user-supplied
-# `extra` does not silently overwrite Azure Functions runtime metadata.
-_LIBRARY_RESERVED_KEYS: frozenset[str] = frozenset(
-    {
-        "cold_start",
-        "function_name",
-        "invocation_id",
-        "trace_id",
-    }
-)
-
-# Derive the stdlib LogRecord attribute set at import time from a pristine record
-# created directly via the base class, bypassing the global LogRecordFactory.
-# Using logging.makeLogRecord({}) would pick up any custom factory already
-# installed by third-party libraries, misclassifying their injected fields as
-# reserved stdlib attributes and breaking extra-key sanitization and redaction.
-# `message` and `asctime` are computed lazily by formatters and absent from
-# `__dict__`; we add them explicitly to preserve the original guarantee.
-#
-# `taskName` is also kept in the explicit forward-compat set so that user code
-# passing it as `extra` is sanitized identically across 3.10 / 3.11 / 3.12+.
-_FORWARD_COMPAT_RECORD_KEYS: frozenset[str] = frozenset({"message", "asctime", "taskName"})
-
-# stdlib LogRecord fields only (no library context keys).
-# Use this in formatters that need to distinguish stdlib from application-added fields.
-_STDLIB_RECORD_KEYS: frozenset[str] = (
-    frozenset(logging.LogRecord("", 0, "", 0, "", (), None).__dict__) | _FORWARD_COMPAT_RECORD_KEYS
-)
-
-_RESERVED_LOG_RECORD_KEYS: frozenset[str] = _STDLIB_RECORD_KEYS | _LIBRARY_RESERVED_KEYS
+from ._constants import _FORWARD_COMPAT_RECORD_KEYS as _FORWARD_COMPAT_RECORD_KEYS
+from ._constants import _LIBRARY_RESERVED_KEYS as _LIBRARY_RESERVED_KEYS
+from ._constants import _RESERVED_LOG_RECORD_KEYS as _RESERVED_LOG_RECORD_KEYS
+from ._constants import _STDLIB_RECORD_KEYS as _STDLIB_RECORD_KEYS
 
 
 def _sanitize_extra(extra: dict[str, Any]) -> dict[str, Any]:
@@ -68,6 +41,7 @@ def _sanitize_extra(extra: dict[str, Any]) -> dict[str, Any]:
                 key = f"{key}_{suffix}"
             sanitized[key] = value
     return sanitized
+
 
 class FunctionLogger:
     """Wrapper around a standard ``logging.Logger`` with context binding.

--- a/src/azure_functions_logging/_redaction.py
+++ b/src/azure_functions_logging/_redaction.py
@@ -1,0 +1,67 @@
+"""Centralized sensitive-key definitions and masking helpers.
+
+Single source of truth for redaction so ``RedactionFilter`` (recursive,
+LogRecord-mutating) and ``ColorFormatter`` (inline extra-field masking) share
+the same key set and matching rules instead of maintaining separate copies.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+MASK = "***"
+
+# Default set of sensitive keys masked across the library.
+SENSITIVE_KEYS: frozenset[str] = frozenset(
+    {
+        "password",
+        "passwd",
+        "pwd",
+        "token",
+        "access_token",
+        "refresh_token",
+        "id_token",
+        "authorization",
+        "auth",
+        "secret",
+        "client_secret",
+        "secret_key",
+        "api_key",
+        "apikey",
+        "subscription_key",
+        "connection_string",
+        "conn_str",
+        "sas_token",
+        "x_functions_key",
+        "function_key",
+        "master_key",
+        "private_key",
+        "credential",
+        "account_key",
+        "access_key",
+    }
+)
+
+
+def normalize_key(key: str) -> str:
+    """Normalize a key for sensitive-key lookup: lowercase, hyphens to underscores.
+
+    This ensures HTTP header forms like ``X-Functions-Key`` match the
+    underscore-based entries in the sensitive keys set.
+    """
+    return key.lower().replace("-", "_")
+
+
+def is_sensitive(key: str, sensitive_keys: frozenset[str] = SENSITIVE_KEYS) -> bool:
+    """Return True if ``key`` (after normalization) is a sensitive key."""
+    return normalize_key(key) in sensitive_keys
+
+
+def mask_value(
+    key: str,
+    value: Any,
+    sensitive_keys: frozenset[str] = SENSITIVE_KEYS,
+    mask: str = MASK,
+) -> Any:
+    """Return ``mask`` if ``key`` is sensitive, otherwise the original ``value``."""
+    return mask if is_sensitive(key, sensitive_keys) else value

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -118,6 +118,23 @@ def test_include_extra_masks_sensitive_keys() -> None:
     assert "authorization=***" in output
 
 
+def test_include_extra_masks_shared_redaction_keys() -> None:
+    # Guards the coupling to the shared _redaction rules: keys beyond the
+    # legacy hardcoded set (access_token) and hyphenated header forms
+    # (X-Functions-Key) must be masked via mask_value().
+    formatter = ColorFormatter(include_extra=True)
+    record = _make_record(msg="sensitive")
+    setattr(record, "access_token", "at-secret")
+    setattr(record, "X-Functions-Key", "fk-secret")
+
+    output = formatter.format(record)
+
+    assert "at-secret" not in output
+    assert "fk-secret" not in output
+    assert "access_token=***" in output
+    assert "X-Functions-Key=***" in output
+
+
 def test_include_extra_false_by_default_hides_extra_fields() -> None:
     formatter = ColorFormatter()  # include_extra defaults to False
     record = _make_record(msg="no extra")


### PR DESCRIPTION
## Summary

Implements the two de-duplication items from #207:

- **Consolidate reserved key sets** (`_constants.py`) — moves `_LIBRARY_RESERVED_KEYS`, `_FORWARD_COMPAT_RECORD_KEYS`, `_STDLIB_RECORD_KEYS`, `_RESERVED_LOG_RECORD_KEYS` into one module so they can't drift between `_logger`, `_formatter`, `_filters`. `_logger` re-exports them for backward compatibility.
- **De-duplicate redaction** (`_redaction.py`) — extracts `SENSITIVE_KEYS`, `normalize_key`, `mask_value`; `RedactionFilter` and `ColorFormatter` now share one key set and matching rule. ColorFormatter masks against the unified (broader) set using the same normalization.

## ⚠️ Behavior change (ColorFormatter masking)

Consolidating redaction rules is **not** strictly behavior-preserving for `ColorFormatter`. It previously masked against a small hardcoded key list via `key.lower() in _SENSITIVE_KEYS`; it now uses the shared `mask_value(key, value)`. As a result:

- **More keys are masked** — the full default sensitive-key set now applies (e.g. `access_token`, `refresh_token`, `authorization`, `connection_string`, `x_functions_key`, ...).
- **Hyphenated header forms now match** — keys such as `X-Functions-Key` are normalized and masked.

This is a strict superset of the previous masking (only widens redaction, never leaks previously-masked values), so it is safe by default. New formatter tests cover a newly-masked key (`access_token`) and a hyphenated header form (`X-Functions-Key`). The `ColorFormatter.include_extra` docstring was updated to describe the shared behavior.

## Deferred to #216

Behavior-changing / additive-API / cross-repo items — deprecating `install_context_factory()`, non-destructive factory chaining, `extra_context_vars` extension point, worker-compat ADR, and the cross-package metadata TypedDict. `#207` stays open until those land.

## Verification

- `make lint` ✅  `make typecheck` ✅
- `hatch run pytest` ✅ (coverage ≥95%)

Part of #207
