### PR TITLE
feat(json): emit span_id in JsonFormatter output (#257)

### DIFF
--- a/src/azure_functions_logging/_constants.py
+++ b/src/azure_functions_logging/_constants.py
@@ -17,6 +17,7 @@ _LIBRARY_RESERVED_KEYS: frozenset[str] = frozenset(
         "cold_start",
         "function_name",
         "invocation_id",
+        "span_id",
         "trace_id",
     }
 )

--- a/src/azure_functions_logging/_json_formatter.py
+++ b/src/azure_functions_logging/_json_formatter.py
@@ -83,12 +83,10 @@ def _to_json_safe(
             return "<cyclic>"
         seen = seen | {id(value)}
         if isinstance(value, dict):
-            return {
-                _safe_key(k): _to_json_safe(v, seen, _depth + 1)
-                for k, v in value.items()
-            }
+            return {_safe_key(k): _to_json_safe(v, seen, _depth + 1) for k, v in value.items()}
         return [_to_json_safe(item, seen, _depth + 1) for item in value]
     return value
+
 
 def _truncate_native_strings(value: Any, max_length: int) -> Any:
     """Recursively truncate string values in a JSON-safe structure.
@@ -109,6 +107,7 @@ def _truncate_native_strings(value: Any, max_length: int) -> Any:
     if isinstance(value, list):
         return [_truncate_native_strings(item, max_length) for item in value]
     return value
+
 
 class JsonFormatter(logging.Formatter):
     """Structured JSON log formatter.
@@ -137,9 +136,7 @@ class JsonFormatter(logging.Formatter):
         truncate_native_strings: bool = False,
     ) -> None:
         if max_string_length < 0:
-            raise ValueError(
-                f"max_string_length must be ≥ 0, got {max_string_length}"
-            )
+            raise ValueError(f"max_string_length must be ≥ 0, got {max_string_length}")
         super().__init__()
         self._max_string_length = max_string_length
         self._truncate_native_strings = truncate_native_strings
@@ -174,6 +171,7 @@ class JsonFormatter(logging.Formatter):
             "invocation_id": getattr(record, "invocation_id", None),
             "function_name": getattr(record, "function_name", None),
             "trace_id": getattr(record, "trace_id", None),
+            "span_id": getattr(record, "span_id", None),
             "cold_start": getattr(record, "cold_start", None),
             "exception": exception,
             "extra": extra,
@@ -230,6 +228,7 @@ def _emergency_payload(record: logging.LogRecord) -> str:
             "invocation_id": None,
             "function_name": None,
             "trace_id": None,
+            "span_id": None,
             "cold_start": None,
             "exception": None,
             "extra": {"__serialization_error__": True},

--- a/tests/test_contracts.py
+++ b/tests/test_contracts.py
@@ -75,6 +75,7 @@ _JSON_SCHEMA_KEYS: set[str] = {
     "invocation_id",
     "function_name",
     "trace_id",
+    "span_id",
     "cold_start",
     "exception",
     "extra",

--- a/tests/test_json_formatter.py
+++ b/tests/test_json_formatter.py
@@ -40,6 +40,7 @@ def test_basic_json_output_is_valid_and_has_expected_fields() -> None:
     assert payload["invocation_id"] is None
     assert payload["function_name"] is None
     assert payload["trace_id"] is None
+    assert payload["span_id"] is None
     assert payload["cold_start"] is None
     assert payload["exception"] is None
     assert payload["extra"] == {}
@@ -51,12 +52,14 @@ def test_context_fields_included_when_present() -> None:
     record.invocation_id = "inv-1"
     record.function_name = "fn-1"
     record.trace_id = "trace-1"
+    record.span_id = "span-1"
 
     payload = json.loads(formatter.format(record))
 
     assert payload["invocation_id"] == "inv-1"
     assert payload["function_name"] == "fn-1"
     assert payload["trace_id"] == "trace-1"
+    assert payload["span_id"] == "span-1"
 
 
 def test_cold_start_field_for_true_false_and_none() -> None:
@@ -296,8 +299,6 @@ def test_format_emergency_fallback_when_payload_dict_unserializable(
     formatter = JsonFormatter()
     record = _make_record(logging.WARNING, "force emergency")
 
-
-
     call_count = {"n": 0}
     real_dumps = json.dumps
 
@@ -314,6 +315,7 @@ def test_format_emergency_fallback_when_payload_dict_unserializable(
     assert payload["message"] == "<emergency fallback: formatter failed>"
     assert payload["extra"] == {"__serialization_error__": True}
     assert payload["level"] == "WARNING"
+    assert payload["span_id"] is None
 
 
 def test_format_handles_invalid_timestamp() -> None:


### PR DESCRIPTION
Stacked PR **2/7** · base: `otel/254-trace-context` (#254)

`JsonFormatter` now emits `span_id` alongside `trace_id`, read from the `LogRecord` populated by context injection.

Closes #257 · Refs #252

> **BREAKING CHANGE:** `JsonFormatter` output now includes a `span_id` field. Consumers asserting on the exact JSON key set must account for it.

> Review only the top commit; the diff is stacked on #254.