### PR TITLE
docs: de-duplicate README against docs/ and sync i18n variants

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -252,245 +252,53 @@ curl -s "https://<your-app>.azurewebsites.net/api/logme?correlation_id=demo-123"
 
 > koreacentral リージョンの一時的な Azure Functions デプロイで検証 (Python 3.12, Consumption plan)。レスポンスをキャプチャし、URL は匿名化されています。
 
-## 呼び出しコンテキスト (Invocation Context)
+## 主要機能
 
-ハンドラの実行期間中に呼び出しコンテキストをバインドするには `logging_context()` を使用します。以下を設定します:
+以下の各機能には [ドキュメントサイト](https://yeongseon.github.io/azure-functions-logging-python/) に完全なガイドがあります。このセクションは各機能が何をするかを要約して単一の情報源にリンクし、README がドキュメントのコピーではなく簡潔な概要として保たれるようにします。
 
-- `invocation_id` — 実行ごとに一意、1 リクエストのすべてのログを相関させる
-- `function_name` — Azure Functions の関数名
-- `trace_id` — プラットフォームからのトレースコンテキスト。有効な W3C `traceparent` ヘッダーからのみ抽出され、厳格に検証されるため不正な値は無視されます
-- `cold_start` — この worker プロセスの最初の呼び出しで `True`
+### 呼び出しコンテキスト
 
-> **`cold_start` のセマンティクス。** `cold_start=True` は *モジュールロード後にこの Python worker プロセスで観測された最初の呼び出し* を意味します。**プラットフォームレベル** のコールドスタートメトリックではなく、Azure Functions メトリクスが報告する App Service plan / instance 割当のコールドスタートには対応しません。同じ worker での後続の呼び出しは、worker がリサイクルされるまで `cold_start=False` を発行します。
+`logging_context(context)`（[Quick Start](#quick-start) 参照）はハンドラの実行期間中 `invocation_id`、`function_name`、`trace_id`、`cold_start` をバインドし、終了時には常に以前のコンテキストを復元します。より低レベルな制御が必要な場合は `inject_context()` / `restore_context()` を、暗黙的に注入するには `@with_context` デコレータ（同期/非同期ハンドラの両方をサポート）を使用します。
 
-```python
-def my_function(req, context):
-    with logging_context(context):
-        logger.info("handler started")
-        # ここから先のすべてのログに invocation_id と cold_start が含まれる
-```
+> **`cold_start` の意味。** `cold_start=True` はモジュールロード後にこの Python ワーカープロセスが初めて観測した呼び出しを意味します。プラットフォームレベルのコールドスタート指標では **ありません**。
 
-低レベル制御 (例: ミドルウェア) には、`inject_context()` と `restore_context()` を使用します:
+→ [使い方: コンテキスト注入](https://yeongseon.github.io/azure-functions-logging-python/usage/#3-context-injection-in-azure-functions) · [API: `with_context`](https://yeongseon.github.io/azure-functions-logging-python/api/#with_context)
 
-```python
-tokens = inject_context(context)
-try:
-    logger.info("handler started")
-finally:
-    restore_context(tokens)
-```
+### 構造化 JSON 出力
 
-コンテキスト注入なしでは、これらのフィールドはすべてのログ行で `None` です。
+`setup_logging(functions_formatter=JsonFormatter())` を渡すと、ホスト管理のハンドラで Application Insights 向け NDJSON を出力します（スタンドアロン実行/CI では `format="json"`）。追加フィールドは `extra` の下に入り、`truncate_native_strings=True` で長い文字列値を切り詰められます。
 
-### `with_context` デコレータ
+→ [使い方: JSON 出力](https://yeongseon.github.io/azure-functions-logging-python/usage/#2-json-output-for-production) · [API: `JsonFormatter`](https://yeongseon.github.io/azure-functions-logging-python/api/#jsonformatter)
 
-ボイラープレートを減らすには、`inject_context()` を手動で呼び出す代わりに `with_context` デコレータを使用します:
+### host.json 衝突検出
 
-```python
-import azure.functions as func
-from azure_functions_logging import get_logger, setup_logging, with_context
+起動時、`host.json`（または `AzureFunctionsJobHost__logging__logLevel__...` アプリ設定のオーバーライド）がアプリの発行するレベルを抑制する場合に警告します。`host.json` は作業ディレクトリ（または `AzureWebJobsScriptRoot`）から上位に探索して自動発見され、`host_json_path=` で上書きできます。
 
-setup_logging()
-logger = get_logger(__name__)
+→ [設定: host.json 衝突](https://yeongseon.github.io/azure-functions-logging-python/configuration/#hostjson-level-conflict-warning) · [トラブルシューティング](https://yeongseon.github.io/azure-functions-logging-python/troubleshooting/#hostjson-conflict-warning-appears)
 
-app = func.FunctionApp()
+### ノイズ制御と PII Redaction
 
-@app.route(route="hello")
-@with_context
-def hello(req: func.HttpRequest, context: func.Context) -> func.HttpResponse:
-    logger.info("Request received")
-    return func.HttpResponse("OK")
-```
+`SamplingFilter` は冗長なサードパーティロガー（`azure-core`、`urllib3` など）のレートを制限し、`RedactionFilter` は機密キー（パスワード、トークン、シークレット、接続文字列など — 大文字小文字を区別せず、再帰的）をログ集約前にマスクします。どちらもルートハンドラにアタッチし、`sensitive_keys=[...]` でカスタマイズできます。
 
-デコレータは名前で `context` パラメータを見つけ、ハンドラ実行前に `inject_context()` を呼び出し、戻った後 `finally` で以前のコンテキストへ復元します。
+→ [API: `SamplingFilter`](https://yeongseon.github.io/azure-functions-logging-python/api/#samplingfilter) · [API: `RedactionFilter`](https://yeongseon.github.io/azure-functions-logging-python/api/#redactionfilter)
 
-カスタムパラメータ名:
+### コンテキストバインディング
 
-```python
-@with_context(param="ctx")
-def hello(req: func.HttpRequest, ctx: func.Context) -> func.HttpResponse:
-    ...
-```
+`logger.bind(key=value)` は、以降のすべてのログにリクエストスコープのメタデータを付与するロガーを返します。呼び出しごとにバインドされたロガーを作成し、モジュールレベルでキャッシュしないでください。
 
-同期および非同期ハンドラの両方がサポートされます。
+→ [使い方: コンテキストバインディング](https://yeongseon.github.io/azure-functions-logging-python/usage/#4-context-binding-with-functionloggerbind)
 
 ### グローバル LogRecordFactory (オプトイン)
 
-`setup_logging()` の後にハンドラが追加される可能性がある、またはハンドラ/フィルタ設定に関係なく **すべての** `LogRecord` に呼び出しコンテキストを乗せたいアプリケーションでは、起動時にグローバルコンテキストファクトリを一度インストールしてください:
+`install_context_factory()` はレコード生成時にコンテキストを注入し、ハンドラ/フィルタの構成に関係なく **すべての** `LogRecord` がコンテキストを持つようにします。`setup_logging()` 後にハンドラが追加されたり、ロガーがフィルタチェーンをバイパスする場合に便利です。デフォルトの `ContextFilter` モードとは相互排他的です。
 
-```python
-from azure_functions_logging import install_context_factory, setup_logging
+→ [設定: `use_record_factory`](https://yeongseon.github.io/azure-functions-logging-python/configuration/#parameter-use_record_factory) · [API: `install_context_factory`](https://yeongseon.github.io/azure-functions-logging-python/api/#install_context_factory)
 
-install_context_factory()  # レコード生成時にコンテキストを注入
-setup_logging()
-```
+### ローカル vs クラウド
 
-有効化されると、`invocation_id`, `function_name`, `trace_id`, `cold_start` は予約された `LogRecord` 属性となります。stdlib `extra=` 経由で渡すと `KeyError` が発生します。キーを自動的にサニタイズする `FunctionLogger` を使用するか、別のキー名を選択してください。
+`setup_logging()` は `FUNCTIONS_WORKER_RUNTIME` を検出します：ローカルでは色付きの人間が読みやすい出力、Azure / Core Tools ではホスト管理の NDJSON（コンテキストフィルタのみ — ハンドラ重複なし）、CI では機械可読な JSON。
 
-> **`setup_logging()` との関係:** `use_record_factory=False` (デフォルト) の場合、`setup_logging()` はハンドラに `ContextFilter` をインストールします。両方を呼び出しても問題ありません — 同じ値を設定するため衝突しません。`install_context_factory()` は後で追加されたハンドラやフィルタチェーンをバイパスするロガーでもカバレッジを保証します。
->
-> `use_record_factory=True` の場合、`setup_logging()` はファクトリモードに切り替えます: 既存のルートハンドラから `ContextFilter` インスタンスを削除してから `LogRecordFactory` を登録します。これにより二重注入を防ぎながら、すべてのレコードにコンテキストが付与されることを保証します。
-## 構造化 JSON 出力 (本番)
-
-ログが Application Insights や任意の集約システムに流れる場合は JSON フォーマットを使用してください:
-
-> **注:** `format` パラメータは、このライブラリが作成したハンドラ (ローカル開発) にのみ影響します。
-> Azure Functions では host がハンドラを管理します。host が管理するハンドラに JSON 出力を設定するには
-> `functions_formatter=JsonFormatter()` を使用してください。Azure で `format="json"` を渡すと警告が発生します。
-
-スタンドアロンのローカル開発または CI 出力の場合:
-
-```python
-setup_logging(format="json")
-```
-
-Azure Functions / Core Tools では host がハンドラを所有します。既存の host 管理ハンドラに JSON フォーマットを強制するには:
-
-```python
-from azure_functions_logging import JsonFormatter, setup_logging
-
-setup_logging(functions_formatter=JsonFormatter())
-```
-
-ログ行ごとの出力 (NDJSON — 1 行 1 JSON オブジェクト):
-
-```json
-{"timestamp": "2024-01-15T10:30:00+00:00", "level": "INFO", "logger": "my_module",
- "message": "order accepted", "invocation_id": "abc-123", "function_name": "OrderHandler",
- "cold_start": false, "trace_id": "4bf92f3577b34da6a3ce929d0e0e4736", "exception": null,
- "extra": {"order_id": "o-999"}}
-```
-
-追加フィールドは出力される JSON の `extra` に含まれます。Application Insights で直接インデックス可能かどうかは ingestion パイプラインに依存します: JSON が `customDimensions` にパースされる場合は直接クエリ可能ですが、JSON が `message` カラムに残る場合はまず `parse_json(message)` を通す必要があります.
-
-```python
-logger.info("order accepted", order_id="o-999", tenant_id="t-1")
-```
-
-### 長い文字列値の切り詰め (オプトイン)
-
-デフォルトでは `JsonFormatter` は `extra` の文字列値を全長で保持します。
-`truncate_native_strings=True` を渡すと `max_string_length` 文字 (デフォルト 2048) でクリップします。
-切り詰められた文字列には `…` サフィックスが付加され、切り詰めを検出できます:
-
-```python
-from azure_functions_logging import JsonFormatter, setup_logging
-
-setup_logging(functions_formatter=JsonFormatter(
-    truncate_native_strings=True,
-    max_string_length=512,
-))
-```
-
-> **スコープ:** `extra` の文字列値のみが切り詰められます (dict と list を再帰的に探索)。
-> `message` フィールド、整数、浮動小数点数、ブール値は影響を受けません。
-
-```python
-logger.info("order accepted", order_id="o-999", tenant_id="t-1")
-```
-
-## host.json 衝突検出
-
-`host.json` がアプリが発行するログレベルを抑制する場合、起動時にこの警告が表示されます:
-
-```
-host.json logLevel for default is set to 'Warning' which is more restrictive than the configured level 'INFO'. Logs below 'Warning' will be suppressed by the Azure Functions host.
-```
-
-推奨される `host.json` ベースライン:
-
-```json
-{
-  "version": "2.0",
-  "logging": {
-    "logLevel": {
-      "default": "Information",
-      "Function": "Information"
-    }
-  }
-}
-```
-
-### 探索順序
-
-`host.json` は現在の作業ディレクトリ (または `AzureWebJobsScriptRoot` 環境変数が設定されている場合はそのディレクトリ) から上に向かって探索されます:
-
-| 優先度 | ソース |
-|--------|--------|
-| 1 | `setup_logging()` に渡した明示的な `host_json_path` パラメータ |
-| 2 | `AzureWebJobsScriptRoot` 環境変数 |
-| 3 | `cwd/host.json` および各親ディレクトリ、最大 5 階層 |
-
-最初に存在する `host.json` が採用されます。`AzureWebJobsScriptRoot` はAzure Functions ホストが設定する公式の環境変数で、ディレクトリ自体のみを探索します (祖先ウォークなし)。
-
-最初に存在するファイルが採用されます。自動探索をバイパスするには (テストや非標準レイアウトなど)、明示的なパスを渡してください:
-
-```python
-from pathlib import Path
-from azure_functions_logging import setup_logging
-
-setup_logging(host_json_path=Path("/site/wwwroot/host.json"))
-```
-
-## ノイズ制御
-
-うるさいサードパーティロガーを削除せずに抑制します:
-
-```python
-from azure_functions_logging import SamplingFilter, setup_logging
-import logging
-
-setup_logging()
-
-# ノイズーな azure.* ロガーをサンプリング: 1 秒ウィンドウあたり最大 10 レコードを保持
-# ロガーにアタッチしたフィルターは、子ロガーから伝播されるレコードには実行されないため、
-# ルートハンドラーにアタッチし、ロガー名でスコープを限定します。
-for handler in logging.getLogger().handlers:
-    handler.addFilter(SamplingFilter(rate=10, name="azure"))
-
-# 本番で urllib3 を完全に沈黙
-logging.getLogger("urllib3").setLevel(logging.WARNING)
-```
-
-## PII Redaction
-
-機密フィールドが Application Insights に到達する前に削除します:
-
-```python
-from azure_functions_logging import RedactionFilter, setup_logging
-import logging
-
-setup_logging()
-root = logging.getLogger()
-# 名前付きの子ロガーから出力されるレコードもリダクトされるよう、フィルタはハンドラに付与します。
-for handler in root.handlers:
-    handler.addFilter(RedactionFilter(sensitive_keys=["password", "token", "secret"]))
-```
-
-extra フィールドのキーが sensitive キーと一致するすべてのログレコードは、その値が `***` で置き換えられます。
-
-## ローカル vs クラウド
-
-| 環境 | フォーマット | 動作 |
-|------|------------|------|
-| ローカルターミナル | `color` (デフォルト) | 色付きで人間が読める形式: `HH:MM:SS LEVEL logger  message [context...]` |
-| Azure / Core Tools | host-managed | コンテキストフィルタのみインストール; host ハンドラに NDJSON を強制するには `functions_formatter=JsonFormatter()` を渡す |
-| CI / パイプライン | `json` | NDJSON、機械パース可能 |
-
-`setup_logging()` は `FUNCTIONS_WORKER_RUNTIME` を検出し、Azure Functions / Core Tools とスタンドアロンのローカル実行を区別します。Azure モードではハンドラを追加せずにコンテキストフィルタをインストールします (host パイプラインからの重複出力を回避)。
-
-## コンテキストバインディング
-
-リクエストスコープのメタデータを各呼び出しに渡すことなく、すべてのログにアタッチします:
-
-```python
-def process_order(order_id: str) -> None:
-    order_logger = logger.bind(order_id=order_id, region="eastus")
-    order_logger.info("processing started")   # order_id + region を含む
-    order_logger.info("processing complete")  # 同じメタデータ、新しいメッセージ
-```
-
-呼び出しごとにバインドされたロガーを作成してください。モジュールレベルでキャッシュしないでください。
+→ [設定: 環境検出](https://yeongseon.github.io/azure-functions-logging-python/configuration/#environment-detection)
 
 ## いつ使うか
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -252,242 +252,53 @@ curl -s "https://<your-app>.azurewebsites.net/api/logme?correlation_id=demo-123"
 
 > koreacentral 리전의 임시 Azure Functions 배포로 검증되었습니다 (Python 3.12, Consumption plan). 응답은 캡처되었으며 URL은 익명화되었습니다.
 
-## 호출 컨텍스트 (Invocation Context)
+## 핵심 기능
 
-핸들러가 실행되는 동안 호출 컨텍스트를 바인딩하려면 `logging_context()`를 사용하세요. 다음을 설정합니다:
+아래 모든 기능은 [문서 사이트](https://yeongseon.github.io/azure-functions-logging-python/)에 전체 사용법이 있습니다. 이 섹션은 각 기능이 무엇을 하는지 요약하고 단일 출처로 링크하여, README가 문서의 사본이 아니라 빠른 개요로 유지되도록 합니다.
 
-- `invocation_id` — 실행마다 고유, 한 요청의 모든 로그를 상관시킴
-- `function_name` — Azure Functions 함수 이름
-- `trace_id` — 플랫폼의 trace 컨텍스트. 유효한 W3C `traceparent` 헤더에서만 추출되며, 유효성 검증이 엄격하여 잘못된 값은 무시됩니다
-- `cold_start` — 이 worker 프로세스의 첫 호출일 때 `True`
+### 호출 컨텍스트
 
-> **`cold_start` 의미.** `cold_start=True`는 *모듈 로드 후 이 Python worker 프로세스에서 관측된 첫 호출*을 의미합니다. **플랫폼 레벨**의 cold start 메트릭이 아니며, Azure Functions 메트릭이 보고하는 App Service plan / instance 할당 cold start와는 일치하지 않습니다. 같은 worker의 후속 호출은 worker가 재활용될 때까지 `cold_start=False`를 발행합니다.
+`logging_context(context)`([Quick Start](#quick-start) 참조)는 핸들러가 실행되는 동안 `invocation_id`, `function_name`, `trace_id`, `cold_start`를 바인딩하고, 종료 시 항상 이전 컨텍스트를 복원합니다. 더 낮은 수준의 제어가 필요하면 `inject_context()` / `restore_context()`를, 암묵적으로 주입하려면 `@with_context` 데코레이터(동기/비동기 핸들러 모두 지원)를 사용하세요.
 
-```python
-def my_function(req, context):
-    with logging_context(context):
-        logger.info("handler started")
-        # 이 시점부터의 모든 로그에 invocation_id와 cold_start 포함
-```
+> **`cold_start` 의미.** `cold_start=True`는 모듈 로드 이후 이 Python 워커 프로세스가 처음 관찰한 호출을 의미합니다. 플랫폼 수준의 콜드 스타트 지표가 **아닙니다**.
 
-저수준 제어 (예: 미들웨어)에는 `inject_context()`와 `restore_context()`를 사용하세요:
+→ [사용법: 컨텍스트 주입](https://yeongseon.github.io/azure-functions-logging-python/usage/#3-context-injection-in-azure-functions) · [API: `with_context`](https://yeongseon.github.io/azure-functions-logging-python/api/#with_context)
 
-```python
-tokens = inject_context(context)
-try:
-    logger.info("handler started")
-finally:
-    restore_context(tokens)
-```
+### 구조화된 JSON 출력
 
-컨텍스트 주입이 없으면 모든 로그 라인에서 이 필드들은 `None`입니다.
+`setup_logging(functions_formatter=JsonFormatter())`를 전달하면 호스트 관리 핸들러에서 Application Insights용 NDJSON을 출력합니다(독립 실행/CI에서는 `format="json"`). 추가 필드는 `extra` 아래에 들어가며, `truncate_native_strings=True`로 긴 문자열 값을 자를 수 있습니다.
 
-### `with_context` 데코레이터
+→ [사용법: JSON 출력](https://yeongseon.github.io/azure-functions-logging-python/usage/#2-json-output-for-production) · [API: `JsonFormatter`](https://yeongseon.github.io/azure-functions-logging-python/api/#jsonformatter)
 
-보일러플레이트를 줄이려면, `inject_context()`를 수동으로 호출하는 대신 `with_context` 데코레이터를 사용하세요:
+### host.json 충돌 감지
 
-```python
-import azure.functions as func
-from azure_functions_logging import get_logger, setup_logging, with_context
+시작 시 `host.json`(또는 `AzureFunctionsJobHost__logging__logLevel__...` 앱 설정 오버라이드)이 앱이 방출하는 레벨을 억제하면 경고합니다. `host.json`은 작업 디렉터리(또는 `AzureWebJobsScriptRoot`)에서 상위로 탐색하여 자동 발견되며, `host_json_path=`로 재정의할 수 있습니다.
 
-setup_logging()
-logger = get_logger(__name__)
+→ [구성: host.json 충돌](https://yeongseon.github.io/azure-functions-logging-python/configuration/#hostjson-level-conflict-warning) · [문제 해결](https://yeongseon.github.io/azure-functions-logging-python/troubleshooting/#hostjson-conflict-warning-appears)
 
-app = func.FunctionApp()
+### 노이즈 제어 및 PII Redaction
 
-@app.route(route="hello")
-@with_context
-def hello(req: func.HttpRequest, context: func.Context) -> func.HttpResponse:
-    logger.info("Request received")
-    return func.HttpResponse("OK")
-```
+`SamplingFilter`는 시끄러운 서드파티 로거(`azure-core`, `urllib3` 등)의 속도를 제한하고, `RedactionFilter`는 민감한 키(비밀번호, 토큰, 시크릿, 연결 문자열 등 — 대소문자 무시, 재귀적)를 로그 집계 전에 마스킹합니다. 둘 다 루트 핸들러에 연결하며, `sensitive_keys=[...]`로 사용자 지정할 수 있습니다.
 
-데코레이터는 이름으로 `context` 매개변수를 찾고, 핸들러 실행 전 `inject_context()`를 호출하며, 반환 후 `finally`에서 이전 컨텍스트를 복원합니다.
+→ [API: `SamplingFilter`](https://yeongseon.github.io/azure-functions-logging-python/api/#samplingfilter) · [API: `RedactionFilter`](https://yeongseon.github.io/azure-functions-logging-python/api/#redactionfilter)
 
-커스텀 매개변수 이름:
+### 컨텍스트 바인딩
 
-```python
-@with_context(param="ctx")
-def hello(req: func.HttpRequest, ctx: func.Context) -> func.HttpResponse:
-    ...
-```
+`logger.bind(key=value)`는 이후 모든 로그에 요청 범위 메타데이터를 첨부하는 로거를 반환합니다. 호출당 바운드 로거를 생성하고 모듈 레벨에서 캐싱하지 마세요.
 
-동기 및 비동기 핸들러가 모두 지원됩니다.
+→ [사용법: 컨텍스트 바인딩](https://yeongseon.github.io/azure-functions-logging-python/usage/#4-context-binding-with-functionloggerbind)
 
 ### 글로벌 LogRecordFactory (opt-in)
 
-`setup_logging()` 이후에 핸들러가 추가될 수 있거나, 핸들러/필터 구성과 무관하게 **모든** `LogRecord`에 호출 컨텍스트를 적용하고 싶은 애플리케이션에서는, 시작 시 글로벌 컨텍스트 팩토리를 한 번 설치하세요:
+`install_context_factory()`는 레코드 생성 시점에 컨텍스트를 주입하여 핸들러/필터 구성과 무관하게 **모든** `LogRecord`가 컨텍스트를 갖도록 합니다. `setup_logging()` 이후 핸들러가 추가되거나 로거가 필터 체인을 우회할 때 유용합니다. 기본 `ContextFilter` 모드와는 상호 배타적입니다.
 
-```python
-from azure_functions_logging import install_context_factory, setup_logging
+→ [구성: `use_record_factory`](https://yeongseon.github.io/azure-functions-logging-python/configuration/#parameter-use_record_factory) · [API: `install_context_factory`](https://yeongseon.github.io/azure-functions-logging-python/api/#install_context_factory)
 
-install_context_factory()  # record 생성 시점에 컨텍스트 주입
-setup_logging()
-```
+### 로컬 vs 클라우드
 
-활성화되면 `invocation_id`, `function_name`, `trace_id`, `cold_start`는 예약된 `LogRecord` 속성이 됩니다. stdlib `extra=`를 통해 이들을 전달하면 `KeyError`가 발생합니다. 키를 자동으로 정제하는 `FunctionLogger`를 사용하거나 다른 키 이름을 선택하세요.
+`setup_logging()`은 `FUNCTIONS_WORKER_RUNTIME`을 감지합니다: 로컬에서는 색상이 있는 사람이 읽기 쉬운 출력, Azure / Core Tools에서는 호스트 관리 NDJSON(컨텍스트 필터만 — 핸들러 중복 없음), CI에서는 기계가 파싱 가능한 JSON.
 
-> **`setup_logging()`과의 관계:** `use_record_factory=False` (기본값)일 때 `setup_logging()`은 핸들러에 `ContextFilter`를 설치합니다. 둘 다 호출해도 됩니다 — 동일한 값을 설정하므로 충돌이 없습니다. `install_context_factory()`는 나중에 추가되는 핸들러나 필터 체인을 우회하는 로거에서도 적용됨을 보장합니다.
->
-> `use_record_factory=True`일 때 `setup_logging()`은 팩토리 모드로 전환합니다: 기존 루트 핸들러에서 `ContextFilter` 인스턴스를 제거한 후 `LogRecordFactory`를 등록합니다. 이중 주입을 방지하면서 모든 레코드에 컨텍스트가 실리도록 보장합니다.
-## 구조화된 JSON 출력 (프로덕션)
-
-로그가 Application Insights나 어떤 집계 시스템으로 흘러갈 때는 JSON 포맷을 사용하세요:
-
-> **참고:** `format` 매개변수는 이 라이브러리가 생성한 핸들러 (로컬 개발)에만 영향을 줍니다.
-> Azure Functions에서는 host가 핸들러를 관리합니다. host가 관리하는 핸들러에 JSON 출력을 설정하려면
-> `functions_formatter=JsonFormatter()`를 사용하세요. Azure에서 `format="json"`을 전달하면 경고가 발생합니다.
-
-독립 실행형 로컬 개발 또는 CI 출력의 경우:
-
-```python
-setup_logging(format="json")
-```
-
-Azure Functions / Core Tools에서는 host가 핸들러를 소유합니다. 기존의 host 관리 핸들러에 JSON 포맷을 강제하려면:
-
-```python
-from azure_functions_logging import JsonFormatter, setup_logging
-
-setup_logging(functions_formatter=JsonFormatter())
-```
-
-로그 라인당 출력 (NDJSON — 한 줄에 한 JSON 객체):
-
-```json
-{"timestamp": "2024-01-15T10:30:00+00:00", "level": "INFO", "logger": "my_module",
- "message": "order accepted", "invocation_id": "abc-123", "function_name": "OrderHandler",
- "cold_start": false, "trace_id": "4bf92f3577b34da6a3ce929d0e0e4736", "exception": null,
- "extra": {"order_id": "o-999"}}
-```
-
-추가 필드는 발행되는 JSON의 `extra`에 포함됩니다. Application Insights에서 직접 인덱싱 가능한지 여부는 ingestion 파이프라인에 따라 다릅니다: JSON이 `customDimensions`로 파싱되는 경우 직접 쿼리 가능하며, JSON이 `message` 컬럼에 남아 있는 경우 먼저 `parse_json(message)`를 거쳐야 합니다.
-
-```python
-logger.info("order accepted", order_id="o-999", tenant_id="t-1")
-```
-
-### 긴 문자열 값 자르기 (opt-in)
-
-기본적으로 `JsonFormatter`는 `extra`의 문자열 값을 전체 길이 그대로 유지합니다.
-`truncate_native_strings=True`를 전달하면 `max_string_length` 문자 (기본값 2048)로 잘립니다.
-잘린 문자열은 `…` 접미사가 붙어 잘림 여부를 감지할 수 있습니다:
-
-```python
-from azure_functions_logging import JsonFormatter, setup_logging
-
-setup_logging(functions_formatter=JsonFormatter(
-    truncate_native_strings=True,
-    max_string_length=512,
-))
-```
-
-> **범위:** `extra`의 문자열 값만 잘립니다 (dict와 list를 재귀적으로 탐색).
-> `message` 필드, 정수, 실수, 불리언은 영향을 받지 않습니다.
-```
-
-## host.json 충돌 감지
-
-`host.json`이 앱이 발행하는 로그 레벨을 억제하면 시작 시 다음과 같은 경고가 표시됩니다:
-
-```
-host.json logLevel for default is set to 'Warning' which is more restrictive than the configured level 'INFO'. Logs below 'Warning' will be suppressed by the Azure Functions host.
-```
-
-권장 `host.json` 기본값:
-
-```json
-{
-  "version": "2.0",
-  "logging": {
-    "logLevel": {
-      "default": "Information",
-      "Function": "Information"
-    }
-  }
-}
-```
-
-### 발견 순서
-
-`host.json`은 현재 작업 디렉토리 (또는 `AzureWebJobsScriptRoot` 환경 변수가 설정된 경우 해당 디렉토리)에서 위로 올라가며 탐색됩니다:
-
-| 우선순위 | 소스 |
-|----------|------|
-| 1 | `setup_logging()`에 전달된 명시적 `host_json_path` 파라미터 |
-| 2 | `AzureWebJobsScriptRoot` 환경 변수 |
-| 3 | `cwd/host.json` 및 각 상위 디렉토리, 최대 5단계 |
-
-먼저 발견된 `host.json`이 사용됩니다. `AzureWebJobsScriptRoot`는 Azure Functions 호스트가 설정하는 공식 환경 변수이며, 해당 디렉토리 자체만 검사합니다 (상위 디렉토리 탐색 없음).
-
-먼저 발견된 파일이 사용됩니다. 자동 발견을 우회하려면 (예: 테스트 또는 비표준 레이아웃에서) 명시적 경로를 전달하세요:
-
-```python
-from pathlib import Path
-from azure_functions_logging import setup_logging
-
-setup_logging(host_json_path=Path("/site/wwwroot/host.json"))
-```
-
-## 노이즈 제어
-
-시끄러운 서드파티 로거를 제거하지 않고 억제하세요:
-
-```python
-from azure_functions_logging import SamplingFilter, setup_logging
-import logging
-
-setup_logging()
-
-# 시끄러운 azure.* 로거 샘플링: 1초 윈도우당 최대 10개 레코드 유지
-# 로거에 붙은 필터는 하위 로거에서 전파되는 레코드에는 실행되지 않으므로,
-# 루트 핸들러에 붙이고 로거 이름으로 범위를 제한하세요.
-for handler in logging.getLogger().handlers:
-    handler.addFilter(SamplingFilter(rate=10, name="azure"))
-
-# 프로덕션에서 urllib3를 완전히 침묵
-logging.getLogger("urllib3").setLevel(logging.WARNING)
-```
-
-## PII Redaction
-
-민감 필드가 Application Insights에 도달하기 전에 제거하세요:
-
-```python
-from azure_functions_logging import RedactionFilter, setup_logging
-import logging
-
-setup_logging()
-root = logging.getLogger()
-# 명명된 자식 로거의 레코드도 함께 정제되도록 필터를 핸들러에 부착합니다.
-for handler in root.handlers:
-    handler.addFilter(RedactionFilter(sensitive_keys=["password", "token", "secret"]))
-```
-
-extra 필드의 키가 sensitive 키와 일치하는 모든 로그 레코드는 해당 값이 `***`로 대체됩니다.
-
-## 로컬 vs 클라우드
-
-| 환경 | 포맷 | 동작 |
-|------|------|------|
-| 로컬 터미널 | `color` (기본) | 색상 적용된 읽기 쉬운 형식: `HH:MM:SS LEVEL logger  message [context...]` |
-| Azure / Core Tools | host-managed | 컨텍스트 필터만 설치; host 핸들러에 NDJSON을 강제하려면 `functions_formatter=JsonFormatter()`를 전달 |
-| CI / 파이프라인 | `json` | NDJSON, 머신 파싱 가능 |
-
-`setup_logging()`은 `FUNCTIONS_WORKER_RUNTIME`를 감지하여 Azure Functions / Core Tools와 로컬 독립 실행을 구분합니다. Azure 모드에서는 핸들러를 추가하지 않고 컨텍스트 필터만 설치합니다 (host 파이프라인의 중복 출력을 회피).
-
-## 컨텍스트 바인딩
-
-요청 범위 메타데이터를 모든 로그에 첨부하되, 모든 호출에 전달하지 않아도 됩니다:
-
-```python
-def process_order(order_id: str) -> None:
-    order_logger = logger.bind(order_id=order_id, region="eastus")
-    order_logger.info("processing started")   # order_id + region 포함
-    order_logger.info("processing complete")  # 동일한 메타데이터, 새 메시지
-```
-
-호출당 바운드 로거를 생성하세요. 모듈 레벨에서 캐싱하지 마세요.
+→ [구성: 환경 감지](https://yeongseon.github.io/azure-functions-logging-python/configuration/#environment-detection)
 
 ## 언제 사용하는가
 

--- a/README.md
+++ b/README.md
@@ -276,278 +276,53 @@ curl -s "https://<your-app>.azurewebsites.net/api/logme?correlation_id=demo-123"
 
 > Verified against a temporary Azure Functions deployment in koreacentral (Python 3.12, Consumption plan). Response captured and URL anonymized.
 
-## Invocation Context
+## Core capabilities
 
-Use `logging_context()` to bind invocation context for the duration of a handler. It sets:
+Every capability below has a full how-to on the [documentation site](https://yeongseon.github.io/azure-functions-logging-python/) — this section summarizes what each does and links to the single source, so the README stays a quick overview rather than a second copy of the docs.
 
-- `invocation_id` — unique per execution, correlates all logs for one request
-- `function_name` — the Azure Functions function name
-- `trace_id` — trace context from the platform; extracted only from valid W3C `traceparent` headers (strict validation, invalid values are ignored)
-- `cold_start` — `True` on first invocation of this worker process
+### Invocation context
 
-> **`cold_start` semantics.** `cold_start=True` means *the first invocation observed by this Python worker process after module load*. It is **not** a platform-level cold start metric and does not correspond to App Service plan / instance allocation cold starts reported by Azure Functions metrics. Subsequent invocations on the same worker emit `cold_start=False` until the worker is recycled.
+`logging_context(context)` (see [Quick Start](#quick-start)) binds `invocation_id`, `function_name`, `trace_id`, and `cold_start` for the duration of a handler and always restores the previous context on exit. For lower-level control use `inject_context()` / `restore_context()`, or the `@with_context` decorator to inject implicitly (sync and async handlers).
 
-```python
-def my_function(req, context):
-    with logging_context(context):
-        logger.info("handler started")
-        # every log from here carries invocation_id and cold_start
-```
+> **`cold_start` semantics.** `cold_start=True` means the first invocation observed by this Python worker process after module load — **not** a platform-level cold-start metric.
 
-For lower-level control (e.g. middleware), use `inject_context()` with `restore_context()`:
+→ [Usage: context injection](https://yeongseon.github.io/azure-functions-logging-python/usage/#3-context-injection-in-azure-functions) · [API: `with_context`](https://yeongseon.github.io/azure-functions-logging-python/api/#with_context)
 
-```python
-tokens = inject_context(context)
-try:
-    logger.info("handler started")
-finally:
-    restore_context(tokens)
-```
+### Structured JSON output
 
-Without context injection, these fields are `None` in every log line.
+Pass `setup_logging(functions_formatter=JsonFormatter())` to emit Application Insights-ready NDJSON on host-managed handlers (or `format="json"` for standalone/CI). Extra fields land under `extra`; opt into `truncate_native_strings=True` to clip long string values.
 
-### `with_context` Decorator
+→ [Usage: JSON output](https://yeongseon.github.io/azure-functions-logging-python/usage/#2-json-output-for-production) · [API: `JsonFormatter`](https://yeongseon.github.io/azure-functions-logging-python/api/#jsonformatter)
 
-For less boilerplate, use the `with_context` decorator instead of calling `inject_context()` manually:
+### host.json conflict detection
 
-```python
-import azure.functions as func
-from azure_functions_logging import get_logger, setup_logging, with_context
+At startup the library warns when your `host.json` — or `AzureFunctionsJobHost__logging__logLevel__...` app-setting overrides — suppresses levels your app emits. `host.json` is auto-discovered by walking up from the working directory (or `AzureWebJobsScriptRoot`); pass `host_json_path=` to override.
 
-setup_logging()
-logger = get_logger(__name__)
+→ [Configuration: host.json conflict](https://yeongseon.github.io/azure-functions-logging-python/configuration/#hostjson-level-conflict-warning) · [Troubleshooting](https://yeongseon.github.io/azure-functions-logging-python/troubleshooting/#hostjson-conflict-warning-appears)
 
-app = func.FunctionApp()
+### Noise control & PII redaction
 
-@app.route(route="hello")
-@with_context
-def hello(req: func.HttpRequest, context: func.Context) -> func.HttpResponse:
-    logger.info("Request received")
-    return func.HttpResponse("OK")
-```
+`SamplingFilter` rate-limits chatty third-party loggers (e.g. `azure-core`, `urllib3`); `RedactionFilter` masks sensitive keys (passwords, tokens, secrets, connection strings, and more — case-insensitive, recursive) before logs reach aggregation. Attach either to your root handlers, and pass `sensitive_keys=[...]` to customize redaction.
 
-The decorator finds the `context` parameter by name, calls `inject_context()` before your handler runs, and restores the previous context in `finally` after it returns.
+→ [API: `SamplingFilter`](https://yeongseon.github.io/azure-functions-logging-python/api/#samplingfilter) · [API: `RedactionFilter`](https://yeongseon.github.io/azure-functions-logging-python/api/#redactionfilter)
 
-Custom parameter name:
+### Context binding
 
-```python
-@with_context(param="ctx")
-def hello(req: func.HttpRequest, ctx: func.Context) -> func.HttpResponse:
-    ...
-```
+`logger.bind(key=value)` returns a logger that attaches request-scoped metadata to every subsequent log without threading it through each call. Create bound loggers per-invocation; don't cache them at module level.
 
-Both sync and async handlers are supported.
+→ [Usage: context binding](https://yeongseon.github.io/azure-functions-logging-python/usage/#4-context-binding-with-functionloggerbind)
 
 ### Global LogRecordFactory (opt-in)
 
-For applications where handlers may be added after `setup_logging()`, or where you want
-invocation context on **every** `LogRecord` regardless of handler/filter configuration,
-install the global context factory once at startup:
+`install_context_factory()` injects context at record-creation time so **every** `LogRecord` carries it regardless of handler/filter wiring — useful when handlers are added after `setup_logging()` or loggers bypass the filter chain. It is mutually exclusive with the default `ContextFilter` mode.
 
-```python
-from azure_functions_logging import install_context_factory, setup_logging
+→ [Configuration: `use_record_factory`](https://yeongseon.github.io/azure-functions-logging-python/configuration/#parameter-use_record_factory) · [API: `install_context_factory`](https://yeongseon.github.io/azure-functions-logging-python/api/#install_context_factory)
 
-install_context_factory()  # injects context at record creation time
-setup_logging()
-```
+### Local vs cloud
 
-When enabled, `invocation_id`, `function_name`, `trace_id`, and `cold_start` become
-reserved `LogRecord` attributes. Passing them via stdlib `extra=` will raise `KeyError`.
-Use `FunctionLogger` (which sanitizes keys automatically) or choose different key names.
+`setup_logging()` detects `FUNCTIONS_WORKER_RUNTIME`: colorized human-readable output locally, host-managed NDJSON in Azure / Core Tools (context filters only — no duplicate handlers), and machine-parseable JSON in CI.
 
-> **Relationship with `setup_logging()`:** When `use_record_factory=False` (default),
-> `setup_logging()` installs `ContextFilter` on handlers. You can call both — they set the
-> same values, so there is no conflict. `install_context_factory()` ensures coverage even on
-> handlers added later or loggers that bypass the filter chain.
->
-> When `use_record_factory=True`, `setup_logging()` switches to the factory mode: it actively
-> removes any `ContextFilter` instances from existing root handlers (cleanup), then registers
-> the `LogRecordFactory`. This avoids double-injection while ensuring all records carry context
-> regardless of handler/filter chain configuration.
-## Structured JSON Output (Production)
-
-Use JSON format when logs feed Application Insights or any aggregation system:
-
-> **Note:** The `format` parameter only affects handlers created by this library (local development).
-> In Azure Functions, the host manages handlers. Use `functions_formatter=JsonFormatter()` to set
-> JSON output on host-managed handlers. Passing `format="json"` in Azure emits a warning.
-
-For standalone local development or CI output:
-
-```python
-setup_logging(format="json")
-```
-
-For Azure Functions / Core Tools, the host owns the handlers. To force JSON
-formatting on existing host-managed handlers:
-
-```python
-from azure_functions_logging import JsonFormatter, setup_logging
-
-setup_logging(functions_formatter=JsonFormatter())
-```
-
-Output per log line (NDJSON — one JSON object per line):
-
-```json
-{"timestamp": "2024-01-15T10:30:00+00:00", "level": "INFO", "logger": "my_module",
- "message": "order accepted", "invocation_id": "abc-123", "function_name": "OrderHandler",
- "cold_start": false, "trace_id": "4bf92f3577b34da6a3ce929d0e0e4736", "exception": null,
- "extra": {"order_id": "o-999"}}
-```
-
-Extra fields appear under `extra` in the emitted JSON. Whether they are directly indexable in Application Insights depends on your ingestion pipeline: when JSON is parsed into `customDimensions` they are queryable directly; when the JSON stays in the `message` column you need `parse_json(message)` first.
-
-```python
-logger.info("order accepted", order_id="o-999", tenant_id="t-1")
-```
-
-### Truncating long string values (opt-in)
-
-By default, `JsonFormatter` leaves string values in `extra` at full length.
-Pass `truncate_native_strings=True` to clip them at `max_string_length` characters (default 2048).
-Truncated strings are suffixed with `…` so the cut-off is detectable:
-
-```python
-from azure_functions_logging import JsonFormatter, setup_logging
-
-setup_logging(functions_formatter=JsonFormatter(
-    truncate_native_strings=True,
-    max_string_length=512,  # clip strings longer than 512 chars
-))
-```
-
-> **Scope:** Only string values in `extra` are truncated (recursively through dicts and lists).
-> The `message` field, integers, floats, and booleans are not affected.
-> Unserializable objects fall through to the existing `_json_default` path which truncates
-> their `str()` representation to 2048 characters regardless of this setting.
-## host.json Conflict Detection
-
-If your `host.json` suppresses log levels that your app emits, you get this warning at startup:
-
-```
-host.json logLevel for default is set to 'Warning' which is more restrictive than the configured level 'INFO'. Logs below 'Warning' will be suppressed by the Azure Functions host.
-```
-
-Recommended `host.json` baseline:
-
-```json
-{
-  "version": "2.0",
-  "logging": {
-    "logLevel": {
-      "default": "Information",
-      "Function": "Information"
-    }
-  }
-}
-```
-
-### Discovery order
-
-`host.json` is located by walking up from the current working directory (or from
-`AzureWebJobsScriptRoot` when that environment variable is set):
-
-| Priority | Source |
-|----------|--------|
-| 1 | Explicit `host_json_path` parameter passed to `setup_logging()` |
-| 2 | `AzureWebJobsScriptRoot` environment variable |
-| 3 | `cwd/host.json` and each parent directory, up to 5 levels |
-
-The first existing `host.json` wins. `AzureWebJobsScriptRoot` is the canonical env var
-set by the Azure Functions host; only the directory itself is probed (no ancestor walk).
-The first existing file wins. To bypass auto-discovery (e.g. in tests or
-non-standard layouts), pass an explicit path:
-
-The warning also considers Azure Functions app setting overrides that use the
-`AzureFunctionsJobHost__logging__logLevel__...` convention, for example
-`AzureFunctionsJobHost__logging__logLevel__Function__MyFunction=Warning`.
-
-```python
-from pathlib import Path
-from azure_functions_logging import setup_logging
-
-setup_logging(host_json_path=Path("/site/wwwroot/host.json"))
-```
-
-## Noise Control
-
-Suppress chatty third-party loggers without removing them:
-
-```python
-from azure_functions_logging import SamplingFilter, setup_logging
-import logging
-
-setup_logging()
-
-# Sample noisy azure.* loggers: keep up to 10 records per logger per 1-second window.
-# Filters attached to a logger don't run for records propagated from
-# descendants, so attach to the root handlers and scope by logger name.
-for handler in logging.getLogger().handlers:
-    handler.addFilter(SamplingFilter(rate=10, name="azure", per_logger=True))
-
-# Silence urllib3 completely in production
-logging.getLogger("urllib3").setLevel(logging.WARNING)
-```
-
-## PII Redaction
-
-Strip sensitive fields before they reach Application Insights:
-
-```python
-from azure_functions_logging import RedactionFilter, setup_logging
-import logging
-
-setup_logging()
-root = logging.getLogger()
-# Attach the filter to handlers so records from named child loggers are also redacted.
-for handler in root.handlers:
-    handler.addFilter(RedactionFilter())
-```
-
-Any log record with extra fields whose keys match a sensitive key will have those values replaced with `***`.
-
-**Default sensitive keys** (case-insensitive, applied to nested dicts and lists too):
-
-| Key | Key | Key |
-|-----|-----|-----|
-| `password` | `passwd` | `pwd` |
-| `token` | `access_token` | `refresh_token` |
-| `id_token` | `authorization` | `auth` |
-| `secret` | `client_secret` | `secret_key` |
-| `api_key` | `apikey` | `subscription_key` |
-| `connection_string` | `conn_str` | `sas_token` |
-| `x_functions_key` | `function_key` | `master_key` |
-| `private_key` | `credential` | |
-
-Pass `sensitive_keys=[...]` to override with your own list:
-
-```python
-handler.addFilter(RedactionFilter(sensitive_keys=["account_number", "ssn"]))
-```
-
-## Local vs Cloud
-
-| Environment | Format | Behavior |
-|-------------|--------|---------|
-| Local terminal | `color` (default) | Colorized human-readable: `HH:MM:SS LEVEL logger  message [context...]` |
-| Azure / Core Tools | host-managed | Installs context filters only; pass `functions_formatter=JsonFormatter()` to force NDJSON on host handlers |
-| CI / pipeline | `json` | NDJSON, machine-parseable |
-
-`setup_logging()` detects `FUNCTIONS_WORKER_RUNTIME` to distinguish Azure Functions / Core Tools from standalone local execution. In Azure mode it installs context filters without adding handlers (avoids duplicate output from the host pipeline).
-
-## Context Binding
-
-Attach request-scoped metadata to every log without passing it through every call:
-
-```python
-def process_order(order_id: str) -> None:
-    order_logger = logger.bind(order_id=order_id, region="eastus")
-    order_logger.info("processing started")   # includes order_id + region
-    order_logger.info("processing complete")  # same metadata, new message
-```
-
-Create bound loggers per-invocation. Do not cache them at module level.
+→ [Configuration: environment detection](https://yeongseon.github.io/azure-functions-logging-python/configuration/#environment-detection)
 
 ## When to use
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -252,246 +252,53 @@ curl -s "https://<your-app>.azurewebsites.net/api/logme?correlation_id=demo-123"
 
 > 已在 koreacentral 区域的临时 Azure Functions 部署上验证 (Python 3.12, Consumption plan)。已捕获响应，并对 URL 进行匿名化。
 
-## 调用上下文 (Invocation Context)
+## 核心功能
 
-使用 `logging_context()` 在处理程序运行期间绑定调用上下文。它会设置:
+下面每一项能力在[文档站点](https://yeongseon.github.io/azure-functions-logging-python/)上都有完整的操作指南 —— 本节只概述每项能力的作用并链接到唯一来源，从而让 README 保持为快速概览，而不是文档的第二份副本。
 
-- `invocation_id` — 每次执行唯一，关联一个请求的所有日志
-- `function_name` — Azure Functions 函数名
-- `trace_id` — 来自平台的 trace 上下文；仅从有效的 W3C `traceparent` 头中提取（严格校验，无效值会被忽略）
-- `cold_start` — 此 worker 进程的首次调用时为 `True`
+### 调用上下文
 
-> **`cold_start` 语义。** `cold_start=True` 表示 *模块加载后此 Python worker 进程观察到的首次调用*。它**不是**平台级别的冷启动指标，与 Azure Functions 指标报告的 App Service plan / instance 分配冷启动不对应。在同一 worker 上的后续调用，在 worker 被回收之前会发出 `cold_start=False`。
+`logging_context(context)`（参见 [Quick Start](#quick-start)）在处理函数执行期间绑定 `invocation_id`、`function_name`、`trace_id` 和 `cold_start`，并始终在退出时恢复先前的上下文。如需更底层的控制，可使用 `inject_context()` / `restore_context()`，或使用 `@with_context` 装饰器隐式注入（支持同步和异步处理函数）。
 
-```python
-def my_function(req, context):
-    with logging_context(context):
-        logger.info("handler started")
-        # 从此处开始的每条日志都带有 invocation_id 和 cold_start
-```
+> **`cold_start` 语义。** `cold_start=True` 表示本 Python worker 进程在模块加载后观察到的首次调用 —— **并非**平台级别的冷启动指标。
 
-如需较低级别的控制 (例如中间件)，请使用 `inject_context()` 配合 `restore_context()`:
+→ [Usage: context injection](https://yeongseon.github.io/azure-functions-logging-python/usage/#3-context-injection-in-azure-functions) · [API: `with_context`](https://yeongseon.github.io/azure-functions-logging-python/api/#with_context)
 
-```python
-tokens = inject_context(context)
-try:
-    logger.info("handler started")
-finally:
-    restore_context(tokens)
-```
+### 结构化 JSON 输出
 
-不进行上下文注入时，每条日志中这些字段都为 `None`。
+传入 `setup_logging(functions_formatter=JsonFormatter())`，即可在宿主托管的 handler 上输出可直接用于 Application Insights 的 NDJSON（或用 `format="json"` 用于独立/CI 场景）。额外字段会归入 `extra`；可选择开启 `truncate_native_strings=True` 以裁剪过长的字符串值。
 
-### `with_context` 装饰器
+→ [Usage: JSON output](https://yeongseon.github.io/azure-functions-logging-python/usage/#2-json-output-for-production) · [API: `JsonFormatter`](https://yeongseon.github.io/azure-functions-logging-python/api/#jsonformatter)
 
-为减少样板代码，可使用 `with_context` 装饰器代替手动调用 `inject_context()`:
+### host.json 冲突检测
 
-```python
-import azure.functions as func
-from azure_functions_logging import get_logger, setup_logging, with_context
+启动时，当你的 `host.json` —— 或 `AzureFunctionsJobHost__logging__logLevel__...` 应用设置覆盖 —— 抑制了应用实际发出的日志级别时，本库会发出警告。`host.json` 会从工作目录（或 `AzureWebJobsScriptRoot`）向上遍历自动发现；可传入 `host_json_path=` 覆盖。
 
-setup_logging()
-logger = get_logger(__name__)
+→ [Configuration: host.json conflict](https://yeongseon.github.io/azure-functions-logging-python/configuration/#hostjson-level-conflict-warning) · [Troubleshooting](https://yeongseon.github.io/azure-functions-logging-python/troubleshooting/#hostjson-conflict-warning-appears)
 
-app = func.FunctionApp()
+### 噪声控制与 PII 脱敏
 
-@app.route(route="hello")
-@with_context
-def hello(req: func.HttpRequest, context: func.Context) -> func.HttpResponse:
-    logger.info("Request received")
-    return func.HttpResponse("OK")
-```
+`SamplingFilter` 对话痨式的第三方 logger（如 `azure-core`、`urllib3`）进行限流；`RedactionFilter` 在日志到达聚合之前对敏感键（密码、令牌、密钥、连接字符串等 —— 不区分大小写、递归）进行掩码。将两者中的任意一个附加到根 handler，并可传入 `sensitive_keys=[...]` 自定义脱敏。
 
-装饰器按名称查找 `context` 参数，在处理程序运行前调用 `inject_context()`，并在返回后的 `finally` 中恢复先前上下文。
+→ [API: `SamplingFilter`](https://yeongseon.github.io/azure-functions-logging-python/api/#samplingfilter) · [API: `RedactionFilter`](https://yeongseon.github.io/azure-functions-logging-python/api/#redactionfilter)
 
-自定义参数名:
+### 上下文绑定
 
-```python
-@with_context(param="ctx")
-def hello(req: func.HttpRequest, ctx: func.Context) -> func.HttpResponse:
-    ...
-```
+`logger.bind(key=value)` 返回一个 logger，它会把请求作用域的元数据附加到之后的每一条日志上，而无需逐次调用传递。请按调用创建绑定的 logger；不要在模块级别缓存它们。
 
-支持同步与异步处理程序。
+→ [Usage: context binding](https://yeongseon.github.io/azure-functions-logging-python/usage/#4-context-binding-with-functionloggerbind)
 
-### 全局 LogRecordFactory (opt-in)
+### 全局 LogRecordFactory（可选启用）
 
-对于在 `setup_logging()` 之后可能添加处理程序的应用，或希望无论处理程序/过滤器如何配置都让 **每个** `LogRecord` 都带有调用上下文的应用，请在启动时安装一次全局上下文工厂:
+`install_context_factory()` 在记录创建时注入上下文，因此**每一条** `LogRecord` 都会携带上下文，而不受 handler/filter 接线方式的影响 —— 当 handler 在 `setup_logging()` 之后才添加，或 logger 绕过 filter 链时尤其有用。它与默认的 `ContextFilter` 模式互斥。
 
-```python
-from azure_functions_logging import install_context_factory, setup_logging
+→ [Configuration: `use_record_factory`](https://yeongseon.github.io/azure-functions-logging-python/configuration/#parameter-use_record_factory) · [API: `install_context_factory`](https://yeongseon.github.io/azure-functions-logging-python/api/#install_context_factory)
 
-install_context_factory()  # 在记录创建时注入上下文
-setup_logging()
-```
+### 本地 vs 云端
 
-启用后，`invocation_id`、`function_name`、`trace_id` 和 `cold_start` 将成为保留的 `LogRecord` 属性。通过 stdlib `extra=` 传递它们将引发 `KeyError`。请使用 `FunctionLogger` (它会自动清理键名) 或选择不同的键名。
+`setup_logging()` 会检测 `FUNCTIONS_WORKER_RUNTIME`：本地输出彩色可读格式，在 Azure / Core Tools 中输出宿主托管的 NDJSON（仅 context filter —— 不添加重复 handler），在 CI 中输出机器可解析的 JSON。
 
-> **与 `setup_logging()` 的关系:** 当 `use_record_factory=False` (默认値) 时，`setup_logging()` 会在处理程序上安装 `ContextFilter`。两者可以同时调用 — 它们设置相同的値，因此不会冲突。`install_context_factory()` 确保在稍后添加的处理程序或绕过过滤器链的 logger 上也能覆盖。
->
-> 当 `use_record_factory=True` 时，`setup_logging()` 切换到工厂模式: 先从现有 root 处理程序中删除所有 `ContextFilter` 实例，然后注册 `LogRecordFactory`。这样可以防止重复注入，同时确保所有记录都携带上下文。
-## 结构化 JSON 输出 (生产)
-
-当日志流向 Application Insights 或任何聚合系统时，请使用 JSON 格式:
-
-> **注意:** `format` 参数仅影响本库创建的处理程序 (本地开发)。
-> 在 Azure Functions 中，host 管理处理程序。要在 host 管理的处理程序上设置 JSON 输出，请使用
-> `functions_formatter=JsonFormatter()`。在 Azure 中传递 `format="json"` 会发出警告。
-
-对于独立的本地开发或 CI 输出:
-
-```python
-setup_logging(format="json")
-```
-
-对于 Azure Functions / Core Tools，host 拥有处理程序。要在现有的 host 管理处理程序上强制使用 JSON 格式:
-
-```python
-from azure_functions_logging import JsonFormatter, setup_logging
-
-setup_logging(functions_formatter=JsonFormatter())
-```
-
-每行日志输出 (NDJSON — 每行一个 JSON 对象):
-
-```json
-{"timestamp": "2024-01-15T10:30:00+00:00", "level": "INFO", "logger": "my_module",
- "message": "order accepted", "invocation_id": "abc-123", "function_name": "OrderHandler",
- "cold_start": false, "trace_id": "4bf92f3577b34da6a3ce929d0e0e4736", "exception": null,
- "extra": {"order_id": "o-999"}}
-```
-
-额外字段出现在发出的 JSON 的 `extra` 中。在 Application Insights 中是否可直接索引取决于您的 ingestion 管道: 当 JSON 被解析为 `customDimensions` 时可直接查询；当 JSON 保留在 `message` 列中时，需要先使用 `parse_json(message)`。
-
-```python
-logger.info("order accepted", order_id="o-999", tenant_id="t-1")
-```
-
-### 裁剪长字符串値 (opt-in)
-
-默认情况下，`JsonFormatter` 对 `extra` 中的字符串値保持完整长度。
-传入 `truncate_native_strings=True` 可将它们裁剪到 `max_string_length` 个字符 (默认 2048)。
-被裁剪的字符串会以 `…` 后缀结尾，使调用者可以检测到裁剪:
-
-```python
-from azure_functions_logging import JsonFormatter, setup_logging
-
-setup_logging(functions_formatter=JsonFormatter(
-    truncate_native_strings=True,
-    max_string_length=512,
-))
-```
-
-> **范围:** 仅裁剪 `extra` 中的字符串値 (递归遍历 dict 和 list)。
-> `message` 字段、整数、浮点数和布尔子不受影响。
-
-```python
-logger.info("order accepted", order_id="o-999", tenant_id="t-1")
-```
-
-## host.json 冲突检测
-
-如果您的 `host.json` 抑制了应用发出的日志级别，启动时会出现以下警告:
-
-```
-host.json logLevel for default is set to 'Warning' which is more restrictive than the configured level 'INFO'. Logs below 'Warning' will be suppressed by the Azure Functions host.
-```
-
-推荐的 `host.json` 基线:
-
-```json
-{
-  "version": "2.0",
-  "logging": {
-    "logLevel": {
-      "default": "Information",
-      "Function": "Information"
-    }
-  }
-}
-```
-
-### 发现顺序
-
-`host.json` 通过从当前工作目录 (或 `AzureWebJobsScriptRoot` 环境变量指向的目录) 向上遍历来定位:
-
-| 优先级 | 来源 |
-|--------|------|
-| 1 | 传入 `setup_logging()` 的显式 `host_json_path` 参数 |
-| 2 | `AzureWebJobsScriptRoot` 环境变量 |
-| 3 | `cwd/host.json` 及各父目录，最多 5 层 |
-
-第一个存在的 `host.json` 被采用。`AzureWebJobsScriptRoot` 是 Azure Functions 主机设置的官方环境变量，仅探测该目录本身 (不进行祖先遍历)。
-
-第一个存在的文件被采用。要绕过自动发现 (例如在测试或非标准布局中)，请传递显式路径:
-
-```python
-from pathlib import Path
-from azure_functions_logging import setup_logging
-
-setup_logging(host_json_path=Path("/site/wwwroot/host.json"))
-```
-
-## 噪声控制
-
-在不删除嘈杂第三方 logger 的情况下抑制它们:
-
-```python
-from azure_functions_logging import SamplingFilter, setup_logging
-import logging
-
-setup_logging()
-
-# 对吵闹的 azure.* logger 进行采样: 每 1 秒窗口保留最多 10 条记录
-# 附加到 logger 的过滤器不会对从子 logger 传播的记录运行，
-# 所以附加到根处理程序并按 logger 名称限定范围。
-for handler in logging.getLogger().handlers:
-    handler.addFilter(SamplingFilter(rate=10, name="azure"))
-
-# 在生产环境完全静默 urllib3
-logging.getLogger("urllib3").setLevel(logging.WARNING)
-```
-
-## PII Redaction
-
-在敏感字段到达 Application Insights 之前剥离它们:
-
-```python
-from azure_functions_logging import RedactionFilter, setup_logging
-import logging
-
-setup_logging()
-root = logging.getLogger()
-# 将过滤器附加到处理程序，以便命名子 logger 的记录也被脱敏。
-for handler in root.handlers:
-    handler.addFilter(RedactionFilter(sensitive_keys=["password", "token", "secret"]))
-```
-
-extra 字段中键名匹配 sensitive 键的任何日志记录将其值替换为 `***`。
-
-## 本地 vs 云端
-
-| 环境 | 格式 | 行为 |
-|------|------|------|
-| 本地终端 | `color` (默认) | 彩色人类可读格式: `HH:MM:SS LEVEL logger  message [context...]` |
-| Azure / Core Tools | host-managed | 仅安装上下文过滤器；通过 `functions_formatter=JsonFormatter()` 在 host 处理程序上强制 NDJSON |
-| CI / 管道 | `json` | NDJSON, 机器可解析 |
-
-`setup_logging()` 检测 `FUNCTIONS_WORKER_RUNTIME` 以区分 Azure Functions / Core Tools 与本地独立运行。在 Azure 模式下，它不添加处理程序仅安装上下文过滤器（避免来自 host 管道的重复输出）。
-
-## 上下文绑定
-
-将请求范围的元数据附加到每条日志，而无需在每次调用中传递它:
-
-```python
-def process_order(order_id: str) -> None:
-    order_logger = logger.bind(order_id=order_id, region="eastus")
-    order_logger.info("processing started")   # 包含 order_id + region
-    order_logger.info("processing complete")  # 相同元数据，新消息
-```
-
-按调用创建绑定的 logger。不要在模块级别缓存它们。
-
+→ [Configuration: environment detection](https://yeongseon.github.io/azure-functions-logging-python/configuration/#environment-detection)
 ## 何时使用
 
 - 您需要在 Application Insights 中获得结构化、可查询的日志时

--- a/docs/api.md
+++ b/docs/api.md
@@ -136,6 +136,7 @@ except RuntimeError:
 - Use indirectly via `setup_logging(format="json")` for most cases.
 - Produces one JSON object per line (NDJSON style).
 - Includes context fields when available on log records.
+- Pass `truncate_native_strings=True` to clip string values in `extra` at `max_string_length` characters (default 2048); truncated values are suffixed with `…`. Only strings in `extra` are affected (recursively through dicts/lists) — `message`, ints, floats, and booleans are left intact.
 
 ### Example: Automatic Selection
 


### PR DESCRIPTION
## Summary
- Replace the deep how-to sections that were duplicated from the docs site with a concise **Core capabilities** overview that summarizes each capability and links to the single source on the documentation site.
- Keep the README a strong quick overview: badges, why/what, pipeline, Before/After (incl. App Insights KQL), installation, Quick Start, verification, when-to-use, ecosystem, AI-assistant notes.
- Mirror the exact structure across `README.ko.md`, `README.ja.md`, and `README.zh-CN.md`.
- Add the `truncate_native_strings` note to `docs/api.md` (its only previous home was the README) so no content is lost before trimming.

## Verification
- `mkdocs build --strict` passes with no new warnings.
- README reduced 641 → 416 lines; i18n variants trimmed in lockstep.

Closes #211