### PR TITLE
feat(diagnostics): warn on OpenTelemetry logging misconfiguration (#256)

### DIFF
--- a/src/azure_functions_logging/_host_config.py
+++ b/src/azure_functions_logging/_host_config.py
@@ -207,8 +207,7 @@ def warn_host_json_level_conflict(
     # Only allow recognized app-setting values to override; unrecognized values
     # (e.g. typos) must not mask a restrictive host.json entry.
     normalized_host: dict[str, object] = {
-        (k.lower() if k.lower() == "default" else k): v
-        for k, v in host_json_log_levels.items()
+        (k.lower() if k.lower() == "default" else k): v for k, v in host_json_log_levels.items()
     }
     normalized_app: dict[str, object] = {}
     for k, v in app_setting_log_levels.items():
@@ -229,3 +228,122 @@ def warn_host_json_level_conflict(
         source="host configuration",
         stacklevel=3,
     )
+
+
+def _has_otel_logging_handler(logger: logging.Logger) -> bool:
+    """Return True if *logger* has an OpenTelemetry logging handler attached.
+
+    Detection is **import-free**: it inspects each handler's defining module
+    name rather than importing OpenTelemetry. This covers both
+    ``opentelemetry.sdk._logs`` and ``opentelemetry.instrumentation.logging``
+    handlers, and stays a no-op when OpenTelemetry is not installed.
+    """
+    for handler in logger.handlers:
+        module = type(handler).__module__ or ""
+        if module.startswith("opentelemetry."):
+            return True
+    return False
+
+
+def _read_host_telemetry_mode(host_json_path: Path | str | None) -> str | None:
+    """Return the ``telemetryMode`` string from ``host.json``, or ``None``.
+
+    Uses the same discovery rules as :func:`warn_host_json_level_conflict`.
+    Never raises: any read/parse failure yields ``None``.
+    """
+    host_path: Path | None
+    if host_json_path is not None:
+        host_path = Path(host_json_path)
+        try:
+            if not host_path.is_file():
+                return None
+        except OSError:
+            return None
+    else:
+        host_path = discover_host_json()
+    if host_path is None:
+        return None
+    try:
+        host_config: object = json.loads(host_path.read_text(encoding="utf-8"))
+        host_mapping = _string_key_mapping(host_config)
+        if host_mapping is None:
+            return None
+        mode = host_mapping.get("telemetryMode")
+        return mode if isinstance(mode, str) else None
+    except Exception:  # nosec B110 — host.json read failure is non-fatal
+        return None
+
+
+# App settings that signal the host will export OpenTelemetry logs. Microsoft
+# docs reference both names (likely a mid-rename), so either being set counts.
+_OTEL_TELEMETRY_ENV_VARS: tuple[str, ...] = (
+    "PYTHON_ENABLE_OPENTELEMETRY",
+    "PYTHON_APPLICATIONINSIGHTS_ENABLE_TELEMETRY",
+)
+
+
+def warn_otel_logging_misconfig(
+    *,
+    functions_formatter: logging.Formatter | None = None,
+    host_json_path: Path | str | None = None,
+    stacklevel: int = 3,
+) -> None:
+    """Warn on common OpenTelemetry logging misconfigurations (issue #256).
+
+    These checks run at ``setup_logging()`` call time and assume the documented
+    call order: ``configure_azure_monitor()`` **before** ``setup_logging()`` so
+    the OpenTelemetry ``LoggingHandler`` is already attached to the root logger.
+
+    Emits up to three independent warnings:
+
+    - **6a** — an OTel handler is present **and** ``functions_formatter`` was
+      passed: the formatter is never invoked (the OTel handler formats records
+      itself), so the argument is silently ignored.
+    - **6b** — an OTel handler is present but neither telemetry env var is set:
+      the host may not export these logs. Worded tentatively because the
+      environment is not fully observable from inside the worker.
+    - **6c** — ``host.json`` requests ``telemetryMode: OpenTelemetry`` but no
+      OTel handler is attached: most often a call-order mistake. Worded as an
+      ordering hint rather than a definitive "worker unconfigured" claim, so it
+      does not cry wolf when the handler is simply attached later.
+    """
+    root = logging.getLogger()
+    has_otel_handler = _has_otel_logging_handler(root)
+
+    # 6a: OTel handler present AND a functions_formatter was supplied.
+    if has_otel_handler and functions_formatter is not None:
+        warnings.warn(
+            (
+                "An OpenTelemetry logging handler is attached, so the "
+                "'functions_formatter' passed to setup_logging() is ignored "
+                "— the OpenTelemetry handler formats and exports records itself."
+            ),
+            stacklevel=stacklevel,
+        )
+
+    # 6b: OTel handler present but neither telemetry env var is set (tentative).
+    if has_otel_handler and not any(os.environ.get(name) for name in _OTEL_TELEMETRY_ENV_VARS):
+        joined = " or ".join(_OTEL_TELEMETRY_ENV_VARS)
+        warnings.warn(
+            (
+                "An OpenTelemetry logging handler is attached but neither "
+                f"{joined} appears to be set. Depending on your host "
+                "configuration, these logs may not be exported — verify your "
+                "telemetry settings."
+            ),
+            stacklevel=stacklevel,
+        )
+
+    # 6c: host.json requests OpenTelemetry mode but no OTel handler detected.
+    if not has_otel_handler:
+        mode = _read_host_telemetry_mode(host_json_path)
+        if mode is not None and mode.lower() == "opentelemetry":
+            warnings.warn(
+                (
+                    "host.json sets telemetryMode 'OpenTelemetry' but no "
+                    "OpenTelemetry logging handler is attached yet. If you use "
+                    "configure_azure_monitor(), call it before setup_logging() "
+                    "so filters and context land on the OpenTelemetry handler."
+                ),
+                stacklevel=stacklevel,
+            )

--- a/src/azure_functions_logging/_setup.py
+++ b/src/azure_functions_logging/_setup.py
@@ -11,9 +11,9 @@ from typing import Any
 import warnings
 import weakref
 
-from ._context import ContextFilter, _install_context_factory
+from ._context import ContextFilter, _install_context_factory, set_default_trace_context_activation
 from ._formatter import ColorFormatter
-from ._host_config import warn_host_json_level_conflict
+from ._host_config import warn_host_json_level_conflict, warn_otel_logging_misconfig
 from ._json_formatter import JsonFormatter
 
 # Track configured logger names to ensure per-logger idempotency (local mode).
@@ -65,6 +65,7 @@ def setup_logging(
     host_json_path: Path | str | None = None,
     use_record_factory: bool = False,
     extra_context_vars: dict[str, contextvars.ContextVar[Any]] | None = None,
+    activate_trace_context: bool | None = None,
 ) -> None:
     """Configure logging for the current environment.
     Behavior depends on the detected environment:
@@ -114,6 +115,15 @@ def setup_logging(
             LogRecord, alongside the four built-in context fields. Field names
             must not collide with the built-in fields. Only applies to the
             ``ContextFilter`` strategy (ignored when ``use_record_factory=True``).
+        activate_trace_context: Sets the process-wide default that
+            ``logging_context`` and ``with_context`` consult to attach the
+            host's W3C trace context (via OpenTelemetry) — making OTel log
+            records inherit the host span's ``trace_id``/``span_id``. Requires
+            the ``[otel]`` extra; degrades to a silent no-op when OpenTelemetry
+            is not installed. ``True``/``False`` force the default on/off; the
+            default ``None`` selects the ``auto`` tier (enabled iff
+            ``opentelemetry-api`` is importable). A per-call
+            ``activate_trace_context`` argument overrides this default.
 
     .. warning::
 
@@ -128,6 +138,8 @@ def setup_logging(
     if format not in {"color", "json"}:
         msg = "format must be 'color' or 'json'"
         raise ValueError(msg)
+
+    set_default_trace_context_activation(activate_trace_context)
 
     # Install the global LogRecordFactory only after argument validation,
     # so an invalid call does not leave persistent global side effects.
@@ -187,6 +199,10 @@ def setup_logging(
                 root.addFilter(context_filter)
 
             warn_host_json_level_conflict(level, host_json_path=host_json_path)
+            warn_otel_logging_misconfig(
+                functions_formatter=functions_formatter,
+                host_json_path=host_json_path,
+            )
 
         else:
             # Standalone local development: full idempotency via logger name.

--- a/tests/test_host_config_otel.py
+++ b/tests/test_host_config_otel.py
@@ -1,0 +1,268 @@
+"""Tests for OpenTelemetry logging misconfiguration warnings (issue #256).
+
+These cover ``warn_otel_logging_misconfig`` and its import-free helpers:
+
+- **6a** — OTel handler present *and* ``functions_formatter`` supplied → warn ignored.
+- **6b** — OTel handler present but no telemetry env var set → tentative warning.
+- **6c** — ``host.json`` requests OpenTelemetry mode but no OTel handler → ordering hint.
+
+A key requirement is **no false positives** in the wrong-call-order scenario:
+when no OTel handler is attached and ``host.json`` does not request OpenTelemetry,
+the function must stay silent regardless of ``functions_formatter``.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+import json
+import logging
+from pathlib import Path
+import warnings
+
+import pytest
+
+from azure_functions_logging._host_config import (
+    _has_otel_logging_handler,
+    _read_host_telemetry_mode,
+    warn_otel_logging_misconfig,
+)
+
+
+def _write_host_json(path: Path, content: dict[str, object]) -> None:
+    path.write_text(json.dumps(content), encoding="utf-8")
+
+
+class _FakeOtelHandler(logging.Handler):
+    """A stand-in whose defining module mimics OpenTelemetry's SDK handler."""
+
+    def emit(self, record: logging.LogRecord) -> None:  # pragma: no cover - no-op
+        pass
+
+
+# Make the import-free module-name detection treat this as an OTel handler.
+_FakeOtelHandler.__module__ = "opentelemetry.sdk._logs._internal"
+
+
+class _PlainHandler(logging.Handler):
+    def emit(self, record: logging.LogRecord) -> None:  # pragma: no cover - no-op
+        pass
+
+
+@pytest.fixture
+def clean_root() -> Iterator[logging.Logger]:
+    """Provide the root logger with its handlers/filters restored after the test."""
+    root = logging.getLogger()
+    saved_handlers = root.handlers[:]
+    saved_filters = root.filters[:]
+    root.handlers = []
+    root.filters = []
+    try:
+        yield root
+    finally:
+        root.handlers = saved_handlers
+        root.filters = saved_filters
+
+
+@pytest.fixture(autouse=True)
+def _clear_otel_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Ensure telemetry env vars are unset unless a test sets them explicitly."""
+    monkeypatch.delenv("PYTHON_ENABLE_OPENTELEMETRY", raising=False)
+    monkeypatch.delenv("PYTHON_APPLICATIONINSIGHTS_ENABLE_TELEMETRY", raising=False)
+
+
+# --------------------------------------------------------------------------- #
+# _has_otel_logging_handler
+# --------------------------------------------------------------------------- #
+
+
+def test_has_otel_logging_handler_detects_otel_module(clean_root: logging.Logger) -> None:
+    clean_root.addHandler(_FakeOtelHandler())
+    assert _has_otel_logging_handler(clean_root) is True
+
+
+def test_has_otel_logging_handler_false_for_plain_handler(clean_root: logging.Logger) -> None:
+    clean_root.addHandler(_PlainHandler())
+    assert _has_otel_logging_handler(clean_root) is False
+
+
+def test_has_otel_logging_handler_false_when_no_handlers(clean_root: logging.Logger) -> None:
+    assert _has_otel_logging_handler(clean_root) is False
+
+
+# --------------------------------------------------------------------------- #
+# _read_host_telemetry_mode
+# --------------------------------------------------------------------------- #
+
+
+def test_read_host_telemetry_mode_explicit_path(tmp_path: Path) -> None:
+    host = tmp_path / "host.json"
+    _write_host_json(host, {"telemetryMode": "OpenTelemetry"})
+    assert _read_host_telemetry_mode(host) == "OpenTelemetry"
+
+
+def test_read_host_telemetry_mode_missing_key(tmp_path: Path) -> None:
+    host = tmp_path / "host.json"
+    _write_host_json(host, {"version": "2.0"})
+    assert _read_host_telemetry_mode(host) is None
+
+
+def test_read_host_telemetry_mode_non_string(tmp_path: Path) -> None:
+    host = tmp_path / "host.json"
+    _write_host_json(host, {"telemetryMode": 123})
+    assert _read_host_telemetry_mode(host) is None
+
+
+def test_read_host_telemetry_mode_missing_file(tmp_path: Path) -> None:
+    assert _read_host_telemetry_mode(tmp_path / "nope.json") is None
+
+
+def test_read_host_telemetry_mode_malformed(tmp_path: Path) -> None:
+    host = tmp_path / "host.json"
+    host.write_text("not valid json", encoding="utf-8")
+    assert _read_host_telemetry_mode(host) is None
+
+
+def test_read_host_telemetry_mode_autodiscovers(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _write_host_json(tmp_path / "host.json", {"telemetryMode": "OpenTelemetry"})
+    monkeypatch.chdir(tmp_path)
+    assert _read_host_telemetry_mode(None) == "OpenTelemetry"
+
+
+def test_read_host_telemetry_mode_non_mapping(tmp_path: Path) -> None:
+    # A top-level JSON array is valid JSON but not a mapping.
+    host = tmp_path / "host.json"
+    host.write_text("[1, 2, 3]", encoding="utf-8")
+    assert _read_host_telemetry_mode(host) is None
+
+
+def test_read_host_telemetry_mode_oserror_on_stat(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    host = tmp_path / "host.json"
+    _write_host_json(host, {"telemetryMode": "OpenTelemetry"})
+
+    def _boom(self: Path) -> bool:
+        raise OSError("stat failed")
+
+    monkeypatch.setattr(Path, "is_file", _boom)
+    assert _read_host_telemetry_mode(host) is None
+
+
+# --------------------------------------------------------------------------- #
+# 6a — functions_formatter ignored when OTel handler present
+# --------------------------------------------------------------------------- #
+
+
+def test_6a_warns_when_formatter_passed_with_otel_handler(
+    clean_root: logging.Logger,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    clean_root.addHandler(_FakeOtelHandler())
+    # Set a telemetry env var so 6b stays silent; isolate 6a.
+    monkeypatch.setenv("PYTHON_ENABLE_OPENTELEMETRY", "1")
+    with pytest.warns(UserWarning, match="functions_formatter"):
+        warn_otel_logging_misconfig(functions_formatter=logging.Formatter())
+
+
+def test_6a_silent_when_no_formatter(
+    clean_root: logging.Logger,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    clean_root.addHandler(_FakeOtelHandler())
+    # env var set so 6b does not fire; only 6a is under test here.
+    monkeypatch.setenv("PYTHON_ENABLE_OPENTELEMETRY", "1")
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        warn_otel_logging_misconfig(functions_formatter=None)
+
+
+# --------------------------------------------------------------------------- #
+# 6b — OTel handler present but no telemetry env var
+# --------------------------------------------------------------------------- #
+
+
+def test_6b_warns_when_no_telemetry_env_var(clean_root: logging.Logger) -> None:
+    clean_root.addHandler(_FakeOtelHandler())
+    with pytest.warns(UserWarning, match="may not be exported"):
+        warn_otel_logging_misconfig()
+
+
+@pytest.mark.parametrize(
+    "env_name",
+    ["PYTHON_ENABLE_OPENTELEMETRY", "PYTHON_APPLICATIONINSIGHTS_ENABLE_TELEMETRY"],
+)
+def test_6b_silent_when_env_var_set(
+    clean_root: logging.Logger,
+    monkeypatch: pytest.MonkeyPatch,
+    env_name: str,
+) -> None:
+    clean_root.addHandler(_FakeOtelHandler())
+    monkeypatch.setenv(env_name, "1")
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        warn_otel_logging_misconfig()
+
+
+# --------------------------------------------------------------------------- #
+# 6c — host.json OpenTelemetry mode but no OTel handler
+# --------------------------------------------------------------------------- #
+
+
+def test_6c_warns_on_ordering_mismatch(
+    clean_root: logging.Logger,
+    tmp_path: Path,
+) -> None:
+    host = tmp_path / "host.json"
+    _write_host_json(host, {"telemetryMode": "OpenTelemetry"})
+    with pytest.warns(UserWarning, match="before setup_logging"):
+        warn_otel_logging_misconfig(host_json_path=host)
+
+
+def test_6c_case_insensitive(
+    clean_root: logging.Logger,
+    tmp_path: Path,
+) -> None:
+    host = tmp_path / "host.json"
+    _write_host_json(host, {"telemetryMode": "opentelemetry"})
+    with pytest.warns(UserWarning, match="before setup_logging"):
+        warn_otel_logging_misconfig(host_json_path=host)
+
+
+# --------------------------------------------------------------------------- #
+# No false positives in the wrong-call-order / benign scenarios
+# --------------------------------------------------------------------------- #
+
+
+def test_no_warning_when_no_otel_and_no_host_mode(
+    clean_root: logging.Logger,
+    tmp_path: Path,
+) -> None:
+    host = tmp_path / "host.json"
+    _write_host_json(host, {"version": "2.0"})
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        warn_otel_logging_misconfig(
+            functions_formatter=logging.Formatter(),
+            host_json_path=host,
+        )
+
+
+def test_no_warning_when_no_otel_and_no_host_json(clean_root: logging.Logger) -> None:
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        warn_otel_logging_misconfig(host_json_path=None)
+
+
+def test_6c_silent_for_non_otel_telemetry_mode(
+    clean_root: logging.Logger,
+    tmp_path: Path,
+) -> None:
+    host = tmp_path / "host.json"
+    _write_host_json(host, {"telemetryMode": "ApplicationInsights"})
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        warn_otel_logging_misconfig(host_json_path=host)

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -201,6 +201,40 @@ def test_format_color_no_warning_in_azure_environment() -> None:
     root.filters.clear()
 
 
+def test_setup_logging_warns_on_otel_formatter_conflict() -> None:
+    """setup_logging() wires warn_otel_logging_misconfig (issue #256).
+
+    With an OpenTelemetry handler attached and a functions_formatter passed,
+    the '6a' ignored-formatter warning must surface through setup_logging().
+    """
+    import warnings
+
+    class _FakeOtelHandler(logging.Handler):
+        def emit(self, record: logging.LogRecord) -> None:  # pragma: no cover
+            pass
+
+    _FakeOtelHandler.__module__ = "opentelemetry.sdk._logs._internal"
+
+    root = logging.getLogger()
+    root.handlers = [_FakeOtelHandler()]
+
+    env = {
+        "FUNCTIONS_WORKER_RUNTIME": "python",
+        "PYTHON_ENABLE_OPENTELEMETRY": "1",
+    }
+    try:
+        with patch.dict(os.environ, env, clear=True):
+            with warnings.catch_warnings(record=True) as w:
+                warnings.simplefilter("always")
+                setup_logging(functions_formatter=logging.Formatter())
+
+            messages = [str(rec.message) for rec in w]
+            assert any("functions_formatter" in m for m in messages)
+    finally:
+        root.handlers = []
+        root.filters.clear()
+
+
 def test_setup_logging_use_record_factory_installs_factory() -> None:
     """use_record_factory=True installs the global LogRecordFactory."""
     from azure_functions_logging._context import (
@@ -317,7 +351,13 @@ def test_setup_logging_factory_record_survives_contextvar_reset() -> None:
     token = invocation_id_var.set("test-invocation-123")
     try:
         record = logger.makeRecord(
-            logger_name, logging.INFO, "f.py", 1, "msg", (), None,
+            logger_name,
+            logging.INFO,
+            "f.py",
+            1,
+            "msg",
+            (),
+            None,
         )
     finally:
         invocation_id_var.reset(token)
@@ -345,7 +385,6 @@ def test_setup_logging_invalid_format_leaves_no_global_side_effects() -> None:
     with patch.dict(os.environ, {}, clear=True):
         with pytest.raises(ValueError, match="format must be"):
             setup_logging(format="bogus", use_record_factory=True)
-
 
     # Factory must not have been swapped despite use_record_factory=True
     assert logging.getLogRecordFactory() is baseline_factory
@@ -400,7 +439,7 @@ def test_azure_setup_does_not_duplicate_filter_on_repeated_calls() -> None:
         context_filter_count = sum(
             1 for f in handler.filters if type(f).__name__ == "ContextFilter"
         )
-        assert context_filter_count == 1, (", ".join(type(f).__name__ for f in handler.filters))
+        assert context_filter_count == 1, ", ".join(type(f).__name__ for f in handler.filters)
     finally:
         root.handlers[:] = original_handlers
         root.filters[:] = original_filters
@@ -435,10 +474,12 @@ def test_azure_setup_different_use_record_factory_flags_have_isolated_filter_sta
             (f for f in handler_with_factory.filters if type(f).__name__ == "ContextFilter"), None
         )
 
-        assert filter_no_factory is not None, \
+        assert filter_no_factory is not None, (
             "use_record_factory=False should install a ContextFilter on the handler"
-        assert filter_with_factory is None, \
+        )
+        assert filter_with_factory is None, (
             "use_record_factory=True must not install a ContextFilter (factory provides context)"
+        )
         # The filter installed by the first call must not bleed onto the second handler
         assert filter_no_factory not in handler_with_factory.filters
     finally:
@@ -470,8 +511,9 @@ def test_upgrade_to_record_factory_removes_existing_context_filter_local() -> No
     with patch.dict(os.environ, {}, clear=True):
         # Step 1: install ContextFilter mode
         setup_logging(logger_name=logger_name)
-        assert any(isinstance(f, ContextFilter) for h in logger.handlers for f in h.filters), \
+        assert any(isinstance(f, ContextFilter) for h in logger.handlers for f in h.filters), (
             "precondition: ContextFilter should be on handler"
+        )
 
         # Step 2: upgrade to factory mode — must remove the filter
         setup_mod._configured_loggers.discard(logger_name)  # allow re-entry
@@ -479,8 +521,9 @@ def test_upgrade_to_record_factory_removes_existing_context_filter_local() -> No
 
     # Assert filter is gone
     for handler in logger.handlers:
-        assert not any(isinstance(f, ContextFilter) for f in handler.filters), \
+        assert not any(isinstance(f, ContextFilter) for f in handler.filters), (
             "ContextFilter must be removed after switching to use_record_factory=True"
+        )
 
     # Step 3: create record under context A
     token = invocation_id_var.set("context-A")
@@ -499,8 +542,9 @@ def test_upgrade_to_record_factory_removes_existing_context_filter_local() -> No
                 f.filter(record)
 
     # Factory snapshot must survive
-    assert getattr(record, "invocation_id", None) == "context-A", \
+    assert getattr(record, "invocation_id", None) == "context-A", (
         f"Factory snapshot overwritten — got {getattr(record, 'invocation_id', None)!r}"
+    )
 
     logger.handlers.clear()
     logger.filters.clear()
@@ -529,8 +573,9 @@ def test_upgrade_to_record_factory_removes_context_filter_before_idempotency_gua
         # Even though logger_name is in _configured_loggers, cleanup must run
         setup_logging(logger_name=logger_name, use_record_factory=True)
 
-    assert not any(isinstance(f, ContextFilter) for f in handler.filters), \
+    assert not any(isinstance(f, ContextFilter) for f in handler.filters), (
         "ContextFilter must be removed even when re-entering via idempotency guard"
+    )
 
     logger.handlers.clear()
     logger.filters.clear()
@@ -556,17 +601,20 @@ def test_upgrade_to_record_factory_removes_context_filter_azure_mode() -> None:
         with patch.dict(os.environ, env, clear=True):
             # First call — installs ContextFilter
             setup_logging(use_record_factory=False)
-            assert any(isinstance(f, ContextFilter) for f in test_handler.filters), \
+            assert any(isinstance(f, ContextFilter) for f in test_handler.filters), (
                 "precondition: ContextFilter must be on handler after filter-mode call"
+            )
 
             # Second call — must remove ContextFilter
             setup_logging(use_record_factory=True)
 
         # After factory upgrade: no ContextFilter on handler or root logger
-        assert not any(isinstance(f, ContextFilter) for f in test_handler.filters), \
+        assert not any(isinstance(f, ContextFilter) for f in test_handler.filters), (
             "ContextFilter must be removed from root handler after use_record_factory=True"
-        assert not any(isinstance(f, ContextFilter) for f in root.filters), \
+        )
+        assert not any(isinstance(f, ContextFilter) for f in root.filters), (
             "ContextFilter must be removed from root.filters after use_record_factory=True"
+        )
     finally:
         root.handlers[:] = original_handlers
         root.filters[:] = original_filters
@@ -585,9 +633,7 @@ class TestInjectionModeParity:
     class _Ctx:
         invocation_id = "inv-parity-1"
         function_name = "parity_fn"
-        trace_context = SimpleNamespace(
-            trace_parent="00-" + "a" * 32 + "-" + "b" * 16 + "-01"
-        )
+        trace_context = SimpleNamespace(trace_parent="00-" + "a" * 32 + "-" + "b" * 16 + "-01")
 
     # trace_id extracted from the W3C traceparent above.
     EXPECTED_TRACE_ID = "a" * 32
@@ -616,7 +662,13 @@ class TestInjectionModeParity:
         reset_context()
         inject_context(self._Ctx())
         factory_record = logger.makeRecord(
-            logger_name, logging.INFO, "f.py", 1, "m", (), None,
+            logger_name,
+            logging.INFO,
+            "f.py",
+            1,
+            "m",
+            (),
+            None,
         )
         factory_fields = self._fields(factory_record)
         reset_context()


### PR DESCRIPTION
Stacked PR **5/7** · base: `otel/255-activate` (#255)

`warn_otel_logging_misconfig()` runs at `setup_logging()` time (documented `configure_azure_monitor()`-before-`setup_logging()` order) and emits up to three independent warnings: **6a** `functions_formatter` ignored when an OTel handler is attached, **6b** OTel handler present but no telemetry env var set, **6c** `host.json` `telemetryMode: OpenTelemetry` but no handler attached. Import-free handler detection; no false positives in the wrong-call-order path.

Closes #256 · Refs #252

> Review only the top commit; the diff is stacked on #255.