### PR TITLE
feat(context): add extra_context_vars extension point for custom context providers

### DIFF
--- a/src/azure_functions_logging/_context.py
+++ b/src/azure_functions_logging/_context.py
@@ -63,12 +63,37 @@ class ContextFilter(logging.Filter):
         "cold_start",
     )
 
+    def __init__(
+        self,
+        extra_context_vars: dict[str, contextvars.ContextVar[Any]] | None = None,
+    ) -> None:
+        """Create the filter, optionally injecting *extra_context_vars*.
+
+        Args:
+            extra_context_vars: Optional mapping of ``field_name -> ContextVar``.
+                Each variable's current value is copied onto the LogRecord under
+                ``field_name`` in addition to the four built-in context fields.
+                Field names must not collide with the built-in context fields.
+        """
+        super().__init__()
+        extra = extra_context_vars or {}
+        collisions = set(extra) & set(self.CONTEXT_FIELDS)
+        if collisions:
+            msg = (
+                "extra_context_vars field names collide with built-in "
+                f"context fields: {', '.join(sorted(collisions))}"
+            )
+            raise ValueError(msg)
+        self._extra_context_vars = dict(extra)
+
     def filter(self, record: logging.LogRecord) -> bool:
         """Add context fields to the log record. Always returns True."""
         record.invocation_id = invocation_id_var.get()
         record.function_name = function_name_var.get()
         record.trace_id = trace_id_var.get()
         record.cold_start = cold_start_var.get()
+        for field_name, var in self._extra_context_vars.items():
+            setattr(record, field_name, var.get())
         return True
 
 

--- a/src/azure_functions_logging/_setup.py
+++ b/src/azure_functions_logging/_setup.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
+import contextvars
 import logging
 import os
 from pathlib import Path
 import threading
+from typing import Any
 import warnings
 import weakref
 
@@ -62,6 +64,7 @@ def setup_logging(
     functions_formatter: logging.Formatter | None = None,
     host_json_path: Path | str | None = None,
     use_record_factory: bool = False,
+    extra_context_vars: dict[str, contextvars.ContextVar[Any]] | None = None,
 ) -> None:
     """Configure logging for the current environment.
     Behavior depends on the detected environment:
@@ -106,6 +109,11 @@ def setup_logging(
             handlers, because the global ``LogRecordFactory`` would be
             overwritten by the filter at handler dispatch time. Defaults to
             False to preserve the existing handler-filter-only behavior.
+        extra_context_vars: Optional mapping of ``field_name -> ContextVar``
+            whose current values ``ContextFilter`` also copies onto each
+            LogRecord, alongside the four built-in context fields. Field names
+            must not collide with the built-in fields. Only applies to the
+            ``ContextFilter`` strategy (ignored when ``use_record_factory=True``).
 
     .. warning::
 
@@ -159,7 +167,9 @@ def setup_logging(
             # Retrieve or create the per-call-signature state.
             _state_key: _AzureStateKey = (logger_name, use_record_factory)
             if _state_key not in _azure_state:
-                ctx_filter: ContextFilter | None = None if use_record_factory else ContextFilter()
+                ctx_filter: ContextFilter | None = (
+                    None if use_record_factory else ContextFilter(extra_context_vars)
+                )
                 _azure_state[_state_key] = (ctx_filter, weakref.WeakSet())
             context_filter, configured_handlers = _azure_state[_state_key]
             root = logging.getLogger()
@@ -185,7 +195,7 @@ def setup_logging(
 
             # When the LogRecordFactory is active, attaching ContextFilter would
             # overwrite factory-injected fields at handler dispatch time.
-            context_filter = None if use_record_factory else ContextFilter()
+            context_filter = None if use_record_factory else ContextFilter(extra_context_vars)
             target = logging.getLogger(logger_name)
             target.setLevel(level)
 

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -567,3 +567,39 @@ def test_extract_trace_id_forward_compatible_future_version() -> None:
 
 def test_extract_trace_id_baseline_valid_still_works() -> None:
     assert _extract_trace_id(_VALID_TRACEPARENT) == _VALID_TRACE_ID
+
+
+def test_context_filter_injects_extra_context_vars() -> None:
+    import contextvars
+
+    tenant_var: contextvars.ContextVar[str | None] = contextvars.ContextVar(
+        "tenant_id", default=None
+    )
+    token = tenant_var.set("acme")
+    try:
+        record = logging.LogRecord(
+            name="test",
+            level=logging.INFO,
+            pathname=__file__,
+            lineno=1,
+            msg="hello",
+            args=(),
+            exc_info=None,
+        )
+        keep = ContextFilter({"tenant_id": tenant_var}).filter(record)
+        assert keep is True
+        assert record.tenant_id == "acme"  # type: ignore[attr-defined]
+        # Built-in fields still injected.
+        assert record.invocation_id is None  # type: ignore[attr-defined]
+    finally:
+        tenant_var.reset(token)
+
+
+def test_context_filter_extra_collision_raises() -> None:
+    import contextvars
+
+    bad_var: contextvars.ContextVar[str | None] = contextvars.ContextVar(
+        "trace_id", default=None
+    )
+    with pytest.raises(ValueError, match="collide"):
+        ContextFilter({"trace_id": bad_var})


### PR DESCRIPTION
## Summary
- Adds an optional `extra_context_vars: dict[str, ContextVar]` parameter to `setup_logging()` and `ContextFilter`, so callers can inject arbitrary context variables (e.g. `tenant_id`, `request_id`) onto every LogRecord alongside the four built-in fields.
- `ContextFilter.filter()` copies each extra var's current value onto the record. Field names that collide with the built-in context fields raise `ValueError` at construction.
- Applies to the `ContextFilter` strategy (the default); ignored under `use_record_factory=True`.

## Verification
- `make lint`, `make typecheck` clean.
- Full suite green, coverage 96.30% (gate 95%). Adds 2 tests covering injection + collision.

Part of #216