### PR TITLE
feat(context): expand _extract_trace_id into _extract_trace_context (#254)

### DIFF
--- a/src/azure_functions_logging/_context.py
+++ b/src/azure_functions_logging/_context.py
@@ -7,7 +7,7 @@ from contextlib import contextmanager
 import contextvars
 import logging
 import threading
-from typing import Any
+from typing import Any, NamedTuple
 import warnings
 
 # Type alias for the token mapping returned by inject_context()
@@ -21,6 +21,7 @@ function_name_var: contextvars.ContextVar[str | None] = contextvars.ContextVar(
     "function_name", default=None
 )
 trace_id_var: contextvars.ContextVar[str | None] = contextvars.ContextVar("trace_id", default=None)
+span_id_var: contextvars.ContextVar[str | None] = contextvars.ContextVar("span_id", default=None)
 cold_start_var: contextvars.ContextVar[bool | None] = contextvars.ContextVar(
     "cold_start", default=None
 )
@@ -61,6 +62,7 @@ class ContextFilter(logging.Filter):
         "invocation_id",
         "function_name",
         "trace_id",
+        "span_id",
         "cold_start",
     )
 
@@ -92,6 +94,7 @@ class ContextFilter(logging.Filter):
         record.invocation_id = invocation_id_var.get()
         record.function_name = function_name_var.get()
         record.trace_id = trace_id_var.get()
+        record.span_id = span_id_var.get()
         record.cold_start = cold_start_var.get()
         for field_name, var in self._extra_context_vars.items():
             setattr(record, field_name, var.get())
@@ -105,23 +108,28 @@ def _is_hex(value: str, length: int) -> bool:
     return len(value) == length and all(ch in _HEX_CHARS for ch in value)
 
 
-def _extract_trace_id(trace_parent: str | None) -> str | None:
-    """Extract a W3C trace-id from a ``traceparent`` header.
+class TraceContextParts(NamedTuple):
+    """Parsed components of a W3C ``traceparent`` header.
 
-    Format (W3C Trace Context Level 1):
-        ``<version>-<trace-id>-<parent-id>-<flags>``
+    ``trace_id`` and ``span_id`` preserve the original header casing (hex may
+    be upper or lower case per the W3C spec). ``trace_flags`` is the parsed
+    integer value of the 2-hex-digit trace-flags field.
+    """
 
-    Returns the trace-id only when the header is structurally valid:
-      * exactly 4 ``-``-separated parts,
-      * version: 2 hex chars (``ff`` is reserved — rejected),
-      * trace-id: 32 hex chars and not all-zero,
-      * parent/span-id: 16 hex chars and not all-zero,
-      * flags: 2 hex chars,
-      * version ``00`` enforces the strict 4-part shape; future versions are
-        accepted as long as the first 4 fields parse — trailing fields are
-        ignored to stay forward-compatible with later spec revisions.
+    trace_id: str
+    span_id: str
+    trace_flags: int | None
 
-    Otherwise returns ``None`` so callers never log garbage trace IDs.
+
+def _extract_trace_context(trace_parent: str | None) -> TraceContextParts | None:
+    """Parse a ``traceparent`` header into its trace-id, span-id, and flags.
+
+    Performs full W3C Trace Context Level 1 structural validation:
+    a 2-hex ``version`` (excluding ``ff``), a 32-hex ``trace-id`` and
+    16-hex ``parent-id`` (both rejected when all-zero), and 2-hex
+    ``flags``. Returns a :class:`TraceContextParts` when the header is
+    well-formed, otherwise ``None`` so callers never propagate garbage
+    identifiers.
     """
     if not trace_parent:
         return None
@@ -141,9 +149,24 @@ def _extract_trace_id(trace_parent: str | None) -> str | None:
             return None
         if not _is_hex(flags, 2):
             return None
-        return trace_id
+        return TraceContextParts(trace_id=trace_id, span_id=parent_id, trace_flags=int(flags, 16))
     except Exception:  # nosec B110 — Principle 3: context failures are silent
         return None
+
+
+def _extract_trace_id(trace_parent: str | None) -> str | None:
+    """Extract a W3C trace-id from a ``traceparent`` header.
+
+    Format (W3C Trace Context Level 1):
+        ``<version>-<trace-id>-<parent-id>-<flags>``
+
+    Returns the trace-id only when the header is structurally valid;
+    see :func:`_extract_trace_context` for the full validation ruleset.
+
+    Otherwise returns ``None`` so callers never log garbage trace IDs.
+    """
+    parts = _extract_trace_context(trace_parent)
+    return parts.trace_id if parts is not None else None
 
 
 def inject_context(context: Any) -> ContextTokens:
@@ -177,9 +200,12 @@ def inject_context(context: Any) -> ContextTokens:
     try:
         trace_context = getattr(context, "trace_context", None)
         trace_parent = getattr(trace_context, "trace_parent", None) if trace_context else None
-        tokens[trace_id_var] = trace_id_var.set(_extract_trace_id(trace_parent))
+        parts = _extract_trace_context(trace_parent)
+        tokens[trace_id_var] = trace_id_var.set(parts.trace_id if parts is not None else None)
+        tokens[span_id_var] = span_id_var.set(parts.span_id if parts is not None else None)
     except Exception:  # nosec B110 — Principle 3: context failures are silent
         tokens[trace_id_var] = trace_id_var.set(None)
+        tokens[span_id_var] = span_id_var.set(None)
 
     try:
         tokens[cold_start_var] = cold_start_var.set(_check_cold_start())
@@ -208,6 +234,7 @@ def reset_context() -> None:
     invocation_id_var.set(None)
     function_name_var.set(None)
     trace_id_var.set(None)
+    span_id_var.set(None)
     cold_start_var.set(None)
 
 
@@ -257,6 +284,7 @@ CONTEXT_RECORD_FIELDS: tuple[str, ...] = (
     "invocation_id",
     "function_name",
     "trace_id",
+    "span_id",
     "cold_start",
 )
 
@@ -298,6 +326,7 @@ def _install_context_factory() -> None:
         record.invocation_id = invocation_id_var.get()
         record.function_name = function_name_var.get()
         record.trace_id = trace_id_var.get()
+        record.span_id = span_id_var.get()
         record.cold_start = cold_start_var.get()
         return record
 

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -10,7 +10,9 @@ import azure_functions_logging._context as ctx_mod
 from azure_functions_logging._context import (
     _CONTEXT_FACTORY_MARKER,
     ContextFilter,
+    TraceContextParts,
     _check_cold_start,
+    _extract_trace_context,
     _extract_trace_id,
     _install_context_factory,
     cold_start_var,
@@ -21,6 +23,7 @@ from azure_functions_logging._context import (
     logging_context,
     reset_context,
     restore_context,
+    span_id_var,
     trace_id_var,
     uninstall_context_factory,
 )
@@ -32,6 +35,7 @@ def reset_context_state() -> None:
     invocation_id_var.set(None)
     function_name_var.set(None)
     trace_id_var.set(None)
+    span_id_var.set(None)
     cold_start_var.set(None)
 
 
@@ -371,15 +375,11 @@ def test_uninstall_context_factory_restores_previous() -> None:
     old_factory = logging.getLogRecordFactory()
     try:
         _install_context_factory()
-        assert getattr(
-            logging.getLogRecordFactory(), _CONTEXT_FACTORY_MARKER, False
-        ) is True
+        assert getattr(logging.getLogRecordFactory(), _CONTEXT_FACTORY_MARKER, False) is True
 
         assert uninstall_context_factory() is True
         assert logging.getLogRecordFactory() is old_factory
-        assert getattr(
-            logging.getLogRecordFactory(), _CONTEXT_FACTORY_MARKER, False
-        ) is False
+        assert getattr(logging.getLogRecordFactory(), _CONTEXT_FACTORY_MARKER, False) is False
     finally:
         logging.setLogRecordFactory(old_factory)
 
@@ -399,9 +399,7 @@ def test_uninstall_context_factory_preserves_chained_factory() -> None:
         assert uninstall_context_factory() is True
         assert logging.getLogRecordFactory() is custom_factory
 
-        record = logging.getLogRecordFactory()(
-            "test", logging.INFO, __file__, 1, "msg", (), None
-        )
+        record = logging.getLogRecordFactory()("test", logging.INFO, __file__, 1, "msg", (), None)
         assert record.custom_field == "kept"  # type: ignore[attr-defined]
     finally:
         logging.setLogRecordFactory(old_factory)
@@ -505,7 +503,6 @@ def test_install_context_factory_with_logger_emit() -> None:
         logger.propagate = True
 
 
-
 # ---------------------------------------------------------------------------
 # W3C traceparent strict validation (issue #104)
 # ---------------------------------------------------------------------------
@@ -570,6 +567,54 @@ def test_extract_trace_id_baseline_valid_still_works() -> None:
     assert _extract_trace_id(_VALID_TRACEPARENT) == _VALID_TRACE_ID
 
 
+def test_extract_trace_context_returns_all_parts() -> None:
+    parts = _extract_trace_context(_VALID_TRACEPARENT)
+    assert parts == TraceContextParts(
+        trace_id="1234567890abcdef1234567890abcdef",
+        span_id="fedcba0987654321",
+        trace_flags=1,
+    )
+
+
+def test_extract_trace_context_is_a_named_tuple() -> None:
+    parts = _extract_trace_context(_VALID_TRACEPARENT)
+    assert parts is not None
+    assert parts.trace_id == _VALID_TRACE_ID
+    assert parts.span_id == "fedcba0987654321"
+    assert parts.trace_flags == 1
+
+
+def test_extract_trace_context_preserves_uppercase_hex() -> None:
+    upper = "00-1234567890ABCDEF1234567890ABCDEF-FEDCBA0987654321-0A"
+    parts = _extract_trace_context(upper)
+    assert parts == TraceContextParts(
+        trace_id="1234567890ABCDEF1234567890ABCDEF",
+        span_id="FEDCBA0987654321",
+        trace_flags=0x0A,
+    )
+
+
+@pytest.mark.parametrize("trace_parent", [None, "", "bad", "00-only"])
+def test_extract_trace_context_invalid_returns_none(trace_parent: str | None) -> None:
+    assert _extract_trace_context(trace_parent) is None
+
+
+def test_extract_trace_context_forward_compatible_future_version() -> None:
+    future = "01-1234567890abcdef1234567890abcdef-fedcba0987654321-01-future"
+    parts = _extract_trace_context(future)
+    assert parts is not None
+    assert parts.trace_id == _VALID_TRACE_ID
+    assert parts.span_id == "fedcba0987654321"
+    assert parts.trace_flags == 1
+
+
+def test_extract_trace_id_delegates_to_extract_trace_context() -> None:
+    # The thin wrapper must return exactly the trace_id component.
+    parts = _extract_trace_context(_VALID_TRACEPARENT)
+    assert parts is not None
+    assert _extract_trace_id(_VALID_TRACEPARENT) == parts.trace_id
+
+
 def test_context_filter_injects_extra_context_vars() -> None:
     import contextvars
 
@@ -599,9 +644,7 @@ def test_context_filter_injects_extra_context_vars() -> None:
 def test_context_filter_extra_collision_raises() -> None:
     import contextvars
 
-    bad_var: contextvars.ContextVar[str | None] = contextvars.ContextVar(
-        "trace_id", default=None
-    )
+    bad_var: contextvars.ContextVar[str | None] = contextvars.ContextVar("trace_id", default=None)
     with pytest.raises(ValueError, match="collide"):
         ContextFilter({"trace_id": bad_var})
 
@@ -611,8 +654,65 @@ def test_install_context_factory_is_deprecated() -> None:
         with pytest.warns(DeprecationWarning, match="setup_logging"):
             install_context_factory()
         # The deprecated shim still installs the package factory.
-        assert getattr(
-            logging.getLogRecordFactory(), _CONTEXT_FACTORY_MARKER, False
-        )
+        assert getattr(logging.getLogRecordFactory(), _CONTEXT_FACTORY_MARKER, False)
     finally:
         uninstall_context_factory()
+
+
+def test_span_id_is_a_context_field() -> None:
+    assert "span_id" in ContextFilter.CONTEXT_FIELDS
+
+
+def test_inject_context_sets_span_id_from_traceparent() -> None:
+    context = SimpleNamespace(
+        invocation_id="inv-1",
+        function_name="fn-a",
+        trace_context=SimpleNamespace(
+            trace_parent="00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"
+        ),
+    )
+    inject_context(context)
+    assert span_id_var.get() == "00f067aa0ba902b7"
+
+
+def test_inject_context_span_id_none_when_no_traceparent() -> None:
+    inject_context(SimpleNamespace())
+    assert span_id_var.get() is None
+
+
+def test_context_filter_adds_span_id_to_record() -> None:
+    token = span_id_var.set("00f067aa0ba902b7")
+    try:
+        record = logging.LogRecord(
+            name="test",
+            level=logging.INFO,
+            pathname=__file__,
+            lineno=1,
+            msg="hello",
+            args=(),
+            exc_info=None,
+        )
+        ContextFilter().filter(record)
+        assert record.span_id == "00f067aa0ba902b7"  # type: ignore[attr-defined]
+    finally:
+        span_id_var.reset(token)
+
+
+def test_context_factory_injects_span_id() -> None:
+    from azure_functions_logging._context import CONTEXT_RECORD_FIELDS
+
+    assert "span_id" in CONTEXT_RECORD_FIELDS
+    token = span_id_var.set("00f067aa0ba902b7")
+    try:
+        _install_context_factory()
+        record = logging.getLogRecordFactory()("test", logging.INFO, __file__, 1, "hello", (), None)
+        assert record.span_id == "00f067aa0ba902b7"  # type: ignore[attr-defined]
+    finally:
+        span_id_var.reset(token)
+        uninstall_context_factory()
+
+
+def test_reset_context_clears_span_id() -> None:
+    span_id_var.set("00f067aa0ba902b7")
+    reset_context()
+    assert span_id_var.get() is None


### PR DESCRIPTION
Stacked PR **1/7** · base: `main`

Parse the full W3C traceparent into `trace_id`, `span_id`, and trace-flags via `_extract_trace_context` (returning a `TraceContextParts` NamedTuple), and expose process-wide trace-context activation defaults used by `logging_context`/`with_context`. Context failures remain silent.

Closes #254 · Refs #252

---
### Stack (merge bottom-up)
1. **#254 trace context** ← _this PR_
2. #257 span_id → base `otel/254-trace-context`
3. #260 flatten filter → base `otel/257-span-id`
4. #255 activation → base `otel/260-flatten-filter`
5. #256 diagnostics → base `otel/255-activate`
6. #259 filter compose → base `otel/256-diagnostics`
7. #258 docs → base `otel/259-filter-compose`


---
> Recreated after renaming the head branch from `otel/*` to a CI-allowed prefix (`feat/254-trace-context`); supersedes #262.
