### PR TITLE
feat(otel): activate host W3C trace context for OTel log correlation (#255)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ dev = [
     "git-cliff",
     "hatch",
     "mypy==2.3.0",
+    "opentelemetry-sdk>=1.24",
     "pre-commit",
     "pytest",
     "pytest-cov",
@@ -48,6 +49,9 @@ docs = [
     "mkdocs<2.0",
     "mkdocs-material<10.0",
     "mkdocstrings[python]<2.0",
+]
+otel = [
+    "opentelemetry-api>=1.24",
 ]
 
 [build-system]

--- a/src/azure_functions_logging/__init__.py
+++ b/src/azure_functions_logging/__init__.py
@@ -12,13 +12,16 @@ from ._context import (
     uninstall_context_factory,
 )
 from ._decorator import get_logging_metadata, with_context
-from ._filters import RedactionFilter, SamplingFilter
+from ._filters import AttributeFlattenFilter, RedactionFilter, SamplingFilter
 from ._json_formatter import JsonFormatter
 from ._logger import FunctionLogger
+from ._otel import activated_trace_context
 from ._setup import setup_logging
 
 __all__ = [
     "__version__",
+    "activated_trace_context",
+    "AttributeFlattenFilter",
     "ContextTokens",
     "FunctionLogger",
     "JsonFormatter",

--- a/src/azure_functions_logging/_context.py
+++ b/src/azure_functions_logging/_context.py
@@ -250,8 +250,61 @@ def restore_context(tokens: ContextTokens) -> None:
         var.reset(token)
 
 
+# Process-wide default for OpenTelemetry trace-context activation. Toggled by
+# ``setup_logging(activate_trace_context=...)`` and consulted by
+# ``logging_context`` / ``with_context`` when their per-call flag is ``None``.
+# ``None`` selects the ``auto`` tier: enabled iff ``opentelemetry-api`` is
+# importable.
+_default_trace_context_activation: bool | None = None
+
+
+def set_default_trace_context_activation(enabled: bool | None) -> None:
+    """Set the process-wide default for OTel trace-context activation.
+
+    Called by :func:`setup_logging`. When enabled, ``logging_context`` and
+    ``with_context`` activate the host trace context unless a per-call
+    ``activate_trace_context`` argument overrides it. Passing ``None`` selects
+    the ``auto`` tier (enabled iff ``opentelemetry-api`` is importable).
+    """
+    global _default_trace_context_activation
+    _default_trace_context_activation = enabled if enabled is None else bool(enabled)
+
+
+def _resolve_auto_trace_context_activation() -> bool:
+    """Resolve the ``auto`` tier: enabled iff ``opentelemetry-api`` is importable."""
+    try:
+        from ._otel import is_available
+    except ImportError:  # pragma: no cover - defensive; _otel always ships
+        return False
+    return is_available()
+
+
+def get_default_trace_context_activation() -> bool:
+    """Return the resolved process-wide OTel trace-context activation default.
+
+    A stored default of ``None`` selects the ``auto`` tier: enabled iff
+    ``opentelemetry-api`` is importable.
+    """
+    if _default_trace_context_activation is None:
+        return _resolve_auto_trace_context_activation()
+    return _default_trace_context_activation
+
+
+def _read_trace_headers(context: Any) -> tuple[str | None, str | None]:
+    """Extract ``(traceparent, tracestate)`` from a context object, never raising."""
+    try:
+        trace_context = getattr(context, "trace_context", None)
+        if trace_context is None:
+            return None, None
+        trace_parent = getattr(trace_context, "trace_parent", None)
+        trace_state = getattr(trace_context, "trace_state", None)
+        return trace_parent, trace_state
+    except Exception:  # nosec B110 — Principle 3: context failures are silent
+        return None, None
+
+
 @contextmanager
-def logging_context(context: Any) -> Iterator[None]:
+def logging_context(context: Any, *, activate_trace_context: bool | None = None) -> Iterator[None]:
     """Context manager wrapping ``inject_context`` + ``restore_context``.
 
     Recommended pattern when handlers don't use the ``with_context`` decorator::
@@ -263,10 +316,34 @@ def logging_context(context: Any) -> Iterator[None]:
 
     Guarantees context is restored to its previous state even if the body raises,
     supporting safe nesting of contexts.
+
+    Args:
+        context: An Azure Functions context object (func.Context).
+        activate_trace_context: When ``True``, also attach the host's W3C trace
+            context (from ``context.trace_context``) via OpenTelemetry so log
+            records emitted through an OTel ``LoggingHandler`` inherit the host
+            span's ``trace_id``/``span_id``. Requires the ``[otel]`` extra;
+            degrades to a silent no-op when OpenTelemetry is unavailable. When
+            ``None`` (default), the process-wide default configured via
+            ``setup_logging(activate_trace_context=...)`` is used, which itself
+            defaults to the ``auto`` tier (enabled iff ``opentelemetry-api`` is
+            importable).
     """
+    should_activate = (
+        get_default_trace_context_activation()
+        if activate_trace_context is None
+        else activate_trace_context
+    )
     tokens = inject_context(context)
     try:
-        yield
+        if should_activate:
+            trace_parent, trace_state = _read_trace_headers(context)
+            from ._otel import activated_trace_context
+
+            with activated_trace_context(trace_parent, trace_state):
+                yield
+        else:
+            yield
     finally:
         restore_context(tokens)
 

--- a/src/azure_functions_logging/_decorator.py
+++ b/src/azure_functions_logging/_decorator.py
@@ -12,7 +12,7 @@ import asyncio
 import inspect
 from typing import Any, Callable, TypeVar, overload
 
-from ._context import inject_context, restore_context
+from ._context import logging_context
 from ._metadata import LoggingMetadata, read_logging_metadata, set_logging_metadata
 from ._metadata_helpers import copy_identity_attrs
 
@@ -49,7 +49,6 @@ def _build_logging_payload(param: str) -> LoggingMetadata:
     return {"version": 1, "context_param": param}
 
 
-
 def _find_context_arg(
     func: Callable[..., Any],
     param: str,
@@ -74,38 +73,30 @@ def _find_context_arg(
     return None
 
 
-def _wrap_sync(func: _F, param: str) -> _F:
+def _wrap_sync(func: _F, param: str, activate_trace_context: bool | None) -> _F:
     """Wrap a synchronous handler."""
 
     def wrapper(*args: Any, **kwargs: Any) -> Any:
         ctx = _find_context_arg(func, param, args, kwargs)
         if ctx is not None:
-            tokens = inject_context(ctx)
-        else:
-            tokens = {}
-        try:
-            return func(*args, **kwargs)
-        finally:
-            restore_context(tokens)
+            with logging_context(ctx, activate_trace_context=activate_trace_context):
+                return func(*args, **kwargs)
+        return func(*args, **kwargs)
 
     _copy_safe_metadata(wrapper, func)
     set_logging_metadata(wrapper, func, _build_logging_payload(param))
     return wrapper  # type: ignore[return-value]
 
 
-def _wrap_async(func: _F, param: str) -> _F:
+def _wrap_async(func: _F, param: str, activate_trace_context: bool | None) -> _F:
     """Wrap an asynchronous handler."""
 
     async def wrapper(*args: Any, **kwargs: Any) -> Any:
         ctx = _find_context_arg(func, param, args, kwargs)
         if ctx is not None:
-            tokens = inject_context(ctx)
-        else:
-            tokens = {}
-        try:
-            return await func(*args, **kwargs)
-        finally:
-            restore_context(tokens)
+            with logging_context(ctx, activate_trace_context=activate_trace_context):
+                return await func(*args, **kwargs)
+        return await func(*args, **kwargs)
 
     _copy_safe_metadata(wrapper, func)
     set_logging_metadata(wrapper, func, _build_logging_payload(param))
@@ -117,13 +108,16 @@ def with_context(func: _F) -> _F: ...
 
 
 @overload
-def with_context(*, param: str = ...) -> Callable[[_F], _F]: ...
+def with_context(
+    *, param: str = ..., activate_trace_context: bool | None = ...
+) -> Callable[[_F], _F]: ...
 
 
 def with_context(
     func: _F | None = None,
     *,
     param: str = _DEFAULT_PARAM,
+    activate_trace_context: bool | None = None,
 ) -> _F | Callable[[_F], _F]:
     """Decorator that automatically injects invocation context.
 
@@ -149,12 +143,17 @@ def with_context(
         func: The handler function (when used without parentheses).
         param: Name of the parameter that receives the Azure Functions
             context object. Defaults to ``"context"``.
+        activate_trace_context: When ``True``, also attach the host's W3C trace
+            context so OTel log records inherit the host span's
+            ``trace_id``/``span_id`` (requires the ``[otel]`` extra; silent
+            no-op otherwise). When ``None`` (default), the process-wide default
+            configured via ``setup_logging(activate_trace_context=...)`` applies.
     """
 
     def decorator(fn: _F) -> _F:
         if asyncio.iscoroutinefunction(fn):
-            return _wrap_async(fn, param)
-        return _wrap_sync(fn, param)
+            return _wrap_async(fn, param, activate_trace_context)
+        return _wrap_sync(fn, param, activate_trace_context)
 
     if func is not None:
         # Called as @with_context (no parentheses)

--- a/src/azure_functions_logging/_otel.py
+++ b/src/azure_functions_logging/_otel.py
@@ -1,0 +1,100 @@
+"""Optional OpenTelemetry trace-context activation for log correlation.
+
+This module lets ``azure-functions-logging`` bind the Azure Functions host's
+incoming W3C trace context into the current execution context so that an
+OpenTelemetry ``LoggingHandler`` (owned by the host or the user's OTel setup)
+stamps emitted log records with the host span's ``trace_id`` and ``span_id``.
+
+Design constraints (see README "What this package does not do"):
+
+* This package never creates, records, or exports a span. It only *attaches*
+  the already-existing remote span context extracted from the ``traceparent``
+  header, using :func:`opentelemetry.context.attach` /
+  :func:`opentelemetry.context.detach`.
+* ``opentelemetry-api`` is an **optional** dependency (the ``[otel]`` extra).
+  The base install stays zero-dependency: every entry point degrades to a
+  silent no-op when OpenTelemetry is not importable.
+* Consistent with Principle 3 ("context failures are silent"), no code path
+  here raises as a result of trace-context handling.
+
+Known limitation: OpenTelemetry's runtime context is contextvar-based, so
+correlation does **not** propagate into worker threads spawned via
+``ThreadPoolExecutor`` / ``run_in_executor``. Logs emitted from such threads
+are orphaned. This matches the behaviour pinned by the spike test suite.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from contextlib import contextmanager
+
+
+def is_available() -> bool:
+    """Return ``True`` when the OpenTelemetry API is importable.
+
+    Only the API package (``opentelemetry-api``) is required — the SDK,
+    exporters, and a ``TracerProvider`` are owned by the host or the user.
+    """
+    try:
+        import opentelemetry.context  # noqa: F401
+        import opentelemetry.propagate  # noqa: F401
+    except Exception:  # nosec B110 — optional dependency; absence is expected
+        return False
+    return True
+
+
+@contextmanager
+def activated_trace_context(
+    trace_parent: str | None,
+    trace_state: str | None = None,
+) -> Iterator[None]:
+    """Attach the host trace context for the duration of the ``with`` block.
+
+    While the block is active, OpenTelemetry's "current span" is the
+    non-recording remote span described by *trace_parent*, so any log record
+    emitted through an OTel ``LoggingHandler`` inherits the host's
+    ``trace_id`` and ``span_id``.
+
+    The context is always detached (LIFO) on exit, including when the block
+    raises, so no trace context leaks into the next invocation on a reused
+    worker.
+
+    This is a silent no-op — yielding without attaching anything — when:
+
+    * *trace_parent* is empty/``None``;
+    * OpenTelemetry is not installed (:func:`is_available` is ``False``);
+    * extraction/attach fails for any reason (malformed header, etc.).
+
+    Args:
+        trace_parent: The W3C ``traceparent`` header value from the host.
+        trace_state: The optional W3C ``tracestate`` header value.
+    """
+    if not trace_parent or not is_available():
+        yield
+        return
+
+    try:
+        from opentelemetry import context as otel_context
+        from opentelemetry.propagate import extract as otel_extract
+    except Exception:  # nosec B110 — optional dependency; degrade to no-op
+        yield
+        return
+
+    carrier: dict[str, str] = {"traceparent": trace_parent}
+    if trace_state:
+        carrier["tracestate"] = trace_state
+
+    token = None
+    try:
+        token = otel_context.attach(otel_extract(carrier))
+    except Exception:  # nosec B110 — Principle 3: context failures are silent
+        token = None
+
+    try:
+        yield
+    finally:
+        if token is not None:
+            try:
+                otel_context.detach(token)
+            except Exception:  # nosec B110 — Principle 3: silent on cleanup
+                pass

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -81,6 +81,8 @@ def test_get_logger_returns_function_logger() -> None:
 def test_public_api_exports() -> None:
     expected = {
         "__version__",
+        "activated_trace_context",
+        "AttributeFlattenFilter",
         "ContextTokens",
         "FunctionLogger",
         "JsonFormatter",

--- a/tests/test_otel.py
+++ b/tests/test_otel.py
@@ -1,0 +1,299 @@
+"""Tests for the optional OpenTelemetry trace-context activation (issue #255).
+
+These validate the production ``activated_trace_context`` context manager that
+attaches the host's W3C trace context so an OTel ``LoggingHandler`` stamps
+emitted records with the host span's ``trace_id``/``span_id`` — without this
+package ever creating, recording, or exporting a span.
+
+The OTel-dependent tests skip cleanly when ``opentelemetry-api`` is absent, so
+the base install stays zero-dependency.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from azure_functions_logging import _otel
+
+_TRACE_ID_HEX = "4bf92f3577b34da6a3ce929d0e0e4736"
+_PARENT_ID_HEX = "00f067aa0ba902b7"
+_TRACEPARENT = f"00-{_TRACE_ID_HEX}-{_PARENT_ID_HEX}-01"
+
+
+def test_is_available_reflects_otel_import() -> None:
+    # In this repo's test env opentelemetry-api is installed, so this is True.
+    pytest.importorskip("opentelemetry.context")
+    assert _otel.is_available() is True
+
+
+def test_activated_trace_context_is_noop_when_traceparent_missing() -> None:
+    # Must not raise and must yield even with no traceparent.
+    with _otel.activated_trace_context(None):
+        pass
+    with _otel.activated_trace_context(""):
+        pass
+
+
+def test_activated_trace_context_noop_when_otel_unavailable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(_otel, "is_available", lambda: False)
+    # Even with a valid traceparent, absence of OTel must degrade to a no-op.
+    with _otel.activated_trace_context(_TRACEPARENT):
+        pass
+
+
+def test_activated_trace_context_binds_host_span() -> None:
+    pytest.importorskip("opentelemetry.context")
+    from opentelemetry import trace
+
+    assert not trace.get_current_span().get_span_context().is_valid
+    with _otel.activated_trace_context(_TRACEPARENT):
+        span_context = trace.get_current_span().get_span_context()
+        assert span_context.is_valid
+        assert span_context.is_remote is True
+        assert format(span_context.trace_id, "032x") == _TRACE_ID_HEX
+        assert format(span_context.span_id, "016x") == _PARENT_ID_HEX
+    # Context restored (LIFO detach) after the block.
+    assert not trace.get_current_span().get_span_context().is_valid
+
+
+def test_activated_trace_context_detaches_on_exception() -> None:
+    pytest.importorskip("opentelemetry.context")
+    from opentelemetry import trace
+
+    with pytest.raises(ValueError):
+        with _otel.activated_trace_context(_TRACEPARENT):
+            raise ValueError("boom")
+    assert not trace.get_current_span().get_span_context().is_valid
+
+
+def test_activated_trace_context_honours_trace_state() -> None:
+    pytest.importorskip("opentelemetry.context")
+    from opentelemetry import trace
+
+    with _otel.activated_trace_context(_TRACEPARENT, trace_state="vendor=abc"):
+        span_context = trace.get_current_span().get_span_context()
+        assert span_context.is_valid
+        assert span_context.trace_state.get("vendor") == "abc"
+
+
+def test_activated_trace_context_survives_malformed_traceparent() -> None:
+    # A structurally invalid traceparent must never raise out of the CM.
+    with _otel.activated_trace_context("not-a-valid-traceparent"):
+        pass
+
+
+# ---------------------------------------------------------------------------
+# Integration: activation wired through the public entry points
+# ---------------------------------------------------------------------------
+
+
+def _make_context(
+    trace_parent: str | None = _TRACEPARENT,
+    trace_state: str | None = None,
+) -> SimpleNamespace:
+
+    return SimpleNamespace(
+        invocation_id="inv-1",
+        function_name="fn-a",
+        trace_context=SimpleNamespace(
+            trace_parent=trace_parent,
+            trace_state=trace_state,
+        ),
+    )
+
+
+def test_logging_context_activates_host_span_when_enabled() -> None:
+    pytest.importorskip("opentelemetry.context")
+    from opentelemetry import trace
+
+    from azure_functions_logging import logging_context
+
+    with logging_context(_make_context(), activate_trace_context=True):
+        sc = trace.get_current_span().get_span_context()
+        assert sc.is_valid
+        assert format(sc.span_id, "016x") == _PARENT_ID_HEX
+    assert not trace.get_current_span().get_span_context().is_valid
+
+
+def test_logging_context_does_not_activate_when_explicitly_disabled() -> None:
+    pytest.importorskip("opentelemetry.context")
+    from opentelemetry import trace
+
+    from azure_functions_logging import logging_context
+    from azure_functions_logging._context import set_default_trace_context_activation
+
+    # An explicit per-call ``False`` must override the auto default and stay off,
+    # even when OpenTelemetry is importable.
+    try:
+        set_default_trace_context_activation(None)
+        with logging_context(_make_context(), activate_trace_context=False):
+            assert not trace.get_current_span().get_span_context().is_valid
+    finally:
+        set_default_trace_context_activation(None)
+
+
+def test_logging_context_auto_activates_when_otel_available() -> None:
+    pytest.importorskip("opentelemetry.context")
+    from opentelemetry import trace
+
+    from azure_functions_logging import logging_context
+    from azure_functions_logging._context import set_default_trace_context_activation
+
+    # Auto tier (#255): with no explicit flag and no configured default,
+    # activation is enabled iff opentelemetry-api is importable — which it is
+    # in this test env.
+    try:
+        set_default_trace_context_activation(None)
+        with logging_context(_make_context()):
+            assert trace.get_current_span().get_span_context().is_valid
+    finally:
+        set_default_trace_context_activation(None)
+
+
+def test_with_context_activates_host_span_when_enabled() -> None:
+    pytest.importorskip("opentelemetry.context")
+    from opentelemetry import trace
+
+    from azure_functions_logging import with_context
+
+    seen: dict[str, bool] = {}
+
+    @with_context(activate_trace_context=True)
+    def handler(req: object, context: object) -> str:
+        seen["valid"] = trace.get_current_span().get_span_context().is_valid
+        return "ok"
+
+    assert handler(None, _make_context()) == "ok"
+    assert seen["valid"] is True
+    assert not trace.get_current_span().get_span_context().is_valid
+
+
+def test_setup_logging_sets_default_activation() -> None:
+    pytest.importorskip("opentelemetry.context")
+    from opentelemetry import trace
+
+    from azure_functions_logging import logging_context, setup_logging
+    from azure_functions_logging._context import set_default_trace_context_activation
+
+    try:
+        setup_logging(logger_name="afl.otel.default", activate_trace_context=True)
+        with logging_context(_make_context()):
+            assert trace.get_current_span().get_span_context().is_valid
+    finally:
+        set_default_trace_context_activation(None)
+
+
+# ---------------------------------------------------------------------------
+# Auto tier (#255): default None resolves to "enabled iff opentelemetry-api
+# is importable".
+# ---------------------------------------------------------------------------
+
+
+def test_get_default_activation_auto_enabled_when_otel_available(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from azure_functions_logging import _context
+
+    monkeypatch.setattr(_context, "_default_trace_context_activation", None)
+    monkeypatch.setattr(_otel, "is_available", lambda: True)
+    assert _context.get_default_trace_context_activation() is True
+
+
+def test_get_default_activation_auto_disabled_when_otel_absent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from azure_functions_logging import _context
+
+    monkeypatch.setattr(_context, "_default_trace_context_activation", None)
+    monkeypatch.setattr(_otel, "is_available", lambda: False)
+    assert _context.get_default_trace_context_activation() is False
+
+
+def test_get_default_activation_explicit_overrides_auto(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from azure_functions_logging import _context
+
+    # An explicit stored default short-circuits the auto probe entirely.
+    monkeypatch.setattr(_context, "_default_trace_context_activation", False)
+    monkeypatch.setattr(_otel, "is_available", lambda: True)
+    assert _context.get_default_trace_context_activation() is False
+
+
+def test_resolve_auto_returns_false_when_otel_import_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import sys
+
+    from azure_functions_logging import _context
+
+    # Simulate the base (zero-dependency) install where importing the helper's
+    # ``is_available`` path is fine but OTel itself is absent.
+    monkeypatch.setitem(sys.modules, "opentelemetry.context", None)
+    monkeypatch.setitem(sys.modules, "opentelemetry.propagate", None)
+    assert _context._resolve_auto_trace_context_activation() is False
+
+
+# ---------------------------------------------------------------------------
+# _otel silent-failure paths (Principle 3): every branch degrades to a no-op.
+# ---------------------------------------------------------------------------
+
+
+def test_is_available_false_when_import_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    import sys
+
+    monkeypatch.setitem(sys.modules, "opentelemetry.context", None)
+    assert _otel.is_available() is False
+
+
+def test_activated_trace_context_noop_when_extract_import_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import sys
+
+    pytest.importorskip("opentelemetry.context")
+    # OTel appears available (is_available forced True), but importing the
+    # propagate API inside the context manager fails.
+    monkeypatch.setattr(_otel, "is_available", lambda: True)
+    monkeypatch.setitem(sys.modules, "opentelemetry.propagate", None)
+    with _otel.activated_trace_context(_TRACEPARENT):
+        pass
+
+
+def test_activated_trace_context_noop_when_attach_raises(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    pytest.importorskip("opentelemetry.context")
+    from opentelemetry import context as otel_context
+
+    def _boom(_ctx: object) -> None:
+        raise RuntimeError("attach failed")
+
+    monkeypatch.setattr(otel_context, "attach", _boom)
+    # Attach failure must be swallowed; the block still runs and detach is skipped.
+    with _otel.activated_trace_context(_TRACEPARENT):
+        pass
+
+
+def test_activated_trace_context_swallows_detach_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    pytest.importorskip("opentelemetry.context")
+    from opentelemetry import context as otel_context
+
+    real_detach = otel_context.detach
+
+    def _boom(token: object) -> None:
+        # Perform the real detach first so global OTel context is not leaked
+        # into later tests, then raise to exercise the silent-cleanup branch.
+        real_detach(token)  # type: ignore[arg-type]
+        raise RuntimeError("detach failed")
+
+    monkeypatch.setattr(otel_context, "detach", _boom)
+    # A failing detach on cleanup must never propagate.
+    with _otel.activated_trace_context(_TRACEPARENT):
+        pass

--- a/tests/test_otel_spike.py
+++ b/tests/test_otel_spike.py
@@ -1,0 +1,189 @@
+"""OpenTelemetry log-correlation spike, kept as a regression guard (issue #253).
+
+The original spike proved that attaching the host's W3C trace context lets an
+OpenTelemetry ``LoggingHandler`` stamp emitted log records with the host span's
+``trace_id`` / ``span_id`` — without this package ever creating, recording, or
+exporting a span. Per #253 the spike itself is retained here so the pinned
+behaviour (including its known thread-boundary limitation) cannot silently
+regress.
+
+These tests require the OpenTelemetry SDK. They skip cleanly when it is absent,
+so the base install stays zero-dependency.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from concurrent.futures import ThreadPoolExecutor
+import logging
+from types import SimpleNamespace
+from typing import TYPE_CHECKING, Any
+
+import pytest
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+pytest.importorskip("opentelemetry.sdk._logs")
+
+from opentelemetry.sdk._logs import LoggerProvider, LoggingHandler  # noqa: E402
+from opentelemetry.sdk._logs.export import (  # noqa: E402
+    InMemoryLogRecordExporter,
+    SimpleLogRecordProcessor,
+)
+
+from azure_functions_logging import logging_context  # noqa: E402
+
+# W3C traceparent fixtures. ``_PARENT_ID`` is the host span-id every correlated
+# record must inherit.
+_TRACE_ID = "4bf92f3577b34da6a3ce929d0e0e4736"
+_PARENT_ID = "00f067aa0ba902b7"
+_TRACEPARENT = f"00-{_TRACE_ID}-{_PARENT_ID}-01"
+
+# A second, distinct host span for concurrency-isolation assertions.
+_TRACE_ID_B = "0af7651916cd43dd8448eb211c80319c"
+_PARENT_ID_B = "b7ad6b7169203331"
+_TRACEPARENT_B = f"00-{_TRACE_ID_B}-{_PARENT_ID_B}-01"
+
+
+def _make_context(trace_parent: str | None = _TRACEPARENT) -> SimpleNamespace:
+    return SimpleNamespace(
+        invocation_id="inv-1",
+        function_name="fn-a",
+        trace_context=SimpleNamespace(trace_parent=trace_parent, trace_state=None),
+    )
+
+
+@pytest.fixture
+def otel_logger() -> Iterator[tuple[logging.Logger, InMemoryLogRecordExporter]]:
+    """A logger wired to an in-memory OTel ``LoggingHandler``."""
+    provider = LoggerProvider()
+    exporter = InMemoryLogRecordExporter()  # type: ignore[no-untyped-call]
+    provider.add_log_record_processor(SimpleLogRecordProcessor(exporter))
+    handler = LoggingHandler(logger_provider=provider)
+
+    logger = logging.getLogger("afl.otel.spike")
+    logger.setLevel(logging.INFO)
+    logger.addHandler(handler)
+    logger.propagate = False
+    try:
+        yield logger, exporter
+    finally:
+        logger.removeHandler(handler)
+        provider.shutdown()
+
+
+def _only_record(exporter: InMemoryLogRecordExporter) -> Any:
+    logs = exporter.get_finished_logs()
+    assert len(logs) == 1
+    return logs[0].log_record
+
+
+def test_spike_sync_record_inherits_host_span(
+    otel_logger: tuple[logging.Logger, InMemoryLogRecordExporter],
+) -> None:
+    logger, exporter = otel_logger
+    with logging_context(_make_context(), activate_trace_context=True):
+        logger.info("hello")
+    record = _only_record(exporter)
+    assert format(record.trace_id, "032x") == _TRACE_ID
+    assert format(record.span_id, "016x") == _PARENT_ID
+
+
+def test_spike_correlation_survives_await(
+    otel_logger: tuple[logging.Logger, InMemoryLogRecordExporter],
+) -> None:
+    logger, exporter = otel_logger
+
+    async def handler() -> None:
+        with logging_context(_make_context(), activate_trace_context=True):
+            await asyncio.sleep(0)
+            logger.info("after await")
+
+    asyncio.run(handler())
+    record = _only_record(exporter)
+    assert format(record.span_id, "016x") == _PARENT_ID
+
+
+def test_spike_gather_isolates_concurrent_contexts(
+    otel_logger: tuple[logging.Logger, InMemoryLogRecordExporter],
+) -> None:
+    logger, exporter = otel_logger
+
+    async def emit(trace_parent: str, message: str) -> None:
+        with logging_context(_make_context(trace_parent), activate_trace_context=True):
+            await asyncio.sleep(0)
+            logger.info(message)
+
+    async def run() -> None:
+        await asyncio.gather(
+            emit(_TRACEPARENT, "a"),
+            emit(_TRACEPARENT_B, "b"),
+        )
+
+    asyncio.run(run())
+
+    by_message = {
+        rec.log_record.body: format(rec.log_record.span_id, "016x")
+        for rec in exporter.get_finished_logs()
+    }
+    # Each concurrent task's record carries only its own host span — no bleed.
+    assert by_message == {"a": _PARENT_ID, "b": _PARENT_ID_B}
+
+
+def test_spike_thread_boundary_loses_correlation(
+    otel_logger: tuple[logging.Logger, InMemoryLogRecordExporter],
+) -> None:
+    """Known limitation: OTel runtime context is contextvar-based, so worker
+    threads spawned via ``ThreadPoolExecutor`` do NOT inherit the host span.
+    Pinned as a regression guard (span_id == 0 in the spawned thread)."""
+    logger, exporter = otel_logger
+
+    with logging_context(_make_context(), activate_trace_context=True):
+        with ThreadPoolExecutor(max_workers=1) as pool:
+            pool.submit(logger.info, "from thread").result()
+
+    record = _only_record(exporter)
+    assert record.span_id == 0
+
+
+def test_spike_nested_contexts_restore_outer_span(
+    otel_logger: tuple[logging.Logger, InMemoryLogRecordExporter],
+) -> None:
+    logger, exporter = otel_logger
+
+    with logging_context(_make_context(_TRACEPARENT), activate_trace_context=True):
+        with logging_context(_make_context(_TRACEPARENT_B), activate_trace_context=True):
+            logger.info("inner")
+        logger.info("outer")
+
+    spans = {
+        rec.log_record.body: format(rec.log_record.span_id, "016x")
+        for rec in exporter.get_finished_logs()
+    }
+    assert spans == {"inner": _PARENT_ID_B, "outer": _PARENT_ID}
+
+
+def test_spike_exception_path_detaches_context(
+    otel_logger: tuple[logging.Logger, InMemoryLogRecordExporter],
+) -> None:
+    logger, exporter = otel_logger
+
+    with pytest.raises(ValueError):
+        with logging_context(_make_context(), activate_trace_context=True):
+            raise ValueError("boom")
+
+    # After the failing block the host span must be detached: a later record
+    # emitted outside any context is uncorrelated.
+    logger.info("after")
+    record = _only_record(exporter)
+    assert record.span_id == 0
+
+
+def test_spike_no_context_is_uncorrelated(
+    otel_logger: tuple[logging.Logger, InMemoryLogRecordExporter],
+) -> None:
+    logger, exporter = otel_logger
+    logger.info("orphan")
+    record = _only_record(exporter)
+    assert record.span_id == 0

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -9,6 +9,8 @@ class TestAPISurface:
     def test_all_exports(self) -> None:
         assert set(azure_functions_logging.__all__) == {
             "__version__",
+            "activated_trace_context",
+            "AttributeFlattenFilter",
             "ContextTokens",
             "FunctionLogger",
             "JsonFormatter",
@@ -36,11 +38,13 @@ class TestAPISurface:
 
     def test_public_names_are_importable(self) -> None:
         from azure_functions_logging import (  # noqa: F401  # pyright: ignore[reportMissingImports]
+            AttributeFlattenFilter,
             ContextTokens,
             FunctionLogger,
             JsonFormatter,
             RedactionFilter,
             SamplingFilter,
+            activated_trace_context,
             get_logger,
             get_logging_metadata,
             inject_context,
@@ -70,8 +74,7 @@ class TestDocsCoverage:
         missing = [
             name
             for name in azure_functions_logging.__all__
-            if name != "__version__"
-            and f"::: azure_functions_logging.{name}" not in text
+            if name != "__version__" and f"::: azure_functions_logging.{name}" not in text
         ]
         assert not missing, (
             "Public symbols missing an mkdocstrings directive "


### PR DESCRIPTION
Stacked PR **4/7** · base: `otel/260-flatten-filter` (#260)

Bind the Azure Functions host's W3C trace context into handlers so OpenTelemetry log records inherit the host invocation span's `trace_id`/`span_id` — without creating, recording, or exporting spans. Adds the `[otel]` extra, `activated_trace_context()`/`is_available()`, setup/decorator/`logging_context` activation plumbing, and the public export. Silent no-op when OpenTelemetry is not installed.

Closes #253, #255 · Refs #252

> Review only the top commit; the diff is stacked on #260.