### PR TITLE
refactor: deprecate install_context_factory() in favor of setup_logging(use_record_factory=True)

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -290,6 +290,8 @@ curl -s "https://<your-app>.azurewebsites.net/api/logme?correlation_id=demo-123"
 
 ### グローバル LogRecordFactory (オプトイン)
 
+> **Deprecated:** `setup_logging(use_record_factory=True)` を使用してください。単体の `install_context_factory()` は非推奨です。
+
 `install_context_factory()` はレコード生成時にコンテキストを注入し、ハンドラ/フィルタの構成に関係なく **すべての** `LogRecord` がコンテキストを持つようにします。`setup_logging()` 後にハンドラが追加されたり、ロガーがフィルタチェーンをバイパスする場合に便利です。デフォルトの `ContextFilter` モードとは相互排他的です。
 
 → [設定: `use_record_factory`](https://yeongseon.github.io/azure-functions-logging-python/configuration/#parameter-use_record_factory) · [API: `install_context_factory`](https://yeongseon.github.io/azure-functions-logging-python/api/#install_context_factory)

--- a/README.ko.md
+++ b/README.ko.md
@@ -290,6 +290,8 @@ curl -s "https://<your-app>.azurewebsites.net/api/logme?correlation_id=demo-123"
 
 ### 글로벌 LogRecordFactory (opt-in)
 
+> **Deprecated:** `setup_logging(use_record_factory=True)`를 사용하세요. 독립형 `install_context_factory()`는 더 이상 권장되지 않습니다.
+
 `install_context_factory()`는 레코드 생성 시점에 컨텍스트를 주입하여 핸들러/필터 구성과 무관하게 **모든** `LogRecord`가 컨텍스트를 갖도록 합니다. `setup_logging()` 이후 핸들러가 추가되거나 로거가 필터 체인을 우회할 때 유용합니다. 기본 `ContextFilter` 모드와는 상호 배타적입니다.
 
 → [구성: `use_record_factory`](https://yeongseon.github.io/azure-functions-logging-python/configuration/#parameter-use_record_factory) · [API: `install_context_factory`](https://yeongseon.github.io/azure-functions-logging-python/api/#install_context_factory)

--- a/README.md
+++ b/README.md
@@ -369,7 +369,7 @@ This package provides structured logging for Azure Functions with zero modificat
 
 **Key Implementation Details for Code Generation:**
 
-1. **Preserves host configuration** — In Azure / Core Tools, no handlers are added and the root logger level is left to `host.json`; `ContextFilter` is installed on existing root handlers and on the root logger itself (so direct calls on the root logger carry context). For records that propagate from named child loggers to handlers attached later (e.g. by the host or third-party libraries), call `install_context_factory()` to guarantee context coverage. In standalone local mode, `setup_logging(logger_name=None)` configures the root logger (sets level, adds a `StreamHandler` if none exist).
+1. **Preserves host configuration** — In Azure / Core Tools, no handlers are added and the root logger level is left to `host.json`; `ContextFilter` is installed on existing root handlers and on the root logger itself (so direct calls on the root logger carry context). For records that propagate from named child loggers to handlers attached later (e.g. by the host or third-party libraries), pass `use_record_factory=True` to `setup_logging()` to guarantee context coverage (the standalone `install_context_factory()` is deprecated). In standalone local mode, `setup_logging(logger_name=None)` configures the root logger (sets level, adds a `StreamHandler` if none exist).
 2. **Context injection is contextvar-based** — Not thread-local, works with asyncio
 3. **Idempotent setup** — Calling setup_logging() multiple times is safe
 4. **Two environments, two behaviors**:

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -290,6 +290,8 @@ curl -s "https://<your-app>.azurewebsites.net/api/logme?correlation_id=demo-123"
 
 ### 全局 LogRecordFactory（可选启用）
 
+> **Deprecated:** 请使用 `setup_logging(use_record_factory=True)`。独立的 `install_context_factory()` 已弃用。
+
 `install_context_factory()` 在记录创建时注入上下文，因此**每一条** `LogRecord` 都会携带上下文，而不受 handler/filter 接线方式的影响 —— 当 handler 在 `setup_logging()` 之后才添加，或 logger 绕过 filter 链时尤其有用。它与默认的 `ContextFilter` 模式互斥。
 
 → [Configuration: `use_record_factory`](https://yeongseon.github.io/azure-functions-logging-python/configuration/#parameter-use_record_factory) · [API: `install_context_factory`](https://yeongseon.github.io/azure-functions-logging-python/api/#install_context_factory)

--- a/docs/api.md
+++ b/docs/api.md
@@ -271,6 +271,11 @@ metadata = get_logging_metadata(handler)
 
 ::: azure_functions_logging.install_context_factory
 
+!!! warning "Deprecated"
+    Direct use of `install_context_factory()` is deprecated. Prefer
+    `setup_logging(use_record_factory=True)`, which selects the
+    `LogRecordFactory` injection strategy and manages teardown consistently.
+
 ## uninstall_context_factory
 
 ::: azure_functions_logging.uninstall_context_factory

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -286,7 +286,7 @@ Cold start detection uses a module-level boolean that starts `True` and flips to
 Two complementary mechanisms inject context variable values onto each `LogRecord`:
 
 - **`ContextFilter` (default)** runs during the filter phase, before the formatter, and reads context variables at handler-dispatch time. It works with both `ColorFormatter` and `JsonFormatter` but reflects the *current* contextvar state when the handler runs — not when the record was created.
-- **`install_context_factory()` (opt-in via `setup_logging(use_record_factory=True)`)** swaps the global `logging.LogRecordFactory` so context fields are captured at record-creation time. This snapshot survives thread hops, queued/delayed handlers, and contextvar resets between record creation and handler dispatch.
+- **`setup_logging(use_record_factory=True)`** swaps the global `logging.LogRecordFactory` so context fields are captured at record-creation time. This snapshot survives thread hops, queued/delayed handlers, and contextvar resets between record creation and handler dispatch. (The standalone `install_context_factory()` function is deprecated — prefer this entry point.)
 
 When `use_record_factory=True`, `ContextFilter` is intentionally **not** attached to handlers, so the factory snapshot is the single source of truth and cannot be overwritten downstream.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -116,7 +116,7 @@ setup_logging(format="json", use_record_factory=True)
 Behavior details:
 
 - Default is `False` to preserve the existing handler-filter-only behavior.
-- When `True`, `install_context_factory()` is called once; repeated calls are no-ops.
+- When `True`, the global `LogRecordFactory` injection strategy is installed once; repeated calls are no-ops. (Internally this used the now-deprecated `install_context_factory()`; prefer this `use_record_factory=True` entry point.)
 - When `True`, `ContextFilter` is **not** attached to handlers. The global
   `LogRecordFactory` is the sole source of context fields, so values captured at
   record-creation time survive thread hops, queued handlers, and delayed flushes

--- a/docs/index.md
+++ b/docs/index.md
@@ -37,7 +37,7 @@ This library addresses those gaps with a small API surface.
 - Structured NDJSON output (`format="json"`) for production ingestion.
 - `logging_context(context)` context manager that always restores prior context on exit (recommended).
 - `inject_context(context)` returns `ContextTokens` for paired `restore_context(tokens)` use in middleware.
-- `install_context_factory()` opt-in global LogRecordFactory so context flows to every `LogRecord`.
+- `setup_logging(use_record_factory=True)` opt-in global LogRecordFactory so context flows to every `LogRecord`. (The standalone `install_context_factory()` is deprecated.)
 - `JsonFormatter` for host-managed handlers via `setup_logging(functions_formatter=JsonFormatter())`.
 - Automatic `cold_start` flag detection on first invocation per process.
 - `FunctionLogger.bind()` for immutable request-scoped context binding.
@@ -81,7 +81,7 @@ This combines context-managed invocation context and request binding in a safe, 
 Behavior changes intentionally by runtime:
 
 - Local standalone process: sets the target/root logger level; adds a `StreamHandler` (`color` or `json`) only if no handlers exist, otherwise just attaches filters to existing handlers.
-- Azure/Core Tools runtime: installs `ContextFilter` on existing root handlers **and on the root logger itself** (so direct calls on the root logger carry context); does not add handlers or change root level. To guarantee context on records that propagate from named child loggers to handlers attached later, pass `use_record_factory=True` to `setup_logging()` (preferred) or call `install_context_factory()` directly.
+- Azure/Core Tools runtime: installs `ContextFilter` on existing root handlers **and on the root logger itself** (so direct calls on the root logger carry context); does not add handlers or change root level. To guarantee context on records that propagate from named child loggers to handlers attached later, pass `use_record_factory=True` to `setup_logging()` (the standalone `install_context_factory()` is deprecated).
 
 !!! warning
     In Azure-hosted execution, host-level `host.json` settings can still suppress logs even when application-level setup appears correct.

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -293,7 +293,7 @@ def logging_context(context: Any) -> Iterator[None]:
     """
     ...
 
-def install_context_factory() -> None:
+def install_context_factory() -> None:  # DEPRECATED: prefer setup_logging(use_record_factory=True)
     """Opt-in: install a global logging.setLogRecordFactory() that copies
     contextvars onto every LogRecord at creation time. Ensures coverage even
     on handlers added after setup_logging() and on loggers that bypass the

--- a/llms.txt
+++ b/llms.txt
@@ -36,7 +36,7 @@ Key features:
 - `restore_context(tokens)` — Restore previous contextvars from tokens (paired with `inject_context`)
 - `reset_context()` — Clear all context vars unconditionally (for test teardown)
 - `with_context` — Decorator to inject context per-request (sync/async)
-- `install_context_factory()` — Opt-in global LogRecordFactory so context flows to every record
+- `install_context_factory()` — **Deprecated**; prefer `setup_logging(use_record_factory=True)`. Opt-in global LogRecordFactory so context flows to every record
 - `get_logging_metadata(func)` — Inspect `@with_context` metadata on a function; returns `dict[str, Any] | None`
 - `ContextTokens` — Type alias for the token bundle returned by `inject_context()`
 

--- a/src/azure_functions_logging/_context.py
+++ b/src/azure_functions_logging/_context.py
@@ -8,6 +8,7 @@ import contextvars
 import logging
 import threading
 from typing import Any
+import warnings
 
 # Type alias for the token mapping returned by inject_context()
 ContextTokens = dict[contextvars.ContextVar[Any], contextvars.Token[Any]]
@@ -260,7 +261,7 @@ CONTEXT_RECORD_FIELDS: tuple[str, ...] = (
 )
 
 
-def install_context_factory() -> None:
+def _install_context_factory() -> None:
     """Install a global LogRecordFactory that injects context into every LogRecord.
 
     This is an alternative to ``ContextFilter`` that guarantees context fields
@@ -303,6 +304,25 @@ def install_context_factory() -> None:
     setattr(context_record_factory, _CONTEXT_FACTORY_MARKER, True)
     setattr(context_record_factory, _CONTEXT_FACTORY_PREVIOUS, previous_factory)
     logging.setLogRecordFactory(context_record_factory)
+
+
+def install_context_factory() -> None:
+    """Deprecated shim for the LogRecordFactory injection strategy.
+
+    .. deprecated::
+        Direct use of ``install_context_factory`` is deprecated in favour of
+        the single ``setup_logging(use_record_factory=True)`` entry point,
+        which selects the ``LogRecordFactory`` injection strategy and manages
+        ``ContextFilter`` teardown consistently. This shim will be removed in
+        a future release.
+    """
+    warnings.warn(
+        "install_context_factory() is deprecated; use "
+        "setup_logging(use_record_factory=True) instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    _install_context_factory()
 
 
 def uninstall_context_factory() -> bool:

--- a/src/azure_functions_logging/_setup.py
+++ b/src/azure_functions_logging/_setup.py
@@ -11,7 +11,7 @@ from typing import Any
 import warnings
 import weakref
 
-from ._context import ContextFilter, install_context_factory
+from ._context import ContextFilter, _install_context_factory
 from ._formatter import ColorFormatter
 from ._host_config import warn_host_json_level_conflict
 from ._json_formatter import JsonFormatter
@@ -102,7 +102,7 @@ def setup_logging(
             ``host.json`` is auto-discovered by walking up from the current
             working directory (bounded). Pass an explicit path to disable
             auto-discovery in environments where it might pick the wrong file.
-        use_record_factory: When True, install :func:`install_context_factory`
+        use_record_factory: When True, install the global ``LogRecordFactory``
             so context fields are injected at LogRecord creation time and are
             preserved through queued, delayed, or cross-thread handling. When
             this option is enabled, ``ContextFilter`` is **not** attached to
@@ -132,7 +132,7 @@ def setup_logging(
     # Install the global LogRecordFactory only after argument validation,
     # so an invalid call does not leave persistent global side effects.
     if use_record_factory:
-        install_context_factory()
+        _install_context_factory()
 
     with _configured_lock:
         # When switching to record-factory mode, strip any previously-installed

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -12,6 +12,7 @@ from azure_functions_logging._context import (
     ContextFilter,
     _check_cold_start,
     _extract_trace_id,
+    _install_context_factory,
     cold_start_var,
     function_name_var,
     inject_context,
@@ -339,7 +340,7 @@ def test_install_context_factory_injects_fields() -> None:
         invocation_id_var.set("factory-inv")
         function_name_var.set("factory-fn")
 
-        install_context_factory()
+        _install_context_factory()
 
         factory = logging.getLogRecordFactory()
         assert getattr(factory, _CONTEXT_FACTORY_MARKER, False) is True
@@ -357,7 +358,7 @@ def test_install_context_factory_injects_fields() -> None:
         assert record.function_name == "factory-fn"  # type: ignore[attr-defined]
 
         # Idempotent — calling again does not double-wrap
-        install_context_factory()
+        _install_context_factory()
         assert logging.getLogRecordFactory() is factory
     finally:
         logging.setLogRecordFactory(old_factory)
@@ -369,7 +370,7 @@ def test_uninstall_context_factory_restores_previous() -> None:
     """uninstall_context_factory restores the factory active before install."""
     old_factory = logging.getLogRecordFactory()
     try:
-        install_context_factory()
+        _install_context_factory()
         assert getattr(
             logging.getLogRecordFactory(), _CONTEXT_FACTORY_MARKER, False
         ) is True
@@ -394,7 +395,7 @@ def test_uninstall_context_factory_preserves_chained_factory() -> None:
 
     try:
         logging.setLogRecordFactory(custom_factory)
-        install_context_factory()
+        _install_context_factory()
         assert uninstall_context_factory() is True
         assert logging.getLogRecordFactory() is custom_factory
 
@@ -429,7 +430,7 @@ def test_install_context_factory_chains_existing_factory() -> None:
         logging.setLogRecordFactory(custom_factory)
         invocation_id_var.set("chain-inv")
 
-        install_context_factory()
+        _install_context_factory()
 
         record = logging.getLogRecordFactory()("test", logging.INFO, __file__, 1, "msg", (), None)
 
@@ -446,7 +447,7 @@ def test_install_context_factory_extra_collision_raises() -> None:
     old_factory = logging.getLogRecordFactory()
 
     try:
-        install_context_factory()
+        _install_context_factory()
         logger = logging.getLogger("test.factory.collision")
         logger.handlers.clear()
         logger.propagate = False
@@ -478,7 +479,7 @@ def test_install_context_factory_with_logger_emit() -> None:
         trace_id_var.set("emit-trace")
         cold_start_var.set(True)
 
-        install_context_factory()
+        _install_context_factory()
 
         logger = logging.getLogger("test.factory.emit")
         logger.handlers.clear()
@@ -603,3 +604,15 @@ def test_context_filter_extra_collision_raises() -> None:
     )
     with pytest.raises(ValueError, match="collide"):
         ContextFilter({"trace_id": bad_var})
+
+
+def test_install_context_factory_is_deprecated() -> None:
+    try:
+        with pytest.warns(DeprecationWarning, match="setup_logging"):
+            install_context_factory()
+        # The deprecated shim still installs the package factory.
+        assert getattr(
+            logging.getLogRecordFactory(), _CONTEXT_FACTORY_MARKER, False
+        )
+    finally:
+        uninstall_context_factory()


### PR DESCRIPTION
## Context

`install_context_factory()` and `setup_logging(use_record_factory=True)` are two entry points for the same LogRecordFactory injection strategy. Having both public creates ambiguity about the intended API surface. This consolidates on `setup_logging(use_record_factory=True)` as the single recommended entry point.

## Changes

- Rename the factory-install logic to private `_install_context_factory()`.
- Keep public `install_context_factory()` as a thin **deprecated** shim that emits a `DeprecationWarning` (`stacklevel=2`) then delegates to the private function.
- `setup_logging(use_record_factory=True)` now calls the private function directly.
- Update docs (`api.md`, `configuration.md`, `index.md`, `architecture.md`), README + localized READMEs (zh-CN/ja/ko), and `llms.txt` / `llms-full.txt` to steer users to the recommended entry point and note the deprecation.
- Add `test_install_context_factory_is_deprecated()`; switch mechanism tests to the private symbol.

`uninstall_context_factory()` remains a supported (non-deprecated) public teardown API.

## Verification

- `make lint` clean, `make typecheck` clean.
- Full suite green; coverage 96.31% (gate 95%).

Part of #216