### PR TITLE
ci(docs): add mermaid render lint to prevent diagram syntax regressions

### DIFF
--- a/.github/workflows/mermaid-lint.yml
+++ b/.github/workflows/mermaid-lint.yml
@@ -1,0 +1,63 @@
+name: Mermaid Render Lint
+
+# Renders every Mermaid diagram in the docs/README so that invalid syntax
+# fails fast in CI. See issue #214 (follow-up from the diagram PR #209).
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - "README*.md"
+      - "docs/**"
+      - ".github/workflows/mermaid-lint.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  mermaid-lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
+
+      - name: Set up Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: "20"
+
+      - name: Install mermaid-cli
+        run: npm install -g @mermaid-js/mermaid-cli@11
+
+      - name: Configure Puppeteer (headless Chromium, no sandbox)
+        run: |
+          echo '{ "args": ["--no-sandbox"] }' > "$RUNNER_TEMP/puppeteer-config.json"
+
+      - name: Render all Mermaid diagrams (fails on invalid syntax)
+        run: |
+          set -euo pipefail
+          # Collect markdown files that contain a ```mermaid fenced block.
+          mapfile -t files < <(grep -rlZ '```mermaid' README*.md docs 2>/dev/null | tr '\0' '\n' | sort -u)
+          if [ "${#files[@]}" -eq 0 ]; then
+            echo "No Mermaid diagrams found — nothing to lint."
+            exit 0
+          fi
+          status=0
+          for f in "${files[@]}"; do
+            echo "::group::Rendering $f"
+            # mmdc processes every ```mermaid block in the markdown file and
+            # exits non-zero if any diagram has invalid syntax. Output is
+            # discarded (we only care about the render succeeding).
+            if mmdc \
+              --puppeteerConfigFile "$RUNNER_TEMP/puppeteer-config.json" \
+              --input "$f" \
+              --output "$RUNNER_TEMP/$(basename "$f" .md)-rendered.md"; then
+              echo "OK: $f"
+            else
+              echo "::error file=$f::Mermaid render failed — check diagram syntax."
+              status=1
+            fi
+            echo "::endgroup::"
+          done
+          exit "$status"


### PR DESCRIPTION
## Summary
Adds a `Mermaid Render Lint` workflow that renders every ` ```mermaid ` block in `README*.md` and `docs/` via `@mermaid-js/mermaid-cli` (`mmdc`), so invalid diagram syntax fails fast in CI. Follow-up from #209 (deferred to keep the chromium-based dependency isolated and reviewable).

- Triggers only on PRs touching `README*.md` / `docs/**` (plus `workflow_dispatch`), keeping the browser dependency out of the main test matrix.
- Uses a `--no-sandbox` Puppeteer config for headless Chromium on the runner.
- Pins `actions/checkout` and `actions/setup-node` to the same SHAs already used elsewhere in the repo.

## Verification
Ran the exact lint logic locally against this repo:
- Positive: all 5 diagram-bearing files (`docs/architecture.md`, `README.md`, `README.ko.md`, `README.ja.md`, `README.zh-CN.md`) render OK, exit 0.
- Negative: a deliberately malformed `flowchart` correctly fails with a non-zero exit.

Closes #214