### PR TITLE
feat(diagnostics): warn on OpenTelemetry logging misconfiguration (#256)

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -190,6 +190,25 @@ for handler in logging.getLogger().handlers:
 
 ::: azure_functions_logging.RedactionFilter
 
+## AttributeFlattenFilter
+
+::: azure_functions_logging.AttributeFlattenFilter
+
+### Usage Notes
+
+- Opt-in only. Attach it to a handler/logger to flatten nested `dict` extras
+  into dotted scalar keys (e.g. `order={"id": 1}` becomes `order.id=1`).
+- Intended for OpenTelemetry pipelines, where nested `dict` attributes are
+  silently dropped by the OTel SDK.
+- Lists / heterogeneous arrays are left unchanged (emitted as-is under their
+  dotted key).
+
+```python
+from azure_functions_logging import AttributeFlattenFilter
+
+handler.addFilter(AttributeFlattenFilter())
+```
+
 ## inject_context
 
 ::: azure_functions_logging.inject_context
@@ -266,6 +285,18 @@ metadata = get_logging_metadata(handler)
 ## logging_context
 
 ::: azure_functions_logging.logging_context
+
+## activated_trace_context
+
+::: azure_functions_logging.activated_trace_context
+
+Attaches the host's W3C trace context so log records emitted through an
+OpenTelemetry `LoggingHandler` inherit the host span's `trace_id`/`span_id`.
+Requires the `[otel]` extra (`pip install azure-functions-logging[otel]`); it
+degrades to a silent no-op when OpenTelemetry is not installed. Prefer the
+`activate_trace_context=True` argument on `logging_context` / `with_context` /
+`setup_logging` for most applications; use this context manager directly for
+manual control. See [OpenTelemetry correlation](opentelemetry.md).
 
 ## install_context_factory
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ dev = [
     "git-cliff",
     "hatch",
     "mypy==2.3.0",
+    "opentelemetry-sdk>=1.24",
     "pre-commit",
     "pytest",
     "pytest-cov",
@@ -48,6 +49,9 @@ docs = [
     "mkdocs<2.0",
     "mkdocs-material<10.0",
     "mkdocstrings[python]<2.0",
+]
+otel = [
+    "opentelemetry-api>=1.24",
 ]
 
 [build-system]
@@ -90,6 +94,16 @@ addopts = "--cov=src/azure_functions_logging --cov-report=xml --cov-report=term-
 testpaths = ["tests"]
 pythonpath = ["src", "."]
 markers = ["e2e: real Azure end-to-end tests (require E2E_BASE_URL)"]
+filterwarnings = [
+    # The OTel spike and compose regression tests intentionally attach the
+    # opentelemetry-sdk ``LoggingHandler`` as a functional stand-in for the
+    # handler ``configure_azure_monitor()`` installs. That SDK handler is
+    # deprecated upstream (out of our control); the library detects any handler
+    # under the ``opentelemetry.*`` namespace, so it also covers the
+    # non-deprecated ``opentelemetry.instrumentation.logging`` handler. Silence
+    # the known warning with a documented reason instead of letting it leak.
+    "ignore:`LoggingHandler` in `opentelemetry-sdk` is deprecated:DeprecationWarning",
+]
 
 [tool.ruff]
 line-length = 100

--- a/src/azure_functions_logging/__init__.py
+++ b/src/azure_functions_logging/__init__.py
@@ -12,27 +12,28 @@ from ._context import (
     uninstall_context_factory,
 )
 from ._decorator import get_logging_metadata, with_context
-from ._filters import RedactionFilter, SamplingFilter
+from ._filters import AttributeFlattenFilter, RedactionFilter, SamplingFilter
 from ._json_formatter import JsonFormatter
 from ._logger import FunctionLogger
 from ._setup import setup_logging
 
 __all__ = [
     "__version__",
+    "AttributeFlattenFilter",
     "ContextTokens",
     "FunctionLogger",
-    "JsonFormatter",
-    "RedactionFilter",
-    "SamplingFilter",
-    "get_logging_metadata",
     "get_logger",
+    "get_logging_metadata",
     "inject_context",
     "install_context_factory",
+    "JsonFormatter",
     "logging_context",
+    "RedactionFilter",
     "reset_context",
     "restore_context",
-    "uninstall_context_factory",
+    "SamplingFilter",
     "setup_logging",
+    "uninstall_context_factory",
     "with_context",
 ]
 

--- a/src/azure_functions_logging/_constants.py
+++ b/src/azure_functions_logging/_constants.py
@@ -17,6 +17,7 @@ _LIBRARY_RESERVED_KEYS: frozenset[str] = frozenset(
         "cold_start",
         "function_name",
         "invocation_id",
+        "span_id",
         "trace_id",
     }
 )

--- a/src/azure_functions_logging/_context.py
+++ b/src/azure_functions_logging/_context.py
@@ -252,8 +252,61 @@ def restore_context(tokens: ContextTokens) -> None:
         var.reset(token)
 
 
+# Process-wide default for OpenTelemetry trace-context activation. Toggled by
+# ``setup_logging(activate_trace_context=...)`` and consulted by
+# ``logging_context`` / ``with_context`` when their per-call flag is ``None``.
+# ``None`` selects the ``auto`` tier: enabled iff ``opentelemetry-api`` is
+# importable.
+_default_trace_context_activation: bool | None = None
+
+
+def set_default_trace_context_activation(enabled: bool | None) -> None:
+    """Set the process-wide default for OTel trace-context activation.
+
+    Called by :func:`setup_logging`. When enabled, ``logging_context`` and
+    ``with_context`` activate the host trace context unless a per-call
+    ``activate_trace_context`` argument overrides it. Passing ``None`` selects
+    the ``auto`` tier (enabled iff ``opentelemetry-api`` is importable).
+    """
+    global _default_trace_context_activation
+    _default_trace_context_activation = enabled if enabled is None else bool(enabled)
+
+
+def _resolve_auto_trace_context_activation() -> bool:
+    """Resolve the ``auto`` tier: enabled iff ``opentelemetry-api`` is importable."""
+    try:
+        from ._otel import is_available
+    except ImportError:  # pragma: no cover - defensive; _otel always ships
+        return False
+    return is_available()
+
+
+def get_default_trace_context_activation() -> bool:
+    """Return the resolved process-wide OTel trace-context activation default.
+
+    A stored default of ``None`` selects the ``auto`` tier: enabled iff
+    ``opentelemetry-api`` is importable.
+    """
+    if _default_trace_context_activation is None:
+        return _resolve_auto_trace_context_activation()
+    return _default_trace_context_activation
+
+
+def _read_trace_headers(context: Any) -> tuple[str | None, str | None]:
+    """Extract ``(traceparent, tracestate)`` from a context object, never raising."""
+    try:
+        trace_context = getattr(context, "trace_context", None)
+        if trace_context is None:
+            return None, None
+        trace_parent = getattr(trace_context, "trace_parent", None)
+        trace_state = getattr(trace_context, "trace_state", None)
+        return trace_parent, trace_state
+    except Exception:  # nosec B110 — Principle 3: context failures are silent
+        return None, None
+
+
 @contextmanager
-def logging_context(context: Any) -> Iterator[None]:
+def logging_context(context: Any, *, activate_trace_context: bool | None = None) -> Iterator[None]:
     """Context manager wrapping ``inject_context`` + ``restore_context``.
 
     Recommended pattern when handlers don't use the ``with_context`` decorator::
@@ -265,10 +318,34 @@ def logging_context(context: Any) -> Iterator[None]:
 
     Guarantees context is restored to its previous state even if the body raises,
     supporting safe nesting of contexts.
+
+    Args:
+        context: An Azure Functions context object (func.Context).
+        activate_trace_context: When ``True``, also attach the host's W3C trace
+            context (from ``context.trace_context``) via OpenTelemetry so log
+            records emitted through an OTel ``LoggingHandler`` inherit the host
+            span's ``trace_id``/``span_id``. Requires the ``[otel]`` extra;
+            degrades to a silent no-op when OpenTelemetry is unavailable. When
+            ``None`` (default), the process-wide default configured via
+            ``setup_logging(activate_trace_context=...)`` is used, which itself
+            defaults to the ``auto`` tier (enabled iff ``opentelemetry-api`` is
+            importable).
     """
+    should_activate = (
+        get_default_trace_context_activation()
+        if activate_trace_context is None
+        else activate_trace_context
+    )
     tokens = inject_context(context)
     try:
-        yield
+        if should_activate:
+            trace_parent, trace_state = _read_trace_headers(context)
+            from ._otel import activated_trace_context
+
+            with activated_trace_context(trace_parent, trace_state):
+                yield
+        else:
+            yield
     finally:
         restore_context(tokens)
 

--- a/src/azure_functions_logging/_context.py
+++ b/src/azure_functions_logging/_context.py
@@ -7,7 +7,7 @@ from contextlib import contextmanager
 import contextvars
 import logging
 import threading
-from typing import Any
+from typing import Any, NamedTuple
 import warnings
 
 # Type alias for the token mapping returned by inject_context()
@@ -21,6 +21,7 @@ function_name_var: contextvars.ContextVar[str | None] = contextvars.ContextVar(
     "function_name", default=None
 )
 trace_id_var: contextvars.ContextVar[str | None] = contextvars.ContextVar("trace_id", default=None)
+span_id_var: contextvars.ContextVar[str | None] = contextvars.ContextVar("span_id", default=None)
 cold_start_var: contextvars.ContextVar[bool | None] = contextvars.ContextVar(
     "cold_start", default=None
 )
@@ -61,6 +62,7 @@ class ContextFilter(logging.Filter):
         "invocation_id",
         "function_name",
         "trace_id",
+        "span_id",
         "cold_start",
     )
 
@@ -92,6 +94,7 @@ class ContextFilter(logging.Filter):
         record.invocation_id = invocation_id_var.get()
         record.function_name = function_name_var.get()
         record.trace_id = trace_id_var.get()
+        record.span_id = span_id_var.get()
         record.cold_start = cold_start_var.get()
         for field_name, var in self._extra_context_vars.items():
             setattr(record, field_name, var.get())
@@ -105,23 +108,28 @@ def _is_hex(value: str, length: int) -> bool:
     return len(value) == length and all(ch in _HEX_CHARS for ch in value)
 
 
-def _extract_trace_id(trace_parent: str | None) -> str | None:
-    """Extract a W3C trace-id from a ``traceparent`` header.
+class TraceContextParts(NamedTuple):
+    """Parsed components of a W3C ``traceparent`` header.
 
-    Format (W3C Trace Context Level 1):
-        ``<version>-<trace-id>-<parent-id>-<flags>``
+    ``trace_id`` and ``span_id`` preserve the original header casing (hex may
+    be upper or lower case per the W3C spec). ``trace_flags`` is the parsed
+    integer value of the 2-hex-digit trace-flags field.
+    """
 
-    Returns the trace-id only when the header is structurally valid:
-      * exactly 4 ``-``-separated parts,
-      * version: 2 hex chars (``ff`` is reserved — rejected),
-      * trace-id: 32 hex chars and not all-zero,
-      * parent/span-id: 16 hex chars and not all-zero,
-      * flags: 2 hex chars,
-      * version ``00`` enforces the strict 4-part shape; future versions are
-        accepted as long as the first 4 fields parse — trailing fields are
-        ignored to stay forward-compatible with later spec revisions.
+    trace_id: str
+    span_id: str
+    trace_flags: int | None
 
-    Otherwise returns ``None`` so callers never log garbage trace IDs.
+
+def _extract_trace_context(trace_parent: str | None) -> TraceContextParts | None:
+    """Parse a ``traceparent`` header into its trace-id, span-id, and flags.
+
+    Performs full W3C Trace Context Level 1 structural validation:
+    a 2-hex ``version`` (excluding ``ff``), a 32-hex ``trace-id`` and
+    16-hex ``parent-id`` (both rejected when all-zero), and 2-hex
+    ``flags``. Returns a :class:`TraceContextParts` when the header is
+    well-formed, otherwise ``None`` so callers never propagate garbage
+    identifiers.
     """
     if not trace_parent:
         return None
@@ -141,9 +149,24 @@ def _extract_trace_id(trace_parent: str | None) -> str | None:
             return None
         if not _is_hex(flags, 2):
             return None
-        return trace_id
+        return TraceContextParts(trace_id=trace_id, span_id=parent_id, trace_flags=int(flags, 16))
     except Exception:  # nosec B110 — Principle 3: context failures are silent
         return None
+
+
+def _extract_trace_id(trace_parent: str | None) -> str | None:
+    """Extract a W3C trace-id from a ``traceparent`` header.
+
+    Format (W3C Trace Context Level 1):
+        ``<version>-<trace-id>-<parent-id>-<flags>``
+
+    Returns the trace-id only when the header is structurally valid;
+    see :func:`_extract_trace_context` for the full validation ruleset.
+
+    Otherwise returns ``None`` so callers never log garbage trace IDs.
+    """
+    parts = _extract_trace_context(trace_parent)
+    return parts.trace_id if parts is not None else None
 
 
 def inject_context(context: Any) -> ContextTokens:
@@ -177,9 +200,12 @@ def inject_context(context: Any) -> ContextTokens:
     try:
         trace_context = getattr(context, "trace_context", None)
         trace_parent = getattr(trace_context, "trace_parent", None) if trace_context else None
-        tokens[trace_id_var] = trace_id_var.set(_extract_trace_id(trace_parent))
+        parts = _extract_trace_context(trace_parent)
+        tokens[trace_id_var] = trace_id_var.set(parts.trace_id if parts is not None else None)
+        tokens[span_id_var] = span_id_var.set(parts.span_id if parts is not None else None)
     except Exception:  # nosec B110 — Principle 3: context failures are silent
         tokens[trace_id_var] = trace_id_var.set(None)
+        tokens[span_id_var] = span_id_var.set(None)
 
     try:
         tokens[cold_start_var] = cold_start_var.set(_check_cold_start())
@@ -208,6 +234,7 @@ def reset_context() -> None:
     invocation_id_var.set(None)
     function_name_var.set(None)
     trace_id_var.set(None)
+    span_id_var.set(None)
     cold_start_var.set(None)
 
 
@@ -257,6 +284,7 @@ CONTEXT_RECORD_FIELDS: tuple[str, ...] = (
     "invocation_id",
     "function_name",
     "trace_id",
+    "span_id",
     "cold_start",
 )
 
@@ -298,6 +326,7 @@ def _install_context_factory() -> None:
         record.invocation_id = invocation_id_var.get()
         record.function_name = function_name_var.get()
         record.trace_id = trace_id_var.get()
+        record.span_id = span_id_var.get()
         record.cold_start = cold_start_var.get()
         return record
 

--- a/src/azure_functions_logging/_decorator.py
+++ b/src/azure_functions_logging/_decorator.py
@@ -12,7 +12,7 @@ import asyncio
 import inspect
 from typing import Any, Callable, TypeVar, overload
 
-from ._context import inject_context, restore_context
+from ._context import logging_context
 from ._metadata import LoggingMetadata, read_logging_metadata, set_logging_metadata
 from ._metadata_helpers import copy_identity_attrs
 
@@ -49,7 +49,6 @@ def _build_logging_payload(param: str) -> LoggingMetadata:
     return {"version": 1, "context_param": param}
 
 
-
 def _find_context_arg(
     func: Callable[..., Any],
     param: str,
@@ -74,38 +73,30 @@ def _find_context_arg(
     return None
 
 
-def _wrap_sync(func: _F, param: str) -> _F:
+def _wrap_sync(func: _F, param: str, activate_trace_context: bool | None) -> _F:
     """Wrap a synchronous handler."""
 
     def wrapper(*args: Any, **kwargs: Any) -> Any:
         ctx = _find_context_arg(func, param, args, kwargs)
         if ctx is not None:
-            tokens = inject_context(ctx)
-        else:
-            tokens = {}
-        try:
-            return func(*args, **kwargs)
-        finally:
-            restore_context(tokens)
+            with logging_context(ctx, activate_trace_context=activate_trace_context):
+                return func(*args, **kwargs)
+        return func(*args, **kwargs)
 
     _copy_safe_metadata(wrapper, func)
     set_logging_metadata(wrapper, func, _build_logging_payload(param))
     return wrapper  # type: ignore[return-value]
 
 
-def _wrap_async(func: _F, param: str) -> _F:
+def _wrap_async(func: _F, param: str, activate_trace_context: bool | None) -> _F:
     """Wrap an asynchronous handler."""
 
     async def wrapper(*args: Any, **kwargs: Any) -> Any:
         ctx = _find_context_arg(func, param, args, kwargs)
         if ctx is not None:
-            tokens = inject_context(ctx)
-        else:
-            tokens = {}
-        try:
-            return await func(*args, **kwargs)
-        finally:
-            restore_context(tokens)
+            with logging_context(ctx, activate_trace_context=activate_trace_context):
+                return await func(*args, **kwargs)
+        return await func(*args, **kwargs)
 
     _copy_safe_metadata(wrapper, func)
     set_logging_metadata(wrapper, func, _build_logging_payload(param))
@@ -117,13 +108,16 @@ def with_context(func: _F) -> _F: ...
 
 
 @overload
-def with_context(*, param: str = ...) -> Callable[[_F], _F]: ...
+def with_context(
+    *, param: str = ..., activate_trace_context: bool | None = ...
+) -> Callable[[_F], _F]: ...
 
 
 def with_context(
     func: _F | None = None,
     *,
     param: str = _DEFAULT_PARAM,
+    activate_trace_context: bool | None = None,
 ) -> _F | Callable[[_F], _F]:
     """Decorator that automatically injects invocation context.
 
@@ -149,12 +143,17 @@ def with_context(
         func: The handler function (when used without parentheses).
         param: Name of the parameter that receives the Azure Functions
             context object. Defaults to ``"context"``.
+        activate_trace_context: When ``True``, also attach the host's W3C trace
+            context so OTel log records inherit the host span's
+            ``trace_id``/``span_id`` (requires the ``[otel]`` extra; silent
+            no-op otherwise). When ``None`` (default), the process-wide default
+            configured via ``setup_logging(activate_trace_context=...)`` applies.
     """
 
     def decorator(fn: _F) -> _F:
         if asyncio.iscoroutinefunction(fn):
-            return _wrap_async(fn, param)
-        return _wrap_sync(fn, param)
+            return _wrap_async(fn, param, activate_trace_context)
+        return _wrap_sync(fn, param, activate_trace_context)
 
     if func is not None:
         # Called as @with_context (no parentheses)

--- a/src/azure_functions_logging/_filters.py
+++ b/src/azure_functions_logging/_filters.py
@@ -3,6 +3,8 @@
 Provides:
 - ``SamplingFilter``: Rate-limit noisy loggers to reduce gRPC/stdout pressure.
 - ``RedactionFilter``: Mask PII / sensitive keys on LogRecord extra fields.
+- ``AttributeFlattenFilter``: Flatten nested dict extras to dotted scalar keys
+  so OpenTelemetry does not silently drop them.
 """
 
 from __future__ import annotations
@@ -18,6 +20,46 @@ from ._redaction import SENSITIVE_KEYS as _DEFAULT_SENSITIVE_KEYS
 from ._redaction import normalize_key as _normalize_key
 
 _REDACT_MAX_DEPTH = 10  # default depth limit for recursive redaction
+_FLATTEN_MAX_DEPTH = 10  # default depth limit for recursive flattening
+
+
+def _flatten_dict(
+    prefix: str,
+    value: dict[Any, Any],
+    separator: str,
+    max_depth: int,
+    *,
+    _seen: set[int] | None = None,
+    _depth: int = 0,
+) -> dict[str, Any]:
+    """Flatten a nested dict into ``{dotted_key: scalar}`` pairs.
+
+    Guarded against:
+    - Cyclic references (via id-based seen set); cyclic sub-dicts are dropped.
+    - Pathologically deep structures (via ``_depth`` / ``max_depth``); the
+      remaining nested dict at the depth limit is emitted as-is under its
+      dotted key.
+
+    Lists (and any non-dict leaf) are emitted unchanged under their dotted key.
+    Empty dicts contribute no keys.
+    """
+    if _depth >= max_depth:
+        return {prefix: value}
+    seen = _seen if _seen is not None else set()
+    obj_id = id(value)
+    if obj_id in seen:
+        return {}  # cyclic reference detected
+    seen = seen | {obj_id}
+    result: dict[str, Any] = {}
+    for key, item in value.items():
+        new_key = f"{prefix}{separator}{key}"
+        if isinstance(item, dict):
+            result.update(
+                _flatten_dict(new_key, item, separator, max_depth, _seen=seen, _depth=_depth + 1)
+            )
+        else:
+            result[new_key] = item
+    return result
 
 
 def _redact_value(
@@ -247,6 +289,86 @@ class RedactionFilter(logging.Filter):
                         value = record.__dict__[key]
                         if isinstance(value, (dict, list)):
                             setattr(record, key, _redact_value(value, self._sensitive_keys))
+                except Exception:  # nosec B110 — one broken field must not stop others
+                    pass
+        except Exception:  # nosec B110 — filter must never raise
+            pass
+        return True
+
+
+class AttributeFlattenFilter(logging.Filter):
+    """Flatten nested ``dict`` extras into dotted scalar attributes in-place.
+
+    OpenTelemetry attributes only permit scalars and homogeneous arrays. A
+    nested ``dict`` passed via ``extra`` (e.g. ``order={"id": 1}``) is silently
+    dropped by the OTel SDK. This filter rewrites such attributes into dotted
+    scalar keys (``order.id``) so the data survives export.
+
+    The filter mutates the record in-place, removing the original nested-dict
+    attribute and adding one attribute per leaf. It is **opt-in**: it has no
+    effect unless explicitly attached to a handler/logger.
+
+    Behavior:
+    - Nested dicts are flattened recursively to dotted keys.
+    - Lists / heterogeneous arrays are left unchanged (emitted as-is under
+      their dotted key). OTel accepts homogeneous scalar arrays; heterogeneous
+      or nested-object arrays remain the caller's responsibility.
+    - Scalar attributes and reserved ``LogRecord`` keys are never touched.
+    - Empty dicts contribute no keys (the attribute is removed).
+    - Cyclic references are dropped; over-deep structures (beyond
+      ``max_depth``) are emitted as-is at the depth boundary.
+
+    .. note::
+
+        This filter rewrites the record's attributes, so it also affects
+        **non-OTel** consumers reading the same record — e.g. a
+        :class:`JsonFormatter` on the root handler will emit ``order.id``
+        instead of a nested ``order`` object. To avoid changing your JSON log
+        shape, attach this filter only to the OpenTelemetry ``LoggingHandler``
+        rather than to the root handler.
+
+    Args:
+        name: Optional logger-name scope. When set, only matching loggers are
+            flattened; non-matching records pass through unchanged.
+        separator: Delimiter joining nested keys. Default ``"."``.
+        max_depth: Maximum recursion depth before a nested dict is emitted
+            as-is. Default ``10``.
+
+    Example::
+
+        filter = AttributeFlattenFilter()
+        handler.addFilter(filter)
+    """
+
+    def __init__(
+        self,
+        name: str = "",
+        *,
+        separator: str = ".",
+        max_depth: int = _FLATTEN_MAX_DEPTH,
+    ) -> None:
+        super().__init__(name)
+        self._separator: str = separator
+        self._max_depth: int = max_depth
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        """Flatten nested-dict fields on the record. Always returns True."""
+        # Honor name-based scoping from logging.Filter
+        if not super().filter(record):
+            return True  # bypass flattening for non-matching loggers
+
+        try:
+            for key in list(record.__dict__.keys()):
+                try:
+                    if key in _RESERVED_LOG_RECORD_KEYS:
+                        continue
+                    value = record.__dict__[key]
+                    if not isinstance(value, dict):
+                        continue
+                    flattened = _flatten_dict(key, value, self._separator, self._max_depth)
+                    del record.__dict__[key]
+                    for flat_key, flat_value in flattened.items():
+                        setattr(record, flat_key, flat_value)
                 except Exception:  # nosec B110 — one broken field must not stop others
                     pass
         except Exception:  # nosec B110 — filter must never raise

--- a/src/azure_functions_logging/_host_config.py
+++ b/src/azure_functions_logging/_host_config.py
@@ -207,8 +207,7 @@ def warn_host_json_level_conflict(
     # Only allow recognized app-setting values to override; unrecognized values
     # (e.g. typos) must not mask a restrictive host.json entry.
     normalized_host: dict[str, object] = {
-        (k.lower() if k.lower() == "default" else k): v
-        for k, v in host_json_log_levels.items()
+        (k.lower() if k.lower() == "default" else k): v for k, v in host_json_log_levels.items()
     }
     normalized_app: dict[str, object] = {}
     for k, v in app_setting_log_levels.items():
@@ -229,3 +228,149 @@ def warn_host_json_level_conflict(
         source="host configuration",
         stacklevel=3,
     )
+
+
+def _has_otel_logging_handler(logger: logging.Logger) -> bool:
+    """Return True if *logger* has an OpenTelemetry logging handler attached.
+
+    Detection is **import-free**: it inspects each handler's defining module
+    name rather than importing OpenTelemetry. This covers both
+    ``opentelemetry.sdk._logs`` and ``opentelemetry.instrumentation.logging``
+    handlers, and stays a no-op when OpenTelemetry is not installed.
+    """
+    for handler in logger.handlers:
+        module = type(handler).__module__ or ""
+        if module.startswith("opentelemetry."):
+            return True
+    return False
+
+
+def _any_otel_logging_handler() -> bool:
+    """Return True if an OpenTelemetry logging handler is attached anywhere in
+    the active logger hierarchy, not just on the root logger.
+
+    ``configure_azure_monitor()`` attaches its handler to the root logger, but a
+    self-managed OpenTelemetry setup may attach the ``LoggingHandler`` to a
+    named child logger instead. Scanning the manager's ``loggerDict`` avoids a
+    false "no handler" verdict (and a spurious 6c warning) in that case.
+    """
+    if _has_otel_logging_handler(logging.getLogger()):
+        return True
+    for obj in list(logging.Logger.manager.loggerDict.values()):
+        if isinstance(obj, logging.Logger) and _has_otel_logging_handler(obj):
+            return True
+    return False
+
+
+def _read_host_telemetry_mode(host_json_path: Path | str | None) -> str | None:
+    """Return the ``telemetryMode`` string from ``host.json``, or ``None``.
+
+    Uses the same discovery rules as :func:`warn_host_json_level_conflict`.
+    Never raises: any read/parse failure yields ``None``.
+    """
+    host_path: Path | None
+    if host_json_path is not None:
+        host_path = Path(host_json_path)
+        try:
+            if not host_path.is_file():
+                return None
+        except OSError:
+            return None
+    else:
+        host_path = discover_host_json()
+    if host_path is None:
+        return None
+    try:
+        host_config: object = json.loads(host_path.read_text(encoding="utf-8"))
+        host_mapping = _string_key_mapping(host_config)
+        if host_mapping is None:
+            return None
+        mode = host_mapping.get("telemetryMode")
+        return mode if isinstance(mode, str) else None
+    except Exception:  # nosec B110 — host.json read failure is non-fatal
+        return None
+
+
+# App settings that signal the host will export OpenTelemetry logs. Microsoft
+# docs reference both names (likely a mid-rename), so either being set counts.
+_OTEL_TELEMETRY_ENV_VARS: tuple[str, ...] = (
+    "PYTHON_ENABLE_OPENTELEMETRY",
+    "PYTHON_APPLICATIONINSIGHTS_ENABLE_TELEMETRY",
+)
+
+
+# Generic OpenTelemetry SDK export settings. Their presence signals the user
+# is managing OTel export themselves (e.g. OTLP straight to a collector), so a
+# missing Azure-specific telemetry env var is not necessarily a misconfig.
+_OTEL_GENERIC_EXPORT_ENV_VARS: tuple[str, ...] = (
+    "OTEL_LOGS_EXPORTER",
+    "OTEL_TRACES_EXPORTER",
+)
+
+
+def warn_otel_logging_misconfig(
+    *,
+    functions_formatter: logging.Formatter | None = None,
+    host_json_path: Path | str | None = None,
+    stacklevel: int = 3,
+) -> None:
+    """Warn on common OpenTelemetry logging misconfigurations (issue #256).
+
+    These checks run at ``setup_logging()`` call time and assume the documented
+    call order: ``configure_azure_monitor()`` **before** ``setup_logging()`` so
+    the OpenTelemetry ``LoggingHandler`` is already attached to the root logger.
+
+    Emits up to three independent warnings:
+
+    - **6a** — an OTel handler is present **and** ``functions_formatter`` was
+      passed: the formatter is never invoked (the OTel handler formats records
+      itself), so the argument is silently ignored.
+    - **6b** — an OTel handler is present but neither telemetry env var is set:
+      the host may not export these logs. Worded tentatively because the
+      environment is not fully observable from inside the worker.
+    - **6c** — ``host.json`` requests ``telemetryMode: OpenTelemetry`` but no
+      OTel handler is attached: most often a call-order mistake. Worded as an
+      ordering hint rather than a definitive "worker unconfigured" claim, so it
+      does not cry wolf when the handler is simply attached later.
+    """
+    has_otel_handler = _any_otel_logging_handler()
+
+    # 6a: OTel handler present AND a functions_formatter was supplied.
+    if has_otel_handler and functions_formatter is not None:
+        warnings.warn(
+            (
+                "An OpenTelemetry logging handler is attached, so the "
+                "'functions_formatter' passed to setup_logging() is ignored "
+                "— the OpenTelemetry handler formats and exports records itself."
+            ),
+            stacklevel=stacklevel,
+        )
+
+    # 6b: OTel handler present but neither telemetry env var is set (tentative).
+    if has_otel_handler and not any(
+        os.environ.get(name) for name in (*_OTEL_TELEMETRY_ENV_VARS, *_OTEL_GENERIC_EXPORT_ENV_VARS)
+    ):
+        joined = " or ".join(_OTEL_TELEMETRY_ENV_VARS)
+        warnings.warn(
+            (
+                "An OpenTelemetry logging handler is attached but neither "
+                f"{joined} appears to be set. Depending on your host "
+                "configuration, these logs may not be exported — verify your "
+                "telemetry settings."
+            ),
+            stacklevel=stacklevel,
+        )
+
+    # 6c: host.json requests OpenTelemetry mode but no OTel handler detected.
+    if not has_otel_handler:
+        mode = _read_host_telemetry_mode(host_json_path)
+        if mode is not None and mode.lower() == "opentelemetry":
+            warnings.warn(
+                (
+                    "host.json sets telemetryMode 'OpenTelemetry' but no "
+                    "OpenTelemetry logging handler is attached yet. If you use "
+                    "configure_azure_monitor(), call it before setup_logging() "
+                    "so filters and context land on the OpenTelemetry handler."
+                ),
+                stacklevel=stacklevel,
+            )

--- a/src/azure_functions_logging/_json_formatter.py
+++ b/src/azure_functions_logging/_json_formatter.py
@@ -83,12 +83,10 @@ def _to_json_safe(
             return "<cyclic>"
         seen = seen | {id(value)}
         if isinstance(value, dict):
-            return {
-                _safe_key(k): _to_json_safe(v, seen, _depth + 1)
-                for k, v in value.items()
-            }
+            return {_safe_key(k): _to_json_safe(v, seen, _depth + 1) for k, v in value.items()}
         return [_to_json_safe(item, seen, _depth + 1) for item in value]
     return value
+
 
 def _truncate_native_strings(value: Any, max_length: int) -> Any:
     """Recursively truncate string values in a JSON-safe structure.
@@ -109,6 +107,7 @@ def _truncate_native_strings(value: Any, max_length: int) -> Any:
     if isinstance(value, list):
         return [_truncate_native_strings(item, max_length) for item in value]
     return value
+
 
 class JsonFormatter(logging.Formatter):
     """Structured JSON log formatter.
@@ -137,9 +136,7 @@ class JsonFormatter(logging.Formatter):
         truncate_native_strings: bool = False,
     ) -> None:
         if max_string_length < 0:
-            raise ValueError(
-                f"max_string_length must be ≥ 0, got {max_string_length}"
-            )
+            raise ValueError(f"max_string_length must be ≥ 0, got {max_string_length}")
         super().__init__()
         self._max_string_length = max_string_length
         self._truncate_native_strings = truncate_native_strings
@@ -174,6 +171,7 @@ class JsonFormatter(logging.Formatter):
             "invocation_id": getattr(record, "invocation_id", None),
             "function_name": getattr(record, "function_name", None),
             "trace_id": getattr(record, "trace_id", None),
+            "span_id": getattr(record, "span_id", None),
             "cold_start": getattr(record, "cold_start", None),
             "exception": exception,
             "extra": extra,
@@ -230,6 +228,7 @@ def _emergency_payload(record: logging.LogRecord) -> str:
             "invocation_id": None,
             "function_name": None,
             "trace_id": None,
+            "span_id": None,
             "cold_start": None,
             "exception": None,
             "extra": {"__serialization_error__": True},

--- a/src/azure_functions_logging/_otel.py
+++ b/src/azure_functions_logging/_otel.py
@@ -1,0 +1,100 @@
+"""Optional OpenTelemetry trace-context activation for log correlation.
+
+This module lets ``azure-functions-logging`` bind the Azure Functions host's
+incoming W3C trace context into the current execution context so that an
+OpenTelemetry ``LoggingHandler`` (owned by the host or the user's OTel setup)
+stamps emitted log records with the host span's ``trace_id`` and ``span_id``.
+
+Design constraints (see README "What this package does not do"):
+
+* This package never creates, records, or exports a span. It only *attaches*
+  the already-existing remote span context extracted from the ``traceparent``
+  header, using :func:`opentelemetry.context.attach` /
+  :func:`opentelemetry.context.detach`.
+* ``opentelemetry-api`` is an **optional** dependency (the ``[otel]`` extra).
+  The base install stays zero-dependency: every entry point degrades to a
+  silent no-op when OpenTelemetry is not importable.
+* Consistent with Principle 3 ("context failures are silent"), no code path
+  here raises as a result of trace-context handling.
+
+Known limitation: OpenTelemetry's runtime context is contextvar-based, so
+correlation does **not** propagate into worker threads spawned via
+``ThreadPoolExecutor`` / ``run_in_executor``. Logs emitted from such threads
+are orphaned. This matches the behaviour pinned by the spike test suite.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from contextlib import contextmanager
+
+
+def is_available() -> bool:
+    """Return ``True`` when the OpenTelemetry API is importable.
+
+    Only the API package (``opentelemetry-api``) is required — the SDK,
+    exporters, and a ``TracerProvider`` are owned by the host or the user.
+    """
+    try:
+        import opentelemetry.context  # noqa: F401
+        import opentelemetry.propagate  # noqa: F401
+    except Exception:  # nosec B110 — optional dependency; absence is expected
+        return False
+    return True
+
+
+@contextmanager
+def activated_trace_context(
+    trace_parent: str | None,
+    trace_state: str | None = None,
+) -> Iterator[None]:
+    """Attach the host trace context for the duration of the ``with`` block.
+
+    While the block is active, OpenTelemetry's "current span" is the
+    non-recording remote span described by *trace_parent*, so any log record
+    emitted through an OTel ``LoggingHandler`` inherits the host's
+    ``trace_id`` and ``span_id``.
+
+    The context is always detached (LIFO) on exit, including when the block
+    raises, so no trace context leaks into the next invocation on a reused
+    worker.
+
+    This is a silent no-op — yielding without attaching anything — when:
+
+    * *trace_parent* is empty/``None``;
+    * OpenTelemetry is not installed (:func:`is_available` is ``False``);
+    * extraction/attach fails for any reason (malformed header, etc.).
+
+    Args:
+        trace_parent: The W3C ``traceparent`` header value from the host.
+        trace_state: The optional W3C ``tracestate`` header value.
+    """
+    if not trace_parent or not is_available():
+        yield
+        return
+
+    try:
+        from opentelemetry import context as otel_context
+        from opentelemetry.propagate import extract as otel_extract
+    except Exception:  # nosec B110 — optional dependency; degrade to no-op
+        yield
+        return
+
+    carrier: dict[str, str] = {"traceparent": trace_parent}
+    if trace_state:
+        carrier["tracestate"] = trace_state
+
+    token = None
+    try:
+        token = otel_context.attach(otel_extract(carrier))
+    except Exception:  # nosec B110 — Principle 3: context failures are silent
+        token = None
+
+    try:
+        yield
+    finally:
+        if token is not None:
+            try:
+                otel_context.detach(token)
+            except Exception:  # nosec B110 — Principle 3: silent on cleanup
+                pass

--- a/src/azure_functions_logging/_setup.py
+++ b/src/azure_functions_logging/_setup.py
@@ -11,7 +11,7 @@ from typing import Any
 import warnings
 import weakref
 
-from ._context import ContextFilter, _install_context_factory
+from ._context import ContextFilter, _install_context_factory, set_default_trace_context_activation
 from ._formatter import ColorFormatter
 from ._host_config import warn_host_json_level_conflict
 from ._json_formatter import JsonFormatter
@@ -65,6 +65,7 @@ def setup_logging(
     host_json_path: Path | str | None = None,
     use_record_factory: bool = False,
     extra_context_vars: dict[str, contextvars.ContextVar[Any]] | None = None,
+    activate_trace_context: bool | None = None,
 ) -> None:
     """Configure logging for the current environment.
     Behavior depends on the detected environment:
@@ -114,6 +115,15 @@ def setup_logging(
             LogRecord, alongside the four built-in context fields. Field names
             must not collide with the built-in fields. Only applies to the
             ``ContextFilter`` strategy (ignored when ``use_record_factory=True``).
+        activate_trace_context: Sets the process-wide default that
+            ``logging_context`` and ``with_context`` consult to attach the
+            host's W3C trace context (via OpenTelemetry) — making OTel log
+            records inherit the host span's ``trace_id``/``span_id``. Requires
+            the ``[otel]`` extra; degrades to a silent no-op when OpenTelemetry
+            is not installed. ``True``/``False`` force the default on/off; the
+            default ``None`` selects the ``auto`` tier (enabled iff
+            ``opentelemetry-api`` is importable). A per-call
+            ``activate_trace_context`` argument overrides this default.
 
     .. warning::
 
@@ -135,6 +145,13 @@ def setup_logging(
         _install_context_factory()
 
     with _configured_lock:
+        # Only override the process-wide activation default when the caller
+        # explicitly opts in or out. A bare ``setup_logging()`` (where
+        # ``activate_trace_context`` is ``None``) must not silently revert a
+        # previously-configured default — that would break idempotency.
+        if activate_trace_context is not None:
+            set_default_trace_context_activation(activate_trace_context)
+
         # When switching to record-factory mode, strip any previously-installed
         # ContextFilter from the target logger and root logger.  Must run BEFORE
         # the idempotency guards (so re-entry for the same logger_name still

--- a/src/azure_functions_logging/_setup.py
+++ b/src/azure_functions_logging/_setup.py
@@ -13,7 +13,7 @@ import weakref
 
 from ._context import ContextFilter, _install_context_factory, set_default_trace_context_activation
 from ._formatter import ColorFormatter
-from ._host_config import warn_host_json_level_conflict
+from ._host_config import warn_host_json_level_conflict, warn_otel_logging_misconfig
 from ._json_formatter import JsonFormatter
 
 # Track configured logger names to ensure per-logger idempotency (local mode).
@@ -204,6 +204,10 @@ def setup_logging(
                 root.addFilter(context_filter)
 
             warn_host_json_level_conflict(level, host_json_path=host_json_path)
+            warn_otel_logging_misconfig(
+                functions_formatter=functions_formatter,
+                host_json_path=host_json_path,
+            )
 
         else:
             # Standalone local development: full idempotency via logger name.

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -10,7 +10,9 @@ import azure_functions_logging._context as ctx_mod
 from azure_functions_logging._context import (
     _CONTEXT_FACTORY_MARKER,
     ContextFilter,
+    TraceContextParts,
     _check_cold_start,
+    _extract_trace_context,
     _extract_trace_id,
     _install_context_factory,
     cold_start_var,
@@ -21,6 +23,7 @@ from azure_functions_logging._context import (
     logging_context,
     reset_context,
     restore_context,
+    span_id_var,
     trace_id_var,
     uninstall_context_factory,
 )
@@ -32,6 +35,7 @@ def reset_context_state() -> None:
     invocation_id_var.set(None)
     function_name_var.set(None)
     trace_id_var.set(None)
+    span_id_var.set(None)
     cold_start_var.set(None)
 
 
@@ -371,15 +375,11 @@ def test_uninstall_context_factory_restores_previous() -> None:
     old_factory = logging.getLogRecordFactory()
     try:
         _install_context_factory()
-        assert getattr(
-            logging.getLogRecordFactory(), _CONTEXT_FACTORY_MARKER, False
-        ) is True
+        assert getattr(logging.getLogRecordFactory(), _CONTEXT_FACTORY_MARKER, False) is True
 
         assert uninstall_context_factory() is True
         assert logging.getLogRecordFactory() is old_factory
-        assert getattr(
-            logging.getLogRecordFactory(), _CONTEXT_FACTORY_MARKER, False
-        ) is False
+        assert getattr(logging.getLogRecordFactory(), _CONTEXT_FACTORY_MARKER, False) is False
     finally:
         logging.setLogRecordFactory(old_factory)
 
@@ -399,9 +399,7 @@ def test_uninstall_context_factory_preserves_chained_factory() -> None:
         assert uninstall_context_factory() is True
         assert logging.getLogRecordFactory() is custom_factory
 
-        record = logging.getLogRecordFactory()(
-            "test", logging.INFO, __file__, 1, "msg", (), None
-        )
+        record = logging.getLogRecordFactory()("test", logging.INFO, __file__, 1, "msg", (), None)
         assert record.custom_field == "kept"  # type: ignore[attr-defined]
     finally:
         logging.setLogRecordFactory(old_factory)
@@ -505,7 +503,6 @@ def test_install_context_factory_with_logger_emit() -> None:
         logger.propagate = True
 
 
-
 # ---------------------------------------------------------------------------
 # W3C traceparent strict validation (issue #104)
 # ---------------------------------------------------------------------------
@@ -570,6 +567,54 @@ def test_extract_trace_id_baseline_valid_still_works() -> None:
     assert _extract_trace_id(_VALID_TRACEPARENT) == _VALID_TRACE_ID
 
 
+def test_extract_trace_context_returns_all_parts() -> None:
+    parts = _extract_trace_context(_VALID_TRACEPARENT)
+    assert parts == TraceContextParts(
+        trace_id="1234567890abcdef1234567890abcdef",
+        span_id="fedcba0987654321",
+        trace_flags=1,
+    )
+
+
+def test_extract_trace_context_is_a_named_tuple() -> None:
+    parts = _extract_trace_context(_VALID_TRACEPARENT)
+    assert parts is not None
+    assert parts.trace_id == _VALID_TRACE_ID
+    assert parts.span_id == "fedcba0987654321"
+    assert parts.trace_flags == 1
+
+
+def test_extract_trace_context_preserves_uppercase_hex() -> None:
+    upper = "00-1234567890ABCDEF1234567890ABCDEF-FEDCBA0987654321-0A"
+    parts = _extract_trace_context(upper)
+    assert parts == TraceContextParts(
+        trace_id="1234567890ABCDEF1234567890ABCDEF",
+        span_id="FEDCBA0987654321",
+        trace_flags=0x0A,
+    )
+
+
+@pytest.mark.parametrize("trace_parent", [None, "", "bad", "00-only"])
+def test_extract_trace_context_invalid_returns_none(trace_parent: str | None) -> None:
+    assert _extract_trace_context(trace_parent) is None
+
+
+def test_extract_trace_context_forward_compatible_future_version() -> None:
+    future = "01-1234567890abcdef1234567890abcdef-fedcba0987654321-01-future"
+    parts = _extract_trace_context(future)
+    assert parts is not None
+    assert parts.trace_id == _VALID_TRACE_ID
+    assert parts.span_id == "fedcba0987654321"
+    assert parts.trace_flags == 1
+
+
+def test_extract_trace_id_delegates_to_extract_trace_context() -> None:
+    # The thin wrapper must return exactly the trace_id component.
+    parts = _extract_trace_context(_VALID_TRACEPARENT)
+    assert parts is not None
+    assert _extract_trace_id(_VALID_TRACEPARENT) == parts.trace_id
+
+
 def test_context_filter_injects_extra_context_vars() -> None:
     import contextvars
 
@@ -599,9 +644,7 @@ def test_context_filter_injects_extra_context_vars() -> None:
 def test_context_filter_extra_collision_raises() -> None:
     import contextvars
 
-    bad_var: contextvars.ContextVar[str | None] = contextvars.ContextVar(
-        "trace_id", default=None
-    )
+    bad_var: contextvars.ContextVar[str | None] = contextvars.ContextVar("trace_id", default=None)
     with pytest.raises(ValueError, match="collide"):
         ContextFilter({"trace_id": bad_var})
 
@@ -611,8 +654,65 @@ def test_install_context_factory_is_deprecated() -> None:
         with pytest.warns(DeprecationWarning, match="setup_logging"):
             install_context_factory()
         # The deprecated shim still installs the package factory.
-        assert getattr(
-            logging.getLogRecordFactory(), _CONTEXT_FACTORY_MARKER, False
-        )
+        assert getattr(logging.getLogRecordFactory(), _CONTEXT_FACTORY_MARKER, False)
     finally:
         uninstall_context_factory()
+
+
+def test_span_id_is_a_context_field() -> None:
+    assert "span_id" in ContextFilter.CONTEXT_FIELDS
+
+
+def test_inject_context_sets_span_id_from_traceparent() -> None:
+    context = SimpleNamespace(
+        invocation_id="inv-1",
+        function_name="fn-a",
+        trace_context=SimpleNamespace(
+            trace_parent="00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"
+        ),
+    )
+    inject_context(context)
+    assert span_id_var.get() == "00f067aa0ba902b7"
+
+
+def test_inject_context_span_id_none_when_no_traceparent() -> None:
+    inject_context(SimpleNamespace())
+    assert span_id_var.get() is None
+
+
+def test_context_filter_adds_span_id_to_record() -> None:
+    token = span_id_var.set("00f067aa0ba902b7")
+    try:
+        record = logging.LogRecord(
+            name="test",
+            level=logging.INFO,
+            pathname=__file__,
+            lineno=1,
+            msg="hello",
+            args=(),
+            exc_info=None,
+        )
+        ContextFilter().filter(record)
+        assert record.span_id == "00f067aa0ba902b7"  # type: ignore[attr-defined]
+    finally:
+        span_id_var.reset(token)
+
+
+def test_context_factory_injects_span_id() -> None:
+    from azure_functions_logging._context import CONTEXT_RECORD_FIELDS
+
+    assert "span_id" in CONTEXT_RECORD_FIELDS
+    token = span_id_var.set("00f067aa0ba902b7")
+    try:
+        _install_context_factory()
+        record = logging.getLogRecordFactory()("test", logging.INFO, __file__, 1, "hello", (), None)
+        assert record.span_id == "00f067aa0ba902b7"  # type: ignore[attr-defined]
+    finally:
+        span_id_var.reset(token)
+        uninstall_context_factory()
+
+
+def test_reset_context_clears_span_id() -> None:
+    span_id_var.set("00f067aa0ba902b7")
+    reset_context()
+    assert span_id_var.get() is None

--- a/tests/test_contracts.py
+++ b/tests/test_contracts.py
@@ -75,6 +75,7 @@ _JSON_SCHEMA_KEYS: set[str] = {
     "invocation_id",
     "function_name",
     "trace_id",
+    "span_id",
     "cold_start",
     "exception",
     "extra",

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -7,7 +7,11 @@ import time
 
 import pytest
 
-from azure_functions_logging._filters import RedactionFilter, SamplingFilter
+from azure_functions_logging._filters import (
+    AttributeFlattenFilter,
+    RedactionFilter,
+    SamplingFilter,
+)
 
 
 def _make_record(level: int = logging.INFO, msg: str = "hello") -> logging.LogRecord:
@@ -162,6 +166,7 @@ def test_sampling_filter_per_logger_enforces_hard_cap_on_burst() -> None:
 
     # Hard cap must be enforced: at most _MAX_BUCKETS entries remain
     assert len(flt._buckets) <= 5
+
 
 # ---------------------------------------------------------------------------
 # RedactionFilter tests
@@ -861,3 +866,183 @@ def test_redaction_filter_constructor_normalizes_hyphenated_sensitive_keys() -> 
     assert getattr(record, "x_functions_key") == "***"
     assert getattr(record, "ocp_apim_subscription_key") == "***"
     assert getattr(record, "safe_attr") == "visible"
+
+
+# ---------------------------------------------------------------------------
+# AttributeFlattenFilter tests
+# ---------------------------------------------------------------------------
+
+
+def test_flatten_filter_flattens_nested_dict_to_dotted_keys() -> None:
+    flt = AttributeFlattenFilter()
+    record = _make_record()
+    setattr(record, "order", {"id": 1, "total": 99})
+
+    assert flt.filter(record) is True
+    assert getattr(record, "order.id") == 1
+    assert getattr(record, "order.total") == 99
+    # Original nested dict attribute is removed to avoid SDK drop.
+    assert "order" not in record.__dict__
+
+
+def test_flatten_filter_flattens_deeply_nested_dicts() -> None:
+    flt = AttributeFlattenFilter()
+    record = _make_record()
+    setattr(record, "order", {"customer": {"name": "alice", "tier": "gold"}})
+
+    flt.filter(record)
+
+    assert getattr(record, "order.customer.name") == "alice"
+    assert getattr(record, "order.customer.tier") == "gold"
+    assert "order" not in record.__dict__
+
+
+def test_flatten_filter_leaves_lists_as_is() -> None:
+    """Lists / heterogeneous arrays are left untouched (documented behavior)."""
+    flt = AttributeFlattenFilter()
+    record = _make_record()
+    setattr(record, "tags", ["a", "b", "c"])
+    setattr(record, "order", {"items": [{"id": 1}, {"id": 2}]})
+
+    flt.filter(record)
+
+    assert getattr(record, "tags") == ["a", "b", "c"]
+    # A list value nested inside a dict is emitted as-is under its dotted key.
+    assert getattr(record, "order.items") == [{"id": 1}, {"id": 2}]
+
+
+def test_flatten_filter_leaves_scalar_attributes_untouched() -> None:
+    flt = AttributeFlattenFilter()
+    record = _make_record()
+    setattr(record, "count", 5)
+    setattr(record, "label", "hello")
+
+    flt.filter(record)
+
+    assert getattr(record, "count") == 5
+    assert getattr(record, "label") == "hello"
+
+
+def test_flatten_filter_does_not_touch_reserved_keys() -> None:
+    flt = AttributeFlattenFilter()
+    record = _make_record()
+    original_name = record.name
+
+    flt.filter(record)
+
+    assert record.name == original_name
+    assert record.msg == "hello"
+    # The reserved 'name' key is not split into dotted attributes.
+    assert "name.test" not in record.__dict__
+
+
+def test_flatten_filter_supports_custom_separator() -> None:
+    flt = AttributeFlattenFilter(separator="__")
+    record = _make_record()
+    setattr(record, "order", {"id": 1})
+
+    flt.filter(record)
+
+    assert getattr(record, "order__id") == 1
+    assert "order" not in record.__dict__
+
+
+def test_flatten_filter_empty_dict_is_dropped() -> None:
+    flt = AttributeFlattenFilter()
+    record = _make_record()
+    setattr(record, "meta", {})
+
+    flt.filter(record)
+
+    assert "meta" not in record.__dict__
+
+
+def test_flatten_filter_respects_max_depth() -> None:
+    """Beyond max_depth the remaining nested dict is emitted as-is."""
+    flt = AttributeFlattenFilter(max_depth=1)
+    record = _make_record()
+    setattr(record, "a", {"b": {"c": 1}})
+
+    flt.filter(record)
+
+    # Depth 1 flattens the first level; the inner dict is kept as-is.
+    assert getattr(record, "a.b") == {"c": 1}
+
+
+def test_flatten_filter_handles_cyclic_dict_without_raising() -> None:
+    flt = AttributeFlattenFilter()
+    record = _make_record()
+    cyclic: dict[str, object] = {"self": None}
+    cyclic["self"] = cyclic
+    setattr(record, "loop", cyclic)
+
+    # Must not raise despite the cycle.
+    assert flt.filter(record) is True
+
+
+def test_flatten_filter_always_returns_true() -> None:
+    flt = AttributeFlattenFilter()
+    assert flt.filter(_make_record()) is True
+
+
+def test_flatten_filter_never_raises_on_broken_attribute() -> None:
+    class ExplodingRecord(logging.LogRecord):
+        def __getattribute__(self, name: str) -> object:
+            if name == "explode":
+                msg = "attribute access failure"
+                raise RuntimeError(msg)
+            return super().__getattribute__(name)
+
+    flt = AttributeFlattenFilter()
+    record = ExplodingRecord(
+        name="test.logger",
+        level=logging.INFO,
+        pathname=__file__,
+        lineno=1,
+        msg="exploding",
+        args=(),
+        exc_info=None,
+    )
+    setattr(record, "explode", {"id": 1})
+    setattr(record, "order", {"id": 2})
+
+    assert flt.filter(record) is True
+    # Well-formed attribute is still flattened.
+    assert getattr(record, "order.id") == 2
+
+
+def test_flatten_filter_survives_dict_that_raises_on_iteration() -> None:
+    """A field whose flattening raises must not stop other fields or the filter."""
+
+    class ExplodingDict(dict):  # type: ignore[type-arg]
+        def items(self) -> object:  # type: ignore[override]
+            msg = "items access failure"
+            raise RuntimeError(msg)
+
+    flt = AttributeFlattenFilter()
+    record = _make_record()
+    setattr(record, "broken", ExplodingDict())
+    setattr(record, "order", {"id": 7})
+
+    assert flt.filter(record) is True
+    # The healthy field is still flattened despite the broken sibling.
+    assert getattr(record, "order.id") == 7
+
+
+def test_flatten_filter_honors_name_scoping() -> None:
+    flt = AttributeFlattenFilter(name="myapp")
+    record = logging.LogRecord(
+        name="other.module",
+        level=logging.INFO,
+        pathname=__file__,
+        lineno=1,
+        msg="hello",
+        args=(),
+        exc_info=None,
+    )
+    setattr(record, "order", {"id": 1})
+
+    # Non-matching logger bypasses flattening.
+    assert flt.filter(record) is True
+    assert getattr(record, "order") == {"id": 1}
+    assert "order.id" not in record.__dict__

--- a/tests/test_host_config_otel.py
+++ b/tests/test_host_config_otel.py
@@ -1,0 +1,363 @@
+"""Tests for OpenTelemetry logging misconfiguration warnings (issue #256).
+
+These cover ``warn_otel_logging_misconfig`` and its import-free helpers:
+
+- **6a** — OTel handler present *and* ``functions_formatter`` supplied → warn ignored.
+- **6b** — OTel handler present but no telemetry env var set → tentative warning.
+- **6c** — ``host.json`` requests OpenTelemetry mode but no OTel handler → ordering hint.
+
+A key requirement is **no false positives** in the wrong-call-order scenario:
+when no OTel handler is attached and ``host.json`` does not request OpenTelemetry,
+the function must stay silent regardless of ``functions_formatter``.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+import json
+import logging
+from pathlib import Path
+import warnings
+
+import pytest
+
+from azure_functions_logging._host_config import (
+    _any_otel_logging_handler,
+    _has_otel_logging_handler,
+    _read_host_telemetry_mode,
+    warn_otel_logging_misconfig,
+)
+
+
+def _write_host_json(path: Path, content: dict[str, object]) -> None:
+    path.write_text(json.dumps(content), encoding="utf-8")
+
+
+class _FakeOtelHandler(logging.Handler):
+    """A stand-in whose defining module mimics OpenTelemetry's SDK handler."""
+
+    def emit(self, record: logging.LogRecord) -> None:  # pragma: no cover - no-op
+        pass
+
+
+# Make the import-free module-name detection treat this as an OTel handler.
+_FakeOtelHandler.__module__ = "opentelemetry.sdk._logs._internal"
+
+
+class _FakeInstrumentationOtelHandler(logging.Handler):
+    """A stand-in mimicking the non-deprecated instrumentation handler that
+    ``configure_azure_monitor()`` actually attaches."""
+
+    def emit(self, record: logging.LogRecord) -> None:  # pragma: no cover - no-op
+        pass
+
+
+# The handler ``configure_azure_monitor()`` installs lives here (non-deprecated).
+_FakeInstrumentationOtelHandler.__module__ = "opentelemetry.instrumentation.logging.handler"
+
+
+class _PlainHandler(logging.Handler):
+    def emit(self, record: logging.LogRecord) -> None:  # pragma: no cover - no-op
+        pass
+
+
+@pytest.fixture
+def clean_root() -> Iterator[logging.Logger]:
+    """Provide the root logger with its handlers/filters restored after the test."""
+    root = logging.getLogger()
+    saved_handlers = root.handlers[:]
+    saved_filters = root.filters[:]
+    root.handlers = []
+    root.filters = []
+    try:
+        yield root
+    finally:
+        root.handlers = saved_handlers
+        root.filters = saved_filters
+
+
+@pytest.fixture(autouse=True)
+def _clear_otel_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Ensure telemetry env vars are unset unless a test sets them explicitly."""
+    monkeypatch.delenv("PYTHON_ENABLE_OPENTELEMETRY", raising=False)
+    monkeypatch.delenv("PYTHON_APPLICATIONINSIGHTS_ENABLE_TELEMETRY", raising=False)
+    monkeypatch.delenv("OTEL_LOGS_EXPORTER", raising=False)
+    monkeypatch.delenv("OTEL_TRACES_EXPORTER", raising=False)
+
+
+# --------------------------------------------------------------------------- #
+# _has_otel_logging_handler
+# --------------------------------------------------------------------------- #
+
+
+def test_has_otel_logging_handler_detects_otel_module(clean_root: logging.Logger) -> None:
+    clean_root.addHandler(_FakeOtelHandler())
+    assert _has_otel_logging_handler(clean_root) is True
+
+
+def test_has_otel_logging_handler_detects_instrumentation_handler(
+    clean_root: logging.Logger,
+) -> None:
+    # ``configure_azure_monitor()`` attaches
+    # ``opentelemetry.instrumentation.logging.handler.LoggingHandler`` (the
+    # non-deprecated handler). Detection keys off the ``opentelemetry.*`` module
+    # namespace, so it must recognise this handler too — not only the deprecated
+    # ``opentelemetry.sdk._logs`` one.
+    clean_root.addHandler(_FakeInstrumentationOtelHandler())
+    assert _has_otel_logging_handler(clean_root) is True
+
+
+def test_has_otel_logging_handler_false_for_plain_handler(clean_root: logging.Logger) -> None:
+    clean_root.addHandler(_PlainHandler())
+    assert _has_otel_logging_handler(clean_root) is False
+
+
+def test_has_otel_logging_handler_false_when_no_handlers(clean_root: logging.Logger) -> None:
+    assert _has_otel_logging_handler(clean_root) is False
+
+
+# --------------------------------------------------------------------------- #
+# _read_host_telemetry_mode
+# --------------------------------------------------------------------------- #
+
+
+def test_read_host_telemetry_mode_explicit_path(tmp_path: Path) -> None:
+    host = tmp_path / "host.json"
+    _write_host_json(host, {"telemetryMode": "OpenTelemetry"})
+    assert _read_host_telemetry_mode(host) == "OpenTelemetry"
+
+
+def test_read_host_telemetry_mode_missing_key(tmp_path: Path) -> None:
+    host = tmp_path / "host.json"
+    _write_host_json(host, {"version": "2.0"})
+    assert _read_host_telemetry_mode(host) is None
+
+
+def test_read_host_telemetry_mode_non_string(tmp_path: Path) -> None:
+    host = tmp_path / "host.json"
+    _write_host_json(host, {"telemetryMode": 123})
+    assert _read_host_telemetry_mode(host) is None
+
+
+def test_read_host_telemetry_mode_missing_file(tmp_path: Path) -> None:
+    assert _read_host_telemetry_mode(tmp_path / "nope.json") is None
+
+
+def test_read_host_telemetry_mode_malformed(tmp_path: Path) -> None:
+    host = tmp_path / "host.json"
+    host.write_text("not valid json", encoding="utf-8")
+    assert _read_host_telemetry_mode(host) is None
+
+
+def test_read_host_telemetry_mode_autodiscovers(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _write_host_json(tmp_path / "host.json", {"telemetryMode": "OpenTelemetry"})
+    monkeypatch.chdir(tmp_path)
+    assert _read_host_telemetry_mode(None) == "OpenTelemetry"
+
+
+def test_read_host_telemetry_mode_non_mapping(tmp_path: Path) -> None:
+    # A top-level JSON array is valid JSON but not a mapping.
+    host = tmp_path / "host.json"
+    host.write_text("[1, 2, 3]", encoding="utf-8")
+    assert _read_host_telemetry_mode(host) is None
+
+
+def test_read_host_telemetry_mode_oserror_on_stat(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    host = tmp_path / "host.json"
+    _write_host_json(host, {"telemetryMode": "OpenTelemetry"})
+
+    def _boom(self: Path) -> bool:
+        raise OSError("stat failed")
+
+    monkeypatch.setattr(Path, "is_file", _boom)
+    assert _read_host_telemetry_mode(host) is None
+
+
+# --------------------------------------------------------------------------- #
+# 6a — functions_formatter ignored when OTel handler present
+# --------------------------------------------------------------------------- #
+
+
+def test_6a_warns_when_formatter_passed_with_otel_handler(
+    clean_root: logging.Logger,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    clean_root.addHandler(_FakeOtelHandler())
+    # Set a telemetry env var so 6b stays silent; isolate 6a.
+    monkeypatch.setenv("PYTHON_ENABLE_OPENTELEMETRY", "1")
+    with pytest.warns(UserWarning, match="functions_formatter"):
+        warn_otel_logging_misconfig(functions_formatter=logging.Formatter())
+
+
+def test_6a_silent_when_no_formatter(
+    clean_root: logging.Logger,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    clean_root.addHandler(_FakeOtelHandler())
+    # env var set so 6b does not fire; only 6a is under test here.
+    monkeypatch.setenv("PYTHON_ENABLE_OPENTELEMETRY", "1")
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        warn_otel_logging_misconfig(functions_formatter=None)
+
+
+# --------------------------------------------------------------------------- #
+# 6b — OTel handler present but no telemetry env var
+# --------------------------------------------------------------------------- #
+
+
+def test_6b_warns_when_no_telemetry_env_var(clean_root: logging.Logger) -> None:
+    clean_root.addHandler(_FakeOtelHandler())
+    with pytest.warns(UserWarning, match="may not be exported"):
+        warn_otel_logging_misconfig()
+
+
+@pytest.mark.parametrize(
+    "env_name",
+    ["PYTHON_ENABLE_OPENTELEMETRY", "PYTHON_APPLICATIONINSIGHTS_ENABLE_TELEMETRY"],
+)
+def test_6b_silent_when_env_var_set(
+    clean_root: logging.Logger,
+    monkeypatch: pytest.MonkeyPatch,
+    env_name: str,
+) -> None:
+    clean_root.addHandler(_FakeOtelHandler())
+    monkeypatch.setenv(env_name, "1")
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        warn_otel_logging_misconfig()
+
+
+# --------------------------------------------------------------------------- #
+# 6c — host.json OpenTelemetry mode but no OTel handler
+# --------------------------------------------------------------------------- #
+
+
+def test_6c_warns_on_ordering_mismatch(
+    clean_root: logging.Logger,
+    tmp_path: Path,
+) -> None:
+    host = tmp_path / "host.json"
+    _write_host_json(host, {"telemetryMode": "OpenTelemetry"})
+    with pytest.warns(UserWarning, match="before setup_logging"):
+        warn_otel_logging_misconfig(host_json_path=host)
+
+
+def test_6c_case_insensitive(
+    clean_root: logging.Logger,
+    tmp_path: Path,
+) -> None:
+    host = tmp_path / "host.json"
+    _write_host_json(host, {"telemetryMode": "opentelemetry"})
+    with pytest.warns(UserWarning, match="before setup_logging"):
+        warn_otel_logging_misconfig(host_json_path=host)
+
+
+# --------------------------------------------------------------------------- #
+# No false positives in the wrong-call-order / benign scenarios
+# --------------------------------------------------------------------------- #
+
+
+def test_no_warning_when_no_otel_and_no_host_mode(
+    clean_root: logging.Logger,
+    tmp_path: Path,
+) -> None:
+    host = tmp_path / "host.json"
+    _write_host_json(host, {"version": "2.0"})
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        warn_otel_logging_misconfig(
+            functions_formatter=logging.Formatter(),
+            host_json_path=host,
+        )
+
+
+def test_no_warning_when_no_otel_and_no_host_json(clean_root: logging.Logger) -> None:
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        warn_otel_logging_misconfig(host_json_path=None)
+
+
+def test_6c_silent_for_non_otel_telemetry_mode(
+    clean_root: logging.Logger,
+    tmp_path: Path,
+) -> None:
+    host = tmp_path / "host.json"
+    _write_host_json(host, {"telemetryMode": "ApplicationInsights"})
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        warn_otel_logging_misconfig(host_json_path=host)
+
+
+# --------------------------------------------------------------------------- #
+# m2 — generic OTEL_* export env vars suppress the tentative 6b warning
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize("env_name", ["OTEL_LOGS_EXPORTER", "OTEL_TRACES_EXPORTER"])
+def test_6b_silent_when_generic_otel_export_var_set(
+    clean_root: logging.Logger,
+    monkeypatch: pytest.MonkeyPatch,
+    env_name: str,
+) -> None:
+    """A self-managed OTel exporter (generic OTEL_* var) is not a misconfig."""
+    clean_root.addHandler(_FakeOtelHandler())
+    monkeypatch.setenv(env_name, "otlp")
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        warn_otel_logging_misconfig()
+
+
+# --------------------------------------------------------------------------- #
+# m3 — OTel handler on a child logger is detected across the hierarchy
+# --------------------------------------------------------------------------- #
+
+
+def test_any_otel_logging_handler_false_when_none(clean_root: logging.Logger) -> None:
+    assert _any_otel_logging_handler() is False
+
+
+def test_any_otel_logging_handler_detects_root(clean_root: logging.Logger) -> None:
+    clean_root.addHandler(_FakeOtelHandler())
+    assert _any_otel_logging_handler() is True
+
+
+def test_any_otel_logging_handler_detects_child_logger(
+    clean_root: logging.Logger,
+) -> None:
+    child = logging.getLogger("tests.otel.child")
+    handler = _FakeOtelHandler()
+    child.addHandler(handler)
+    try:
+        assert _any_otel_logging_handler() is True
+    finally:
+        child.removeHandler(handler)
+
+
+def test_6c_silent_when_otel_handler_on_child_logger(
+    clean_root: logging.Logger,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """6c must not fire when the OTel handler lives on a child logger."""
+    child = logging.getLogger("tests.otel.child6c")
+    handler = _FakeOtelHandler()
+    child.addHandler(handler)
+    # Set a telemetry env var so the tentative 6b warning stays silent; this
+    # test isolates 6c (host.json OpenTelemetry mode without a *detected*
+    # handler), which must not fire now that child handlers are detected.
+    monkeypatch.setenv("PYTHON_ENABLE_OPENTELEMETRY", "1")
+    host = tmp_path / "host.json"
+    _write_host_json(host, {"telemetryMode": "OpenTelemetry"})
+    try:
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            warn_otel_logging_misconfig(host_json_path=host)
+    finally:
+        child.removeHandler(handler)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -81,6 +81,7 @@ def test_get_logger_returns_function_logger() -> None:
 def test_public_api_exports() -> None:
     expected = {
         "__version__",
+        "AttributeFlattenFilter",
         "ContextTokens",
         "FunctionLogger",
         "JsonFormatter",

--- a/tests/test_json_formatter.py
+++ b/tests/test_json_formatter.py
@@ -40,6 +40,7 @@ def test_basic_json_output_is_valid_and_has_expected_fields() -> None:
     assert payload["invocation_id"] is None
     assert payload["function_name"] is None
     assert payload["trace_id"] is None
+    assert payload["span_id"] is None
     assert payload["cold_start"] is None
     assert payload["exception"] is None
     assert payload["extra"] == {}
@@ -51,12 +52,14 @@ def test_context_fields_included_when_present() -> None:
     record.invocation_id = "inv-1"
     record.function_name = "fn-1"
     record.trace_id = "trace-1"
+    record.span_id = "span-1"
 
     payload = json.loads(formatter.format(record))
 
     assert payload["invocation_id"] == "inv-1"
     assert payload["function_name"] == "fn-1"
     assert payload["trace_id"] == "trace-1"
+    assert payload["span_id"] == "span-1"
 
 
 def test_cold_start_field_for_true_false_and_none() -> None:
@@ -296,8 +299,6 @@ def test_format_emergency_fallback_when_payload_dict_unserializable(
     formatter = JsonFormatter()
     record = _make_record(logging.WARNING, "force emergency")
 
-
-
     call_count = {"n": 0}
     real_dumps = json.dumps
 
@@ -314,6 +315,7 @@ def test_format_emergency_fallback_when_payload_dict_unserializable(
     assert payload["message"] == "<emergency fallback: formatter failed>"
     assert payload["extra"] == {"__serialization_error__": True}
     assert payload["level"] == "WARNING"
+    assert payload["span_id"] is None
 
 
 def test_format_handles_invalid_timestamp() -> None:

--- a/tests/test_otel.py
+++ b/tests/test_otel.py
@@ -1,0 +1,318 @@
+"""Tests for the optional OpenTelemetry trace-context activation (issue #255).
+
+These validate the production ``activated_trace_context`` context manager that
+attaches the host's W3C trace context so an OTel ``LoggingHandler`` stamps
+emitted records with the host span's ``trace_id``/``span_id`` — without this
+package ever creating, recording, or exporting a span.
+
+The OTel-dependent tests skip cleanly when ``opentelemetry-api`` is absent, so
+the base install stays zero-dependency.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from azure_functions_logging import _otel
+
+_TRACE_ID_HEX = "4bf92f3577b34da6a3ce929d0e0e4736"
+_PARENT_ID_HEX = "00f067aa0ba902b7"
+_TRACEPARENT = f"00-{_TRACE_ID_HEX}-{_PARENT_ID_HEX}-01"
+
+
+def test_is_available_reflects_otel_import() -> None:
+    # In this repo's test env opentelemetry-api is installed, so this is True.
+    pytest.importorskip("opentelemetry.context")
+    assert _otel.is_available() is True
+
+
+def test_activated_trace_context_is_noop_when_traceparent_missing() -> None:
+    # Must not raise and must yield even with no traceparent.
+    with _otel.activated_trace_context(None):
+        pass
+    with _otel.activated_trace_context(""):
+        pass
+
+
+def test_activated_trace_context_noop_when_otel_unavailable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(_otel, "is_available", lambda: False)
+    # Even with a valid traceparent, absence of OTel must degrade to a no-op.
+    with _otel.activated_trace_context(_TRACEPARENT):
+        pass
+
+
+def test_activated_trace_context_binds_host_span() -> None:
+    pytest.importorskip("opentelemetry.context")
+    from opentelemetry import trace
+
+    assert not trace.get_current_span().get_span_context().is_valid
+    with _otel.activated_trace_context(_TRACEPARENT):
+        span_context = trace.get_current_span().get_span_context()
+        assert span_context.is_valid
+        assert span_context.is_remote is True
+        assert format(span_context.trace_id, "032x") == _TRACE_ID_HEX
+        assert format(span_context.span_id, "016x") == _PARENT_ID_HEX
+    # Context restored (LIFO detach) after the block.
+    assert not trace.get_current_span().get_span_context().is_valid
+
+
+def test_activated_trace_context_detaches_on_exception() -> None:
+    pytest.importorskip("opentelemetry.context")
+    from opentelemetry import trace
+
+    with pytest.raises(ValueError):
+        with _otel.activated_trace_context(_TRACEPARENT):
+            raise ValueError("boom")
+    assert not trace.get_current_span().get_span_context().is_valid
+
+
+def test_activated_trace_context_honours_trace_state() -> None:
+    pytest.importorskip("opentelemetry.context")
+    from opentelemetry import trace
+
+    with _otel.activated_trace_context(_TRACEPARENT, trace_state="vendor=abc"):
+        span_context = trace.get_current_span().get_span_context()
+        assert span_context.is_valid
+        assert span_context.trace_state.get("vendor") == "abc"
+
+
+def test_activated_trace_context_survives_malformed_traceparent() -> None:
+    # A structurally invalid traceparent must never raise out of the CM.
+    with _otel.activated_trace_context("not-a-valid-traceparent"):
+        pass
+
+
+# ---------------------------------------------------------------------------
+# Integration: activation wired through the public entry points
+# ---------------------------------------------------------------------------
+
+
+def _make_context(
+    trace_parent: str | None = _TRACEPARENT,
+    trace_state: str | None = None,
+) -> SimpleNamespace:
+
+    return SimpleNamespace(
+        invocation_id="inv-1",
+        function_name="fn-a",
+        trace_context=SimpleNamespace(
+            trace_parent=trace_parent,
+            trace_state=trace_state,
+        ),
+    )
+
+
+def test_logging_context_activates_host_span_when_enabled() -> None:
+    pytest.importorskip("opentelemetry.context")
+    from opentelemetry import trace
+
+    from azure_functions_logging import logging_context
+
+    with logging_context(_make_context(), activate_trace_context=True):
+        sc = trace.get_current_span().get_span_context()
+        assert sc.is_valid
+        assert format(sc.span_id, "016x") == _PARENT_ID_HEX
+    assert not trace.get_current_span().get_span_context().is_valid
+
+
+def test_logging_context_does_not_activate_when_explicitly_disabled() -> None:
+    pytest.importorskip("opentelemetry.context")
+    from opentelemetry import trace
+
+    from azure_functions_logging import logging_context
+    from azure_functions_logging._context import set_default_trace_context_activation
+
+    # An explicit per-call ``False`` must override the auto default and stay off,
+    # even when OpenTelemetry is importable.
+    try:
+        set_default_trace_context_activation(None)
+        with logging_context(_make_context(), activate_trace_context=False):
+            assert not trace.get_current_span().get_span_context().is_valid
+    finally:
+        set_default_trace_context_activation(None)
+
+
+def test_logging_context_auto_activates_when_otel_available() -> None:
+    pytest.importorskip("opentelemetry.context")
+    from opentelemetry import trace
+
+    from azure_functions_logging import logging_context
+    from azure_functions_logging._context import set_default_trace_context_activation
+
+    # Auto tier (#255): with no explicit flag and no configured default,
+    # activation is enabled iff opentelemetry-api is importable — which it is
+    # in this test env.
+    try:
+        set_default_trace_context_activation(None)
+        with logging_context(_make_context()):
+            assert trace.get_current_span().get_span_context().is_valid
+    finally:
+        set_default_trace_context_activation(None)
+
+
+def test_with_context_activates_host_span_when_enabled() -> None:
+    pytest.importorskip("opentelemetry.context")
+    from opentelemetry import trace
+
+    from azure_functions_logging import with_context
+
+    seen: dict[str, bool] = {}
+
+    @with_context(activate_trace_context=True)
+    def handler(req: object, context: object) -> str:
+        seen["valid"] = trace.get_current_span().get_span_context().is_valid
+        return "ok"
+
+    assert handler(None, _make_context()) == "ok"
+    assert seen["valid"] is True
+    assert not trace.get_current_span().get_span_context().is_valid
+
+
+def test_setup_logging_sets_default_activation() -> None:
+    pytest.importorskip("opentelemetry.context")
+    from opentelemetry import trace
+
+    from azure_functions_logging import logging_context, setup_logging
+    from azure_functions_logging._context import set_default_trace_context_activation
+
+    try:
+        setup_logging(logger_name="afl.otel.default", activate_trace_context=True)
+        with logging_context(_make_context()):
+            assert trace.get_current_span().get_span_context().is_valid
+    finally:
+        set_default_trace_context_activation(None)
+
+
+def test_setup_logging_bare_call_preserves_explicit_activation() -> None:
+    """A later argument-less ``setup_logging()`` must not revert a previously
+    configured activation default (idempotency — reviewer finding)."""
+    from azure_functions_logging import setup_logging
+    from azure_functions_logging._context import (
+        get_default_trace_context_activation,
+        set_default_trace_context_activation,
+    )
+
+    try:
+        setup_logging(logger_name="afl.otel.idempotent", activate_trace_context=True)
+        # A bare call (activate_trace_context defaults to None) must leave the
+        # explicitly-set default intact rather than silently reverting to auto.
+        setup_logging(logger_name="afl.otel.idempotent.b")
+        assert get_default_trace_context_activation() is True
+    finally:
+        set_default_trace_context_activation(None)
+
+
+# ---------------------------------------------------------------------------
+# Auto tier (#255): default None resolves to "enabled iff opentelemetry-api
+# is importable".
+# ---------------------------------------------------------------------------
+
+
+def test_get_default_activation_auto_enabled_when_otel_available(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from azure_functions_logging import _context
+
+    monkeypatch.setattr(_context, "_default_trace_context_activation", None)
+    monkeypatch.setattr(_otel, "is_available", lambda: True)
+    assert _context.get_default_trace_context_activation() is True
+
+
+def test_get_default_activation_auto_disabled_when_otel_absent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from azure_functions_logging import _context
+
+    monkeypatch.setattr(_context, "_default_trace_context_activation", None)
+    monkeypatch.setattr(_otel, "is_available", lambda: False)
+    assert _context.get_default_trace_context_activation() is False
+
+
+def test_get_default_activation_explicit_overrides_auto(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from azure_functions_logging import _context
+
+    # An explicit stored default short-circuits the auto probe entirely.
+    monkeypatch.setattr(_context, "_default_trace_context_activation", False)
+    monkeypatch.setattr(_otel, "is_available", lambda: True)
+    assert _context.get_default_trace_context_activation() is False
+
+
+def test_resolve_auto_returns_false_when_otel_import_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import sys
+
+    from azure_functions_logging import _context
+
+    # Simulate the base (zero-dependency) install where importing the helper's
+    # ``is_available`` path is fine but OTel itself is absent.
+    monkeypatch.setitem(sys.modules, "opentelemetry.context", None)
+    monkeypatch.setitem(sys.modules, "opentelemetry.propagate", None)
+    assert _context._resolve_auto_trace_context_activation() is False
+
+
+# ---------------------------------------------------------------------------
+# _otel silent-failure paths (Principle 3): every branch degrades to a no-op.
+# ---------------------------------------------------------------------------
+
+
+def test_is_available_false_when_import_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    import sys
+
+    monkeypatch.setitem(sys.modules, "opentelemetry.context", None)
+    assert _otel.is_available() is False
+
+
+def test_activated_trace_context_noop_when_extract_import_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import sys
+
+    pytest.importorskip("opentelemetry.context")
+    # OTel appears available (is_available forced True), but importing the
+    # propagate API inside the context manager fails.
+    monkeypatch.setattr(_otel, "is_available", lambda: True)
+    monkeypatch.setitem(sys.modules, "opentelemetry.propagate", None)
+    with _otel.activated_trace_context(_TRACEPARENT):
+        pass
+
+
+def test_activated_trace_context_noop_when_attach_raises(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    pytest.importorskip("opentelemetry.context")
+    from opentelemetry import context as otel_context
+
+    def _boom(_ctx: object) -> None:
+        raise RuntimeError("attach failed")
+
+    monkeypatch.setattr(otel_context, "attach", _boom)
+    # Attach failure must be swallowed; the block still runs and detach is skipped.
+    with _otel.activated_trace_context(_TRACEPARENT):
+        pass
+
+
+def test_activated_trace_context_swallows_detach_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    pytest.importorskip("opentelemetry.context")
+    from opentelemetry import context as otel_context
+
+    real_detach = otel_context.detach
+
+    def _boom(token: object) -> None:
+        # Perform the real detach first so global OTel context is not leaked
+        # into later tests, then raise to exercise the silent-cleanup branch.
+        real_detach(token)  # type: ignore[arg-type]
+        raise RuntimeError("detach failed")
+
+    monkeypatch.setattr(otel_context, "detach", _boom)
+    # A failing detach on cleanup must never propagate.
+    with _otel.activated_trace_context(_TRACEPARENT):
+        pass

--- a/tests/test_otel_spike.py
+++ b/tests/test_otel_spike.py
@@ -1,0 +1,189 @@
+"""OpenTelemetry log-correlation spike, kept as a regression guard (issue #253).
+
+The original spike proved that attaching the host's W3C trace context lets an
+OpenTelemetry ``LoggingHandler`` stamp emitted log records with the host span's
+``trace_id`` / ``span_id`` — without this package ever creating, recording, or
+exporting a span. Per #253 the spike itself is retained here so the pinned
+behaviour (including its known thread-boundary limitation) cannot silently
+regress.
+
+These tests require the OpenTelemetry SDK. They skip cleanly when it is absent,
+so the base install stays zero-dependency.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from concurrent.futures import ThreadPoolExecutor
+import logging
+from types import SimpleNamespace
+from typing import TYPE_CHECKING, Any
+
+import pytest
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+pytest.importorskip("opentelemetry.sdk._logs")
+
+from opentelemetry.sdk._logs import LoggerProvider, LoggingHandler  # noqa: E402
+from opentelemetry.sdk._logs.export import (  # noqa: E402
+    InMemoryLogRecordExporter,
+    SimpleLogRecordProcessor,
+)
+
+from azure_functions_logging import logging_context  # noqa: E402
+
+# W3C traceparent fixtures. ``_PARENT_ID`` is the host span-id every correlated
+# record must inherit.
+_TRACE_ID = "4bf92f3577b34da6a3ce929d0e0e4736"
+_PARENT_ID = "00f067aa0ba902b7"
+_TRACEPARENT = f"00-{_TRACE_ID}-{_PARENT_ID}-01"
+
+# A second, distinct host span for concurrency-isolation assertions.
+_TRACE_ID_B = "0af7651916cd43dd8448eb211c80319c"
+_PARENT_ID_B = "b7ad6b7169203331"
+_TRACEPARENT_B = f"00-{_TRACE_ID_B}-{_PARENT_ID_B}-01"
+
+
+def _make_context(trace_parent: str | None = _TRACEPARENT) -> SimpleNamespace:
+    return SimpleNamespace(
+        invocation_id="inv-1",
+        function_name="fn-a",
+        trace_context=SimpleNamespace(trace_parent=trace_parent, trace_state=None),
+    )
+
+
+@pytest.fixture
+def otel_logger() -> Iterator[tuple[logging.Logger, InMemoryLogRecordExporter]]:
+    """A logger wired to an in-memory OTel ``LoggingHandler``."""
+    provider = LoggerProvider()
+    exporter = InMemoryLogRecordExporter()  # type: ignore[no-untyped-call]
+    provider.add_log_record_processor(SimpleLogRecordProcessor(exporter))
+    handler = LoggingHandler(logger_provider=provider)
+
+    logger = logging.getLogger("afl.otel.spike")
+    logger.setLevel(logging.INFO)
+    logger.addHandler(handler)
+    logger.propagate = False
+    try:
+        yield logger, exporter
+    finally:
+        logger.removeHandler(handler)
+        provider.shutdown()
+
+
+def _only_record(exporter: InMemoryLogRecordExporter) -> Any:
+    logs = exporter.get_finished_logs()
+    assert len(logs) == 1
+    return logs[0].log_record
+
+
+def test_spike_sync_record_inherits_host_span(
+    otel_logger: tuple[logging.Logger, InMemoryLogRecordExporter],
+) -> None:
+    logger, exporter = otel_logger
+    with logging_context(_make_context(), activate_trace_context=True):
+        logger.info("hello")
+    record = _only_record(exporter)
+    assert format(record.trace_id, "032x") == _TRACE_ID
+    assert format(record.span_id, "016x") == _PARENT_ID
+
+
+def test_spike_correlation_survives_await(
+    otel_logger: tuple[logging.Logger, InMemoryLogRecordExporter],
+) -> None:
+    logger, exporter = otel_logger
+
+    async def handler() -> None:
+        with logging_context(_make_context(), activate_trace_context=True):
+            await asyncio.sleep(0)
+            logger.info("after await")
+
+    asyncio.run(handler())
+    record = _only_record(exporter)
+    assert format(record.span_id, "016x") == _PARENT_ID
+
+
+def test_spike_gather_isolates_concurrent_contexts(
+    otel_logger: tuple[logging.Logger, InMemoryLogRecordExporter],
+) -> None:
+    logger, exporter = otel_logger
+
+    async def emit(trace_parent: str, message: str) -> None:
+        with logging_context(_make_context(trace_parent), activate_trace_context=True):
+            await asyncio.sleep(0)
+            logger.info(message)
+
+    async def run() -> None:
+        await asyncio.gather(
+            emit(_TRACEPARENT, "a"),
+            emit(_TRACEPARENT_B, "b"),
+        )
+
+    asyncio.run(run())
+
+    by_message = {
+        rec.log_record.body: format(rec.log_record.span_id, "016x")
+        for rec in exporter.get_finished_logs()
+    }
+    # Each concurrent task's record carries only its own host span — no bleed.
+    assert by_message == {"a": _PARENT_ID, "b": _PARENT_ID_B}
+
+
+def test_spike_thread_boundary_loses_correlation(
+    otel_logger: tuple[logging.Logger, InMemoryLogRecordExporter],
+) -> None:
+    """Known limitation: OTel runtime context is contextvar-based, so worker
+    threads spawned via ``ThreadPoolExecutor`` do NOT inherit the host span.
+    Pinned as a regression guard (span_id == 0 in the spawned thread)."""
+    logger, exporter = otel_logger
+
+    with logging_context(_make_context(), activate_trace_context=True):
+        with ThreadPoolExecutor(max_workers=1) as pool:
+            pool.submit(logger.info, "from thread").result()
+
+    record = _only_record(exporter)
+    assert record.span_id == 0
+
+
+def test_spike_nested_contexts_restore_outer_span(
+    otel_logger: tuple[logging.Logger, InMemoryLogRecordExporter],
+) -> None:
+    logger, exporter = otel_logger
+
+    with logging_context(_make_context(_TRACEPARENT), activate_trace_context=True):
+        with logging_context(_make_context(_TRACEPARENT_B), activate_trace_context=True):
+            logger.info("inner")
+        logger.info("outer")
+
+    spans = {
+        rec.log_record.body: format(rec.log_record.span_id, "016x")
+        for rec in exporter.get_finished_logs()
+    }
+    assert spans == {"inner": _PARENT_ID_B, "outer": _PARENT_ID}
+
+
+def test_spike_exception_path_detaches_context(
+    otel_logger: tuple[logging.Logger, InMemoryLogRecordExporter],
+) -> None:
+    logger, exporter = otel_logger
+
+    with pytest.raises(ValueError):
+        with logging_context(_make_context(), activate_trace_context=True):
+            raise ValueError("boom")
+
+    # After the failing block the host span must be detached: a later record
+    # emitted outside any context is uncorrelated.
+    logger.info("after")
+    record = _only_record(exporter)
+    assert record.span_id == 0
+
+
+def test_spike_no_context_is_uncorrelated(
+    otel_logger: tuple[logging.Logger, InMemoryLogRecordExporter],
+) -> None:
+    logger, exporter = otel_logger
+    logger.info("orphan")
+    record = _only_record(exporter)
+    assert record.span_id == 0

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -9,6 +9,7 @@ class TestAPISurface:
     def test_all_exports(self) -> None:
         assert set(azure_functions_logging.__all__) == {
             "__version__",
+            "AttributeFlattenFilter",
             "ContextTokens",
             "FunctionLogger",
             "JsonFormatter",
@@ -36,6 +37,7 @@ class TestAPISurface:
 
     def test_public_names_are_importable(self) -> None:
         from azure_functions_logging import (  # noqa: F401  # pyright: ignore[reportMissingImports]
+            AttributeFlattenFilter,
             ContextTokens,
             FunctionLogger,
             JsonFormatter,
@@ -70,8 +72,7 @@ class TestDocsCoverage:
         missing = [
             name
             for name in azure_functions_logging.__all__
-            if name != "__version__"
-            and f"::: azure_functions_logging.{name}" not in text
+            if name != "__version__" and f"::: azure_functions_logging.{name}" not in text
         ]
         assert not missing, (
             "Public symbols missing an mkdocstrings directive "

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -201,6 +201,40 @@ def test_format_color_no_warning_in_azure_environment() -> None:
     root.filters.clear()
 
 
+def test_setup_logging_warns_on_otel_formatter_conflict() -> None:
+    """setup_logging() wires warn_otel_logging_misconfig (issue #256).
+
+    With an OpenTelemetry handler attached and a functions_formatter passed,
+    the '6a' ignored-formatter warning must surface through setup_logging().
+    """
+    import warnings
+
+    class _FakeOtelHandler(logging.Handler):
+        def emit(self, record: logging.LogRecord) -> None:  # pragma: no cover
+            pass
+
+    _FakeOtelHandler.__module__ = "opentelemetry.sdk._logs._internal"
+
+    root = logging.getLogger()
+    root.handlers = [_FakeOtelHandler()]
+
+    env = {
+        "FUNCTIONS_WORKER_RUNTIME": "python",
+        "PYTHON_ENABLE_OPENTELEMETRY": "1",
+    }
+    try:
+        with patch.dict(os.environ, env, clear=True):
+            with warnings.catch_warnings(record=True) as w:
+                warnings.simplefilter("always")
+                setup_logging(functions_formatter=logging.Formatter())
+
+            messages = [str(rec.message) for rec in w]
+            assert any("functions_formatter" in m for m in messages)
+    finally:
+        root.handlers = []
+        root.filters.clear()
+
+
 def test_setup_logging_use_record_factory_installs_factory() -> None:
     """use_record_factory=True installs the global LogRecordFactory."""
     from azure_functions_logging._context import (
@@ -317,7 +351,13 @@ def test_setup_logging_factory_record_survives_contextvar_reset() -> None:
     token = invocation_id_var.set("test-invocation-123")
     try:
         record = logger.makeRecord(
-            logger_name, logging.INFO, "f.py", 1, "msg", (), None,
+            logger_name,
+            logging.INFO,
+            "f.py",
+            1,
+            "msg",
+            (),
+            None,
         )
     finally:
         invocation_id_var.reset(token)
@@ -345,7 +385,6 @@ def test_setup_logging_invalid_format_leaves_no_global_side_effects() -> None:
     with patch.dict(os.environ, {}, clear=True):
         with pytest.raises(ValueError, match="format must be"):
             setup_logging(format="bogus", use_record_factory=True)
-
 
     # Factory must not have been swapped despite use_record_factory=True
     assert logging.getLogRecordFactory() is baseline_factory
@@ -400,7 +439,7 @@ def test_azure_setup_does_not_duplicate_filter_on_repeated_calls() -> None:
         context_filter_count = sum(
             1 for f in handler.filters if type(f).__name__ == "ContextFilter"
         )
-        assert context_filter_count == 1, (", ".join(type(f).__name__ for f in handler.filters))
+        assert context_filter_count == 1, ", ".join(type(f).__name__ for f in handler.filters)
     finally:
         root.handlers[:] = original_handlers
         root.filters[:] = original_filters
@@ -435,10 +474,12 @@ def test_azure_setup_different_use_record_factory_flags_have_isolated_filter_sta
             (f for f in handler_with_factory.filters if type(f).__name__ == "ContextFilter"), None
         )
 
-        assert filter_no_factory is not None, \
+        assert filter_no_factory is not None, (
             "use_record_factory=False should install a ContextFilter on the handler"
-        assert filter_with_factory is None, \
+        )
+        assert filter_with_factory is None, (
             "use_record_factory=True must not install a ContextFilter (factory provides context)"
+        )
         # The filter installed by the first call must not bleed onto the second handler
         assert filter_no_factory not in handler_with_factory.filters
     finally:
@@ -470,8 +511,9 @@ def test_upgrade_to_record_factory_removes_existing_context_filter_local() -> No
     with patch.dict(os.environ, {}, clear=True):
         # Step 1: install ContextFilter mode
         setup_logging(logger_name=logger_name)
-        assert any(isinstance(f, ContextFilter) for h in logger.handlers for f in h.filters), \
+        assert any(isinstance(f, ContextFilter) for h in logger.handlers for f in h.filters), (
             "precondition: ContextFilter should be on handler"
+        )
 
         # Step 2: upgrade to factory mode — must remove the filter
         setup_mod._configured_loggers.discard(logger_name)  # allow re-entry
@@ -479,8 +521,9 @@ def test_upgrade_to_record_factory_removes_existing_context_filter_local() -> No
 
     # Assert filter is gone
     for handler in logger.handlers:
-        assert not any(isinstance(f, ContextFilter) for f in handler.filters), \
+        assert not any(isinstance(f, ContextFilter) for f in handler.filters), (
             "ContextFilter must be removed after switching to use_record_factory=True"
+        )
 
     # Step 3: create record under context A
     token = invocation_id_var.set("context-A")
@@ -499,8 +542,9 @@ def test_upgrade_to_record_factory_removes_existing_context_filter_local() -> No
                 f.filter(record)
 
     # Factory snapshot must survive
-    assert getattr(record, "invocation_id", None) == "context-A", \
+    assert getattr(record, "invocation_id", None) == "context-A", (
         f"Factory snapshot overwritten — got {getattr(record, 'invocation_id', None)!r}"
+    )
 
     logger.handlers.clear()
     logger.filters.clear()
@@ -529,8 +573,9 @@ def test_upgrade_to_record_factory_removes_context_filter_before_idempotency_gua
         # Even though logger_name is in _configured_loggers, cleanup must run
         setup_logging(logger_name=logger_name, use_record_factory=True)
 
-    assert not any(isinstance(f, ContextFilter) for f in handler.filters), \
+    assert not any(isinstance(f, ContextFilter) for f in handler.filters), (
         "ContextFilter must be removed even when re-entering via idempotency guard"
+    )
 
     logger.handlers.clear()
     logger.filters.clear()
@@ -556,17 +601,20 @@ def test_upgrade_to_record_factory_removes_context_filter_azure_mode() -> None:
         with patch.dict(os.environ, env, clear=True):
             # First call — installs ContextFilter
             setup_logging(use_record_factory=False)
-            assert any(isinstance(f, ContextFilter) for f in test_handler.filters), \
+            assert any(isinstance(f, ContextFilter) for f in test_handler.filters), (
                 "precondition: ContextFilter must be on handler after filter-mode call"
+            )
 
             # Second call — must remove ContextFilter
             setup_logging(use_record_factory=True)
 
         # After factory upgrade: no ContextFilter on handler or root logger
-        assert not any(isinstance(f, ContextFilter) for f in test_handler.filters), \
+        assert not any(isinstance(f, ContextFilter) for f in test_handler.filters), (
             "ContextFilter must be removed from root handler after use_record_factory=True"
-        assert not any(isinstance(f, ContextFilter) for f in root.filters), \
+        )
+        assert not any(isinstance(f, ContextFilter) for f in root.filters), (
             "ContextFilter must be removed from root.filters after use_record_factory=True"
+        )
     finally:
         root.handlers[:] = original_handlers
         root.filters[:] = original_filters
@@ -585,9 +633,7 @@ class TestInjectionModeParity:
     class _Ctx:
         invocation_id = "inv-parity-1"
         function_name = "parity_fn"
-        trace_context = SimpleNamespace(
-            trace_parent="00-" + "a" * 32 + "-" + "b" * 16 + "-01"
-        )
+        trace_context = SimpleNamespace(trace_parent="00-" + "a" * 32 + "-" + "b" * 16 + "-01")
 
     # trace_id extracted from the W3C traceparent above.
     EXPECTED_TRACE_ID = "a" * 32
@@ -616,7 +662,13 @@ class TestInjectionModeParity:
         reset_context()
         inject_context(self._Ctx())
         factory_record = logger.makeRecord(
-            logger_name, logging.INFO, "f.py", 1, "m", (), None,
+            logger_name,
+            logging.INFO,
+            "f.py",
+            1,
+            "m",
+            (),
+            None,
         )
         factory_fields = self._fields(factory_record)
         reset_context()


### PR DESCRIPTION
Stacked PR **5/7** · base: `otel/255-activate` (#255)

`warn_otel_logging_misconfig()` runs at `setup_logging()` time (documented `configure_azure_monitor()`-before-`setup_logging()` order) and emits up to three independent warnings: **6a** `functions_formatter` ignored when an OTel handler is attached, **6b** OTel handler present but no telemetry env var set, **6c** `host.json` `telemetryMode: OpenTelemetry` but no handler attached. Import-free handler detection; no false positives in the wrong-call-order path.

Closes #256 · Refs #252

> Review only the top commit; the diff is stacked on #255.


---
> Recreated after renaming the head branch from `otel/*` to a CI-allowed prefix (`feat/256-diagnostics`); supersedes #266.
