### PR TITLE
ci(lint): gate ruff format --check in CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,10 @@ hatch-clean: ensure-hatch
 format: ensure-hatch
 	@$(HATCH) run format
 
+.PHONY: format-check
+format-check: ensure-hatch
+	@$(HATCH) run format-check
+
 .PHONY: style
 style: ensure-hatch
 	@$(HATCH) run style

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,7 +78,8 @@ features = ["dev", "docs"]
 
 [tool.hatch.envs.default.scripts]
 format = "ruff format src tests"
-style = "ruff check src tests"
+format-check = "ruff format --check src tests"
+style = "ruff check src tests && ruff format --check src tests"
 typecheck = "mypy src tests"
 lint = "hatch run style && hatch run typecheck"
 test = "pytest -v tests"

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -218,6 +218,8 @@ def test_taskname_is_reserved_on_all_supported_versions_for_backward_compat() ->
     from azure_functions_logging._logger import _RESERVED_LOG_RECORD_KEYS
 
     assert "taskName" in _RESERVED_LOG_RECORD_KEYS
+
+
 def test_merge_precedence_kwargs_override_extra_override_bind() -> None:
     """Issue #95: per-call kwargs > explicit extra > bind context."""
     underlying = _mock_underlying_logger()
@@ -284,7 +286,6 @@ def test_sanitize_extra_double_prefix_conflict() -> None:
     assert extra["extra_name"] == "collides"
     assert extra["extra_name_2"] == "user-supplied"
     assert "name" not in extra
-
 
 
 # ---------------------------------------------------------------------------
@@ -379,8 +380,9 @@ def test_stdlib_record_keys_are_immune_to_custom_logrecord_factory() -> None:
     try:
         # Confirm the factory is polluting makeLogRecord
         factory_fields = set(logging.makeLogRecord({}).__dict__)
-        assert "_third_party_injected_field" in factory_fields, \
+        assert "_third_party_injected_field" in factory_fields, (
             "Precondition failed: factory should inject field into makeLogRecord output"
+        )
 
         # _STDLIB_RECORD_KEYS must match what the base class produces, not the factory
         expected = (
@@ -388,7 +390,8 @@ def test_stdlib_record_keys_are_immune_to_custom_logrecord_factory() -> None:
             | _FORWARD_COMPAT_RECORD_KEYS
         )
         assert _STDLIB_RECORD_KEYS == expected
-        assert "_third_party_injected_field" not in _STDLIB_RECORD_KEYS, \
+        assert "_third_party_injected_field" not in _STDLIB_RECORD_KEYS, (
             "Factory-injected fields must not appear in _STDLIB_RECORD_KEYS"
+        )
     finally:
         logging.setLogRecordFactory(original_factory)

--- a/tests/test_toolkit_metadata.py
+++ b/tests/test_toolkit_metadata.py
@@ -142,7 +142,6 @@ class TestMetadataNamespacePreservation:
         assert metadata["validation"] == {"version": 1, "rules": []}
 
 
-
 class TestNoWrappedAttribute:
     """Regression: wrapper must not expose ``__wrapped__`` (Azure worker would follow it)."""
 


### PR DESCRIPTION
## Priority: P1

## Context
Top of the OTel trace-correlation stack (#262→#268). Adds a repo-wide formatting gate surfaced by the Copilot review: `ruff format --check` was not enforced, so several files (across the OTel commits) drifted under `ruff==0.16.0`.

This branch is the cross-cutting infra that has no single owning OTel issue, kept separate to keep the seven issue PRs focused.

## Changes
- `style` hatch script now runs `ruff check` **and** `ruff format --check`, so the existing `make check-all` CI job fails on unformatted code.
- New `format-check` hatch script + `make format-check` target.
- Normalize two pre-existing files that were already drifted on `main` under `ruff 0.16.0` (`tests/test_logger.py`, `tests/test_toolkit_metadata.py`) so the new gate passes green.

## Acceptance Checklist
- [x] `hatch run style` fails on unformatted input, passes on formatted tree
- [x] `make format-check` target works
- [x] Whole tree formatted under ruff 0.16.0
- [x] Full suite green (405 passed, coverage 96.63%)

## Notes
Stacked on `otel/258-docs` (#268). ruff pin `0.16.0` comes from `main` (already merged).