### PR TITLE
fix(ci): replace fragile Core Tools apt install with pinned npm

### DIFF
--- a/.github/workflows/e2e-azure.yml
+++ b/.github/workflows/e2e-azure.yml
@@ -13,6 +13,9 @@ permissions:
 env:
   AZURE_LOCATION: ${{ vars.AZURE_LOCATION || 'koreacentral' }}
   REPO_SHORT: logging
+  # Azure Functions Core Tools version (installed via npm in the install step below).
+  # Pin exactly; bump only after a verified end-to-end run on a tag or workflow_dispatch.
+  FUNCTIONS_CORE_TOOLS_VERSION: "4.12.0"
 
 jobs:
   deploy_and_test:
@@ -70,13 +73,28 @@ jobs:
         with:
           python-version: "3.10"
 
+      # Install Azure Functions Core Tools via npm.
+      # We previously installed from packages.microsoft.com via apt, but that feed
+      # has hit stale-index 404s during Core Tools 4.x package transitions
+      # (Azure/azure-functions-core-tools#4796) and there is no Microsoft-maintained
+      # GitHub Action for Core Tools. npm is Microsoft's documented v4 install path
+      # (see Azure/azure-functions-core-tools README) and is the same approach used
+      # in Microsoft's own CI (e.g. microsoft/agent-framework,
+      # Azure/azure-functions-durable-extension). Version is pinned via the
+      # FUNCTIONS_CORE_TOOLS_VERSION env var declared at the workflow level.
+      # Node is pinned explicitly so the install path stays reproducible across
+      # GitHub-hosted runner image updates (the npm package requires Node >= 20).
+      - name: Set up Node.js 22
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: "22"
+
       - name: Install Azure Functions Core Tools
         run: |
-          curl https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > /tmp/microsoft.gpg
-          sudo install -o root -g root -m 644 /tmp/microsoft.gpg /etc/apt/trusted.gpg.d/
-          sudo sh -c 'echo "deb [arch=amd64] https://packages.microsoft.com/repos/microsoft-ubuntu-$(lsb_release -cs)-prod $(lsb_release -cs) main" > /etc/apt/sources.list.d/dotnetdev.list'
-          sudo apt-get update
-          sudo apt-get install -y azure-functions-core-tools-4
+          npm install -g "azure-functions-core-tools@${FUNCTIONS_CORE_TOOLS_VERSION}"
+          FUNC_VERSION="$(func --version)"
+          echo "Installed func: ${FUNC_VERSION}"
+          test "${FUNC_VERSION}" = "${FUNCTIONS_CORE_TOOLS_VERSION}"
 
       - name: Install library from source + test deps
         run: |


### PR DESCRIPTION
## Summary
Ports the canonical scaffold pattern (scaffold PR #126) to `e2e-azure.yml`:
- Pin `FUNCTIONS_CORE_TOOLS_VERSION: "4.12.0"` at workflow env level.
- SHA-pinned `actions/setup-node@v6.4.0` (Node 22) before install.
- Replace apt install with `npm install -g azure-functions-core-tools@${FUNCTIONS_CORE_TOOLS_VERSION}`.
- Assert `func --version` exact equality to fail fast on drift.

Fixes intermittent stale-index 404s from packages.microsoft.com (Azure/azure-functions-core-tools#4796).

Closes #188