### PR TITLE
feat(context): add uninstall_context_factory restore API

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -270,6 +270,10 @@ metadata = get_logging_metadata(handler)
 
 ::: azure_functions_logging.install_context_factory
 
+## uninstall_context_factory
+
+::: azure_functions_logging.uninstall_context_factory
+
 ## reset_context
 
 ::: azure_functions_logging.reset_context

--- a/src/azure_functions_logging/__init__.py
+++ b/src/azure_functions_logging/__init__.py
@@ -9,6 +9,7 @@ from ._context import (
     logging_context,
     reset_context,
     restore_context,
+    uninstall_context_factory,
 )
 from ._decorator import get_logging_metadata, with_context
 from ._filters import RedactionFilter, SamplingFilter
@@ -30,6 +31,7 @@ __all__ = [
     "logging_context",
     "reset_context",
     "restore_context",
+    "uninstall_context_factory",
     "setup_logging",
     "with_context",
 ]

--- a/src/azure_functions_logging/_context.py
+++ b/src/azure_functions_logging/_context.py
@@ -223,6 +223,7 @@ def logging_context(context: Any) -> Iterator[None]:
 # --- LogRecordFactory-based context injection (opt-in) ---
 
 _CONTEXT_FACTORY_MARKER = "_azure_functions_logging_context_factory"
+_CONTEXT_FACTORY_PREVIOUS = "_azure_functions_logging_previous_factory"
 
 #: Field names injected by the factory. These become reserved LogRecord
 #: attributes when ``install_context_factory()`` is active.
@@ -275,4 +276,31 @@ def install_context_factory() -> None:
         return record
 
     setattr(context_record_factory, _CONTEXT_FACTORY_MARKER, True)
+    setattr(context_record_factory, _CONTEXT_FACTORY_PREVIOUS, previous_factory)
     logging.setLogRecordFactory(context_record_factory)
+
+
+def uninstall_context_factory() -> bool:
+    """Restore the ``LogRecordFactory`` that preceded :func:`install_context_factory`.
+
+    This is the inverse of :func:`install_context_factory` and is primarily
+    intended for test teardown, where leaving a global factory installed would
+    leak context injection into unrelated tests.
+
+    Only the factory installed by this package is removed: the previously
+    active factory (captured at install time, including any chained
+    customizations) is restored as the global ``LogRecordFactory``.
+
+    Returns:
+        ``True`` if this package's context factory was active and has been
+        uninstalled; ``False`` if no such factory was active (no-op).
+    """
+    current_factory = logging.getLogRecordFactory()
+    if not getattr(current_factory, _CONTEXT_FACTORY_MARKER, False):
+        return False
+
+    previous_factory = getattr(current_factory, _CONTEXT_FACTORY_PREVIOUS, None)
+    if previous_factory is None:  # pragma: no cover - defensive; always set on install
+        previous_factory = logging.LogRecord
+    logging.setLogRecordFactory(previous_factory)
+    return True

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -21,6 +21,7 @@ from azure_functions_logging._context import (
     reset_context,
     restore_context,
     trace_id_var,
+    uninstall_context_factory,
 )
 
 
@@ -362,6 +363,57 @@ def test_install_context_factory_injects_fields() -> None:
         logging.setLogRecordFactory(old_factory)
         invocation_id_var.set(None)
         function_name_var.set(None)
+
+
+def test_uninstall_context_factory_restores_previous() -> None:
+    """uninstall_context_factory restores the factory active before install."""
+    old_factory = logging.getLogRecordFactory()
+    try:
+        install_context_factory()
+        assert getattr(
+            logging.getLogRecordFactory(), _CONTEXT_FACTORY_MARKER, False
+        ) is True
+
+        assert uninstall_context_factory() is True
+        assert logging.getLogRecordFactory() is old_factory
+        assert getattr(
+            logging.getLogRecordFactory(), _CONTEXT_FACTORY_MARKER, False
+        ) is False
+    finally:
+        logging.setLogRecordFactory(old_factory)
+
+
+def test_uninstall_context_factory_preserves_chained_factory() -> None:
+    """Uninstall restores a custom factory that install had chained onto."""
+    old_factory = logging.getLogRecordFactory()
+
+    def custom_factory(*args: Any, **kwargs: Any) -> logging.LogRecord:
+        record = old_factory(*args, **kwargs)
+        record.custom_field = "kept"
+        return record
+
+    try:
+        logging.setLogRecordFactory(custom_factory)
+        install_context_factory()
+        assert uninstall_context_factory() is True
+        assert logging.getLogRecordFactory() is custom_factory
+
+        record = logging.getLogRecordFactory()(
+            "test", logging.INFO, __file__, 1, "msg", (), None
+        )
+        assert record.custom_field == "kept"  # type: ignore[attr-defined]
+    finally:
+        logging.setLogRecordFactory(old_factory)
+
+
+def test_uninstall_context_factory_noop_when_not_installed() -> None:
+    """uninstall_context_factory is a no-op when the factory is not active."""
+    old_factory = logging.getLogRecordFactory()
+    try:
+        assert uninstall_context_factory() is False
+        assert logging.getLogRecordFactory() is old_factory
+    finally:
+        logging.setLogRecordFactory(old_factory)
 
 
 def test_install_context_factory_chains_existing_factory() -> None:

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -93,6 +93,7 @@ def test_public_api_exports() -> None:
         "logging_context",
         "reset_context",
         "restore_context",
+        "uninstall_context_factory",
         "setup_logging",
         "with_context",
     }

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -21,6 +21,7 @@ class TestAPISurface:
             "logging_context",
             "reset_context",
             "restore_context",
+            "uninstall_context_factory",
             "setup_logging",
             "with_context",
         }
@@ -47,6 +48,7 @@ class TestAPISurface:
             logging_context,
             reset_context,
             restore_context,
+            uninstall_context_factory,
         )
 
     def test_get_logger_is_callable(self) -> None:


### PR DESCRIPTION
## Summary
Delivers one focused item from the #216 tracker: *"Make `install_context_factory()` non-destructive … and add a restore/uninstall API for test teardown."* The chaining half already existed; this adds the missing restore/uninstall API.

## Problem
`install_context_factory()` installs a global `logging.LogRecordFactory` (chaining onto any previous one), but there was no supported way to undo it. Tests hand-rolled `getLogRecordFactory()` / `setLogRecordFactory()` save-restore boilerplate, and a leaked global factory could bleed context injection into unrelated tests.

## Changes
- Add `uninstall_context_factory()` — the inverse of `install_context_factory()`. It restores the factory captured at install time (including any chained customizations) and returns:
  - `True` when the package's context factory was active and has been uninstalled.
  - `False` (no-op) when it was not active.
- The install path now records the previous factory on the installed factory object so it can be restored precisely.
- Export from the public API (`__init__.__all__`) and document in `docs/api.md`.

## Verification
- New tests cover restore, chained-factory restore, and the no-op path.
- `make lint`, `make typecheck` clean.
- `make test`: 302 passed, coverage **96.19%** (gate 95%). Updated the public-API and docs-coverage guard tests accordingly.

Part of #216
Part of #207