### PR TITLE
docs: add discoverability metadata (pepy badge + llms.txt)

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -3,6 +3,7 @@
 > **Azure Functions Python DX Toolkit** の一部 — [azure-functions-cookbook-python](https://github.com/yeongseon/azure-functions-cookbook-python) によりドッグフーディング検証済み。
 
 [![PyPI](https://img.shields.io/pypi/v/azure-functions-logging.svg)](https://pypi.org/project/azure-functions-logging/)
+[![Downloads](https://static.pepy.tech/badge/azure-functions-logging/month)](https://pepy.tech/project/azure-functions-logging)
 [![Python Version](https://img.shields.io/badge/python-3.10%20%7C%203.11%20%7C%203.12%20%7C%203.13%20%7C%203.14-blue)](https://pypi.org/project/azure-functions-logging/)
 [![CI](https://github.com/yeongseon/azure-functions-logging-python/actions/workflows/ci-test.yml/badge.svg)](https://github.com/yeongseon/azure-functions-logging-python/actions/workflows/ci-test.yml)
 [![Release](https://github.com/yeongseon/azure-functions-logging-python/actions/workflows/publish-pypi.yml/badge.svg)](https://github.com/yeongseon/azure-functions-logging-python/actions/workflows/publish-pypi.yml)

--- a/README.ko.md
+++ b/README.ko.md
@@ -3,6 +3,7 @@
 > **Azure Functions Python DX Toolkit**의 일부 — [azure-functions-cookbook-python](https://github.com/yeongseon/azure-functions-cookbook-python)에서 도그푸딩(dogfooding)으로 검증되었습니다.
 
 [![PyPI](https://img.shields.io/pypi/v/azure-functions-logging.svg)](https://pypi.org/project/azure-functions-logging/)
+[![Downloads](https://static.pepy.tech/badge/azure-functions-logging/month)](https://pepy.tech/project/azure-functions-logging)
 [![Python Version](https://img.shields.io/badge/python-3.10%20%7C%203.11%20%7C%203.12%20%7C%203.13%20%7C%203.14-blue)](https://pypi.org/project/azure-functions-logging/)
 [![CI](https://github.com/yeongseon/azure-functions-logging-python/actions/workflows/ci-test.yml/badge.svg)](https://github.com/yeongseon/azure-functions-logging-python/actions/workflows/ci-test.yml)
 [![Release](https://github.com/yeongseon/azure-functions-logging-python/actions/workflows/publish-pypi.yml/badge.svg)](https://github.com/yeongseon/azure-functions-logging-python/actions/workflows/publish-pypi.yml)

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 > Part of the **Azure Functions Python DX Toolkit** — dogfood-tested by [azure-functions-cookbook-python](https://github.com/yeongseon/azure-functions-cookbook-python).
 
 [![PyPI](https://img.shields.io/pypi/v/azure-functions-logging.svg)](https://pypi.org/project/azure-functions-logging/)
+[![Downloads](https://static.pepy.tech/badge/azure-functions-logging/month)](https://pepy.tech/project/azure-functions-logging)
 [![Python Version](https://img.shields.io/badge/python-3.10%20%7C%203.11%20%7C%203.12%20%7C%203.13%20%7C%203.14-blue)](https://pypi.org/project/azure-functions-logging/)
 [![CI](https://github.com/yeongseon/azure-functions-logging-python/actions/workflows/ci-test.yml/badge.svg)](https://github.com/yeongseon/azure-functions-logging-python/actions/workflows/ci-test.yml)
 [![Release](https://github.com/yeongseon/azure-functions-logging-python/actions/workflows/publish-pypi.yml/badge.svg)](https://github.com/yeongseon/azure-functions-logging-python/actions/workflows/publish-pypi.yml)

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -3,6 +3,7 @@
 > **Azure Functions Python DX Toolkit** 的一部分 — 由 [azure-functions-cookbook-python](https://github.com/yeongseon/azure-functions-cookbook-python) 通过自食其狗粮（dogfooding）方式验证。
 
 [![PyPI](https://img.shields.io/pypi/v/azure-functions-logging.svg)](https://pypi.org/project/azure-functions-logging/)
+[![Downloads](https://static.pepy.tech/badge/azure-functions-logging/month)](https://pepy.tech/project/azure-functions-logging)
 [![Python Version](https://img.shields.io/badge/python-3.10%20%7C%203.11%20%7C%203.12%20%7C%203.13%20%7C%203.14-blue)](https://pypi.org/project/azure-functions-logging/)
 [![CI](https://github.com/yeongseon/azure-functions-logging-python/actions/workflows/ci-test.yml/badge.svg)](https://github.com/yeongseon/azure-functions-logging-python/actions/workflows/ci-test.yml)
 [![Release](https://github.com/yeongseon/azure-functions-logging-python/actions/workflows/publish-pypi.yml/badge.svg)](https://github.com/yeongseon/azure-functions-logging-python/actions/workflows/publish-pypi.yml)

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -1,0 +1,25 @@
+# Azure Functions Logging
+
+> Developer-friendly structured logging helpers for Azure Functions Python.
+
+Part of the **Azure Functions Python DX Toolkit**. Drop-in structured (JSON) logging with context injection and binding for Azure Functions Python, so logs are queryable in Application Insights without boilerplate. Install from PyPI with `pip install azure-functions-logging`.
+
+## Getting Started
+- [Installation](https://yeongseon.github.io/azure-functions-logging-python/installation/): Install the package.
+- [Quickstart](https://yeongseon.github.io/azure-functions-logging-python/getting-started/): Minimal end-to-end example.
+- [Configuration](https://yeongseon.github.io/azure-functions-logging-python/configuration/): Configure formatters and levels.
+
+## User Guide
+- [Usage](https://yeongseon.github.io/azure-functions-logging-python/usage/): Helper reference and injection modes.
+- [Architecture](https://yeongseon.github.io/azure-functions-logging-python/architecture/): How the logging pipeline works.
+
+## Examples
+- [Basic Setup](https://yeongseon.github.io/azure-functions-logging-python/examples/basic_setup/): Get started fast.
+- [JSON Output](https://yeongseon.github.io/azure-functions-logging-python/examples/json_output/): Structured logs.
+- [Context Injection](https://yeongseon.github.io/azure-functions-logging-python/examples/context_injection/): Enrich records with context.
+- [Third-Party Noise Control](https://yeongseon.github.io/azure-functions-logging-python/examples/third_party_noise_control/): Quiet noisy loggers.
+
+## Reference
+- [API Reference](https://yeongseon.github.io/azure-functions-logging-python/api/): Public API surface.
+- [FAQ](https://yeongseon.github.io/azure-functions-logging-python/faq/): Frequently asked questions.
+- [Troubleshooting](https://yeongseon.github.io/azure-functions-logging-python/troubleshooting/): Common issues and fixes.


### PR DESCRIPTION
## Summary

Discoverability improvements (no code changes):

- **pepy.tech monthly download badge** added to `README.md` and locale READMEs (after the PyPI badge).
- **`docs/llms.txt`** added — an llmstxt.org-style summary served at the gh-pages site root (`/llms.txt`) with curated links to key docs.

## Verification
- `mkdocs build --strict` passes; `llms.txt` present at site root.

Closes #218
