### PR TITLE
refactor(metadata): type the logging cross-package metadata contract

### DIFF
--- a/src/azure_functions_logging/_decorator.py
+++ b/src/azure_functions_logging/_decorator.py
@@ -13,12 +13,13 @@ import inspect
 from typing import Any, Callable, TypeVar, overload
 
 from ._context import inject_context, restore_context
+from ._metadata import LoggingMetadata, read_logging_metadata, set_logging_metadata
 
 _F = TypeVar("_F", bound=Callable[..., Any])
 
 _DEFAULT_PARAM = "context"
 
-_TOOLKIT_META_ATTR = "_azure_functions_metadata"
+
 
 
 _SAFE_COPY_ATTRS = ("__name__", "__qualname__", "__doc__", "__module__")
@@ -51,23 +52,11 @@ def _copy_safe_metadata(wrapper: Callable[..., Any], func: Callable[..., Any]) -
     wrapper.__annotations__ = dict(getattr(func, "__annotations__", {}) or {})
 
 
-def _merge_toolkit_metadata_into_wrapper(
-    wrapper: Callable[..., Any],
-    func: Callable[..., Any],
-    namespace: str,
-    payload: dict[str, Any],
-) -> None:
-    """Merge toolkit metadata onto ``wrapper`` only, seeded from ``func``.
+def _build_logging_payload(param: str) -> LoggingMetadata:
+    """Construct the typed ``logging`` namespace payload."""
+    return {"version": 1, "context_param": param}
 
-    Reads any pre-existing convention attribute from ``func`` (set by other
-    decorators applied before this one), merges in our ``namespace`` payload,
-    and writes the result onto ``wrapper``. The original ``func`` is left
-    untouched so the metadata never leaks onto undecorated references.
-    """
-    existing: Any = getattr(func, _TOOLKIT_META_ATTR, None)
-    base: dict[str, Any] = dict(existing) if isinstance(existing, dict) else {}
-    base[namespace] = payload
-    setattr(wrapper, _TOOLKIT_META_ATTR, base)
+
 
 def _find_context_arg(
     func: Callable[..., Any],
@@ -108,9 +97,7 @@ def _wrap_sync(func: _F, param: str) -> _F:
             restore_context(tokens)
 
     _copy_safe_metadata(wrapper, func)
-    _merge_toolkit_metadata_into_wrapper(
-        wrapper, func, "logging", {"version": 1, "context_param": param}
-    )
+    set_logging_metadata(wrapper, func, _build_logging_payload(param))
     return wrapper  # type: ignore[return-value]
 
 
@@ -129,9 +116,7 @@ def _wrap_async(func: _F, param: str) -> _F:
             restore_context(tokens)
 
     _copy_safe_metadata(wrapper, func)
-    _merge_toolkit_metadata_into_wrapper(
-        wrapper, func, "logging", {"version": 1, "context_param": param}
-    )
+    set_logging_metadata(wrapper, func, _build_logging_payload(param))
     return wrapper  # type: ignore[return-value]
 
 
@@ -192,9 +177,5 @@ def get_logging_metadata(func: Any) -> dict[str, Any] | None:
 
     Returns ``None`` if the function has no logging metadata attached.
     """
-    toolkit_meta = getattr(func, _TOOLKIT_META_ATTR, None)
-    if isinstance(toolkit_meta, dict):
-        meta = toolkit_meta.get("logging")
-        if isinstance(meta, dict):
-            return meta
-    return None
+    meta = read_logging_metadata(func)
+    return dict(meta) if meta is not None else None

--- a/src/azure_functions_logging/_metadata.py
+++ b/src/azure_functions_logging/_metadata.py
@@ -1,0 +1,69 @@
+"""Typed cross-package metadata contract for the ``logging`` namespace.
+
+Toolkit convention (shared across the Azure Functions Python DX Toolkit):
+decorators attach an ``_azure_functions_metadata`` dict onto the wrapped
+handler, keyed by a package-owned *namespace* string, so sibling packages can
+discover metadata **without importing this package**.
+
+This module gives the ``"logging"`` namespace payload a checked ``TypedDict``
+shape plus a single merge helper. The contract is intentionally *replicated*
+across toolkit packages (not shared via a runtime dependency); keep the
+``_BaseMetadata`` ``version`` field and the merge-without-clobber semantics
+identical to the sibling packages.
+
+Ref: https://github.com/yeongseon/azure-functions-logging-python/issues/216
+"""
+
+from __future__ import annotations
+
+from typing import Any, TypedDict, cast
+
+#: Convention attribute name shared across all toolkit packages.
+METADATA_ATTR = "_azure_functions_metadata"
+
+#: Namespace owned by this package.
+NAMESPACE = "logging"
+
+#: Schema version for the ``logging`` namespace payload.
+LOGGING_METADATA_VERSION = 1
+
+
+class _BaseMetadata(TypedDict):
+    """Fields common to every toolkit namespace payload."""
+
+    version: int
+
+
+class LoggingMetadata(_BaseMetadata):
+    """Shape of ``_azure_functions_metadata["logging"]`` (schema version 1)."""
+
+    context_param: str
+
+
+def set_logging_metadata(
+    wrapper: Any,
+    func: Any,
+    payload: LoggingMetadata,
+) -> None:
+    """Merge the ``logging`` namespace onto ``wrapper`` without clobbering others.
+
+    Seeds from any pre-existing convention attribute on ``func`` (set by other
+    decorators applied before this one), merges in ``payload`` under the
+    ``logging`` namespace, and writes the result onto ``wrapper`` only. The
+    original ``func`` is left untouched so the metadata never leaks onto
+    undecorated references.
+    """
+    existing = getattr(func, METADATA_ATTR, None)
+    base: dict[str, Any] = dict(existing) if isinstance(existing, dict) else {}
+    base[NAMESPACE] = payload
+    setattr(wrapper, METADATA_ATTR, base)
+
+
+def read_logging_metadata(func: Any) -> LoggingMetadata | None:
+    """Return the typed ``logging`` namespace payload, or ``None`` if absent."""
+    md = getattr(func, METADATA_ATTR, None)
+    if isinstance(md, dict):
+        entry = md.get(NAMESPACE)
+        if isinstance(entry, dict):
+            return cast("LoggingMetadata", entry)
+    return None

--- a/tests/test_metadata_contract.py
+++ b/tests/test_metadata_contract.py
@@ -1,0 +1,100 @@
+"""Tests for the typed cross-package metadata contract (``_metadata``)."""
+
+from __future__ import annotations
+
+from azure_functions_logging._metadata import (
+    LOGGING_METADATA_VERSION,
+    METADATA_ATTR,
+    NAMESPACE,
+    read_logging_metadata,
+    set_logging_metadata,
+)
+
+
+class TestContractConstants:
+    def test_attr_name_is_toolkit_convention(self) -> None:
+        assert METADATA_ATTR == "_azure_functions_metadata"
+
+    def test_namespace_is_logging(self) -> None:
+        assert NAMESPACE == "logging"
+
+    def test_version_constant(self) -> None:
+        assert LOGGING_METADATA_VERSION == 1
+
+
+class TestSetLoggingMetadata:
+    def test_writes_payload_onto_wrapper_only(self) -> None:
+        def func() -> None:
+            pass
+
+        def wrapper() -> None:
+            pass
+
+        set_logging_metadata(wrapper, func, {"version": 1, "context_param": "context"})
+
+        assert not hasattr(func, METADATA_ATTR)
+        meta = getattr(wrapper, METADATA_ATTR)
+        assert meta == {"logging": {"version": 1, "context_param": "context"}}
+
+    def test_seeds_from_existing_namespaces_on_func(self) -> None:
+        def func() -> None:
+            pass
+
+        def wrapper() -> None:
+            pass
+
+        setattr(func, METADATA_ATTR, {"db": {"version": 1, "bindings": []}})
+        set_logging_metadata(wrapper, func, {"version": 1, "context_param": "ctx"})
+
+        meta = getattr(wrapper, METADATA_ATTR)
+        assert meta["db"] == {"version": 1, "bindings": []}
+        assert meta["logging"] == {"version": 1, "context_param": "ctx"}
+
+    def test_ignores_non_dict_existing_attr(self) -> None:
+        def func() -> None:
+            pass
+
+        def wrapper() -> None:
+            pass
+
+        setattr(func, METADATA_ATTR, "not-a-dict")
+        set_logging_metadata(wrapper, func, {"version": 1, "context_param": "context"})
+
+        meta = getattr(wrapper, METADATA_ATTR)
+        assert meta == {"logging": {"version": 1, "context_param": "context"}}
+
+
+class TestReadLoggingMetadata:
+    def test_returns_payload_when_present(self) -> None:
+        def func() -> None:
+            pass
+
+        setattr(func, METADATA_ATTR, {"logging": {"version": 1, "context_param": "c"}})
+        assert read_logging_metadata(func) == {"version": 1, "context_param": "c"}
+
+    def test_returns_none_when_attr_missing(self) -> None:
+        def func() -> None:
+            pass
+
+        assert read_logging_metadata(func) is None
+
+    def test_returns_none_when_attr_not_dict(self) -> None:
+        def func() -> None:
+            pass
+
+        setattr(func, METADATA_ATTR, "not-a-dict")
+        assert read_logging_metadata(func) is None
+
+    def test_returns_none_when_namespace_absent(self) -> None:
+        def func() -> None:
+            pass
+
+        setattr(func, METADATA_ATTR, {"db": {"version": 1}})
+        assert read_logging_metadata(func) is None
+
+    def test_returns_none_when_namespace_not_dict(self) -> None:
+        def func() -> None:
+            pass
+
+        setattr(func, METADATA_ATTR, {"logging": "not-a-dict"})
+        assert read_logging_metadata(func) is None


### PR DESCRIPTION
## Summary
- Add `src/azure_functions_logging/_metadata.py` giving the `_azure_functions_metadata["logging"]` payload a checked `TypedDict` shape (`LoggingMetadata`), a `_BaseMetadata` base carrying the shared `version` field, the `METADATA_ATTR` / `NAMESPACE` constants, and a `LOGGING_METADATA_VERSION` constant.
- Provide a single `set_logging_metadata` merge-without-clobber helper (seeds from the pre-existing attr, writes onto the wrapper only) plus a typed `read_logging_metadata` accessor.
- Route `with_context` through the typed helper; `get_logging_metadata()` now delegates to it. **Behavior-preserving** — the runtime dict shape is unchanged.

## Contract design
Per the toolkit convention, the contract is *replicated* per repo (no cross-package runtime import). This lands the **logging** side; sibling PRs will type the `validation`, `langgraph`, and `db` namespaces with the same `_BaseMetadata` + per-namespace `version` pattern, and `openapi` keeps a read-side mirror.

## Verification
- `make typecheck` clean (mypy, 28 files).
- Full suite green, coverage **96.24%** (≥95% gate).
- New `tests/test_metadata_contract.py` covers merge/seed/read edge cases.

Part of #216