### PR TITLE
feat(otel): add AttributeFlattenFilter to prevent nested-dict attribute drop (#260)

### DIFF
--- a/src/azure_functions_logging/_filters.py
+++ b/src/azure_functions_logging/_filters.py
@@ -3,6 +3,8 @@
 Provides:
 - ``SamplingFilter``: Rate-limit noisy loggers to reduce gRPC/stdout pressure.
 - ``RedactionFilter``: Mask PII / sensitive keys on LogRecord extra fields.
+- ``AttributeFlattenFilter``: Flatten nested dict extras to dotted scalar keys
+  so OpenTelemetry does not silently drop them.
 """
 
 from __future__ import annotations
@@ -18,6 +20,46 @@ from ._redaction import SENSITIVE_KEYS as _DEFAULT_SENSITIVE_KEYS
 from ._redaction import normalize_key as _normalize_key
 
 _REDACT_MAX_DEPTH = 10  # default depth limit for recursive redaction
+_FLATTEN_MAX_DEPTH = 10  # default depth limit for recursive flattening
+
+
+def _flatten_dict(
+    prefix: str,
+    value: dict[Any, Any],
+    separator: str,
+    max_depth: int,
+    *,
+    _seen: set[int] | None = None,
+    _depth: int = 0,
+) -> dict[str, Any]:
+    """Flatten a nested dict into ``{dotted_key: scalar}`` pairs.
+
+    Guarded against:
+    - Cyclic references (via id-based seen set); cyclic sub-dicts are dropped.
+    - Pathologically deep structures (via ``_depth`` / ``max_depth``); the
+      remaining nested dict at the depth limit is emitted as-is under its
+      dotted key.
+
+    Lists (and any non-dict leaf) are emitted unchanged under their dotted key.
+    Empty dicts contribute no keys.
+    """
+    if _depth >= max_depth:
+        return {prefix: value}
+    seen = _seen if _seen is not None else set()
+    obj_id = id(value)
+    if obj_id in seen:
+        return {}  # cyclic reference detected
+    seen = seen | {obj_id}
+    result: dict[str, Any] = {}
+    for key, item in value.items():
+        new_key = f"{prefix}{separator}{key}"
+        if isinstance(item, dict):
+            result.update(
+                _flatten_dict(new_key, item, separator, max_depth, _seen=seen, _depth=_depth + 1)
+            )
+        else:
+            result[new_key] = item
+    return result
 
 
 def _redact_value(
@@ -247,6 +289,86 @@ class RedactionFilter(logging.Filter):
                         value = record.__dict__[key]
                         if isinstance(value, (dict, list)):
                             setattr(record, key, _redact_value(value, self._sensitive_keys))
+                except Exception:  # nosec B110 — one broken field must not stop others
+                    pass
+        except Exception:  # nosec B110 — filter must never raise
+            pass
+        return True
+
+
+class AttributeFlattenFilter(logging.Filter):
+    """Flatten nested ``dict`` extras into dotted scalar attributes in-place.
+
+    OpenTelemetry attributes only permit scalars and homogeneous arrays. A
+    nested ``dict`` passed via ``extra`` (e.g. ``order={"id": 1}``) is silently
+    dropped by the OTel SDK. This filter rewrites such attributes into dotted
+    scalar keys (``order.id``) so the data survives export.
+
+    The filter mutates the record in-place, removing the original nested-dict
+    attribute and adding one attribute per leaf. It is **opt-in**: it has no
+    effect unless explicitly attached to a handler/logger.
+
+    Behavior:
+    - Nested dicts are flattened recursively to dotted keys.
+    - Lists / heterogeneous arrays are left unchanged (emitted as-is under
+      their dotted key). OTel accepts homogeneous scalar arrays; heterogeneous
+      or nested-object arrays remain the caller's responsibility.
+    - Scalar attributes and reserved ``LogRecord`` keys are never touched.
+    - Empty dicts contribute no keys (the attribute is removed).
+    - Cyclic references are dropped; over-deep structures (beyond
+      ``max_depth``) are emitted as-is at the depth boundary.
+
+    .. note::
+
+        This filter rewrites the record's attributes, so it also affects
+        **non-OTel** consumers reading the same record — e.g. a
+        :class:`JsonFormatter` on the root handler will emit ``order.id``
+        instead of a nested ``order`` object. To avoid changing your JSON log
+        shape, attach this filter only to the OpenTelemetry ``LoggingHandler``
+        rather than to the root handler.
+
+    Args:
+        name: Optional logger-name scope. When set, only matching loggers are
+            flattened; non-matching records pass through unchanged.
+        separator: Delimiter joining nested keys. Default ``"."``.
+        max_depth: Maximum recursion depth before a nested dict is emitted
+            as-is. Default ``10``.
+
+    Example::
+
+        filter = AttributeFlattenFilter()
+        handler.addFilter(filter)
+    """
+
+    def __init__(
+        self,
+        name: str = "",
+        *,
+        separator: str = ".",
+        max_depth: int = _FLATTEN_MAX_DEPTH,
+    ) -> None:
+        super().__init__(name)
+        self._separator: str = separator
+        self._max_depth: int = max_depth
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        """Flatten nested-dict fields on the record. Always returns True."""
+        # Honor name-based scoping from logging.Filter
+        if not super().filter(record):
+            return True  # bypass flattening for non-matching loggers
+
+        try:
+            for key in list(record.__dict__.keys()):
+                try:
+                    if key in _RESERVED_LOG_RECORD_KEYS:
+                        continue
+                    value = record.__dict__[key]
+                    if not isinstance(value, dict):
+                        continue
+                    flattened = _flatten_dict(key, value, self._separator, self._max_depth)
+                    del record.__dict__[key]
+                    for flat_key, flat_value in flattened.items():
+                        setattr(record, flat_key, flat_value)
                 except Exception:  # nosec B110 — one broken field must not stop others
                     pass
         except Exception:  # nosec B110 — filter must never raise

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -7,7 +7,11 @@ import time
 
 import pytest
 
-from azure_functions_logging._filters import RedactionFilter, SamplingFilter
+from azure_functions_logging._filters import (
+    AttributeFlattenFilter,
+    RedactionFilter,
+    SamplingFilter,
+)
 
 
 def _make_record(level: int = logging.INFO, msg: str = "hello") -> logging.LogRecord:
@@ -162,6 +166,7 @@ def test_sampling_filter_per_logger_enforces_hard_cap_on_burst() -> None:
 
     # Hard cap must be enforced: at most _MAX_BUCKETS entries remain
     assert len(flt._buckets) <= 5
+
 
 # ---------------------------------------------------------------------------
 # RedactionFilter tests
@@ -861,3 +866,183 @@ def test_redaction_filter_constructor_normalizes_hyphenated_sensitive_keys() -> 
     assert getattr(record, "x_functions_key") == "***"
     assert getattr(record, "ocp_apim_subscription_key") == "***"
     assert getattr(record, "safe_attr") == "visible"
+
+
+# ---------------------------------------------------------------------------
+# AttributeFlattenFilter tests
+# ---------------------------------------------------------------------------
+
+
+def test_flatten_filter_flattens_nested_dict_to_dotted_keys() -> None:
+    flt = AttributeFlattenFilter()
+    record = _make_record()
+    setattr(record, "order", {"id": 1, "total": 99})
+
+    assert flt.filter(record) is True
+    assert getattr(record, "order.id") == 1
+    assert getattr(record, "order.total") == 99
+    # Original nested dict attribute is removed to avoid SDK drop.
+    assert "order" not in record.__dict__
+
+
+def test_flatten_filter_flattens_deeply_nested_dicts() -> None:
+    flt = AttributeFlattenFilter()
+    record = _make_record()
+    setattr(record, "order", {"customer": {"name": "alice", "tier": "gold"}})
+
+    flt.filter(record)
+
+    assert getattr(record, "order.customer.name") == "alice"
+    assert getattr(record, "order.customer.tier") == "gold"
+    assert "order" not in record.__dict__
+
+
+def test_flatten_filter_leaves_lists_as_is() -> None:
+    """Lists / heterogeneous arrays are left untouched (documented behavior)."""
+    flt = AttributeFlattenFilter()
+    record = _make_record()
+    setattr(record, "tags", ["a", "b", "c"])
+    setattr(record, "order", {"items": [{"id": 1}, {"id": 2}]})
+
+    flt.filter(record)
+
+    assert getattr(record, "tags") == ["a", "b", "c"]
+    # A list value nested inside a dict is emitted as-is under its dotted key.
+    assert getattr(record, "order.items") == [{"id": 1}, {"id": 2}]
+
+
+def test_flatten_filter_leaves_scalar_attributes_untouched() -> None:
+    flt = AttributeFlattenFilter()
+    record = _make_record()
+    setattr(record, "count", 5)
+    setattr(record, "label", "hello")
+
+    flt.filter(record)
+
+    assert getattr(record, "count") == 5
+    assert getattr(record, "label") == "hello"
+
+
+def test_flatten_filter_does_not_touch_reserved_keys() -> None:
+    flt = AttributeFlattenFilter()
+    record = _make_record()
+    original_name = record.name
+
+    flt.filter(record)
+
+    assert record.name == original_name
+    assert record.msg == "hello"
+    # The reserved 'name' key is not split into dotted attributes.
+    assert "name.test" not in record.__dict__
+
+
+def test_flatten_filter_supports_custom_separator() -> None:
+    flt = AttributeFlattenFilter(separator="__")
+    record = _make_record()
+    setattr(record, "order", {"id": 1})
+
+    flt.filter(record)
+
+    assert getattr(record, "order__id") == 1
+    assert "order" not in record.__dict__
+
+
+def test_flatten_filter_empty_dict_is_dropped() -> None:
+    flt = AttributeFlattenFilter()
+    record = _make_record()
+    setattr(record, "meta", {})
+
+    flt.filter(record)
+
+    assert "meta" not in record.__dict__
+
+
+def test_flatten_filter_respects_max_depth() -> None:
+    """Beyond max_depth the remaining nested dict is emitted as-is."""
+    flt = AttributeFlattenFilter(max_depth=1)
+    record = _make_record()
+    setattr(record, "a", {"b": {"c": 1}})
+
+    flt.filter(record)
+
+    # Depth 1 flattens the first level; the inner dict is kept as-is.
+    assert getattr(record, "a.b") == {"c": 1}
+
+
+def test_flatten_filter_handles_cyclic_dict_without_raising() -> None:
+    flt = AttributeFlattenFilter()
+    record = _make_record()
+    cyclic: dict[str, object] = {"self": None}
+    cyclic["self"] = cyclic
+    setattr(record, "loop", cyclic)
+
+    # Must not raise despite the cycle.
+    assert flt.filter(record) is True
+
+
+def test_flatten_filter_always_returns_true() -> None:
+    flt = AttributeFlattenFilter()
+    assert flt.filter(_make_record()) is True
+
+
+def test_flatten_filter_never_raises_on_broken_attribute() -> None:
+    class ExplodingRecord(logging.LogRecord):
+        def __getattribute__(self, name: str) -> object:
+            if name == "explode":
+                msg = "attribute access failure"
+                raise RuntimeError(msg)
+            return super().__getattribute__(name)
+
+    flt = AttributeFlattenFilter()
+    record = ExplodingRecord(
+        name="test.logger",
+        level=logging.INFO,
+        pathname=__file__,
+        lineno=1,
+        msg="exploding",
+        args=(),
+        exc_info=None,
+    )
+    setattr(record, "explode", {"id": 1})
+    setattr(record, "order", {"id": 2})
+
+    assert flt.filter(record) is True
+    # Well-formed attribute is still flattened.
+    assert getattr(record, "order.id") == 2
+
+
+def test_flatten_filter_survives_dict_that_raises_on_iteration() -> None:
+    """A field whose flattening raises must not stop other fields or the filter."""
+
+    class ExplodingDict(dict):  # type: ignore[type-arg]
+        def items(self) -> object:  # type: ignore[override]
+            msg = "items access failure"
+            raise RuntimeError(msg)
+
+    flt = AttributeFlattenFilter()
+    record = _make_record()
+    setattr(record, "broken", ExplodingDict())
+    setattr(record, "order", {"id": 7})
+
+    assert flt.filter(record) is True
+    # The healthy field is still flattened despite the broken sibling.
+    assert getattr(record, "order.id") == 7
+
+
+def test_flatten_filter_honors_name_scoping() -> None:
+    flt = AttributeFlattenFilter(name="myapp")
+    record = logging.LogRecord(
+        name="other.module",
+        level=logging.INFO,
+        pathname=__file__,
+        lineno=1,
+        msg="hello",
+        args=(),
+        exc_info=None,
+    )
+    setattr(record, "order", {"id": 1})
+
+    # Non-matching logger bypasses flattening.
+    assert flt.filter(record) is True
+    assert getattr(record, "order") == {"id": 1}
+    assert "order.id" not in record.__dict__


### PR DESCRIPTION
Stacked PR **3/7** · base: `otel/257-span-id` (#257)

Opt-in filter that flattens nested-dict extras to dotted scalar keys (`order={'id':1}` → `order.id=1`) so OpenTelemetry attributes are not silently dropped. Cyclic- and depth-guarded, honors name scoping and reserved keys, never raises.

Closes #260 · Refs #252

> Review only the top commit; the diff is stacked on #257.