### PR TITLE
docs(otel): add opentelemetry guide and examples/otel_app (#258)

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ traces
 This package does not own:
 
 - **Replacing stdlib logging** — it wraps and enriches Python's standard `logging`, never replaces it
-- **Distributed tracing** — use OpenTelemetry or Application Insights SDK for end-to-end trace correlation
+- **Distributed tracing** — it does not create, record, or export spans; use OpenTelemetry or the Application Insights SDK for that. It *can* correlate your logs with the host invocation span — see [OpenTelemetry trace correlation](https://yeongseon.github.io/azure-functions-logging-python/opentelemetry/)
 - **API documentation** — use [`azure-functions-openapi`](https://github.com/yeongseon/azure-functions-openapi-python) for API documentation and spec generation
 
 ## Installation

--- a/docs/api.md
+++ b/docs/api.md
@@ -286,18 +286,6 @@ metadata = get_logging_metadata(handler)
 
 ::: azure_functions_logging.logging_context
 
-## activated_trace_context
-
-::: azure_functions_logging.activated_trace_context
-
-Attaches the host's W3C trace context so log records emitted through an
-OpenTelemetry `LoggingHandler` inherit the host span's `trace_id`/`span_id`.
-Requires the `[otel]` extra (`pip install azure-functions-logging[otel]`); it
-degrades to a silent no-op when OpenTelemetry is not installed. Prefer the
-`activate_trace_context=True` argument on `logging_context` / `with_context` /
-`setup_logging` for most applications; use this context manager directly for
-manual control. See [OpenTelemetry correlation](opentelemetry.md).
-
 ## install_context_factory
 
 ::: azure_functions_logging.install_context_factory

--- a/docs/opentelemetry.md
+++ b/docs/opentelemetry.md
@@ -1,0 +1,143 @@
+# OpenTelemetry trace correlation
+
+`azure-functions-logging` can bind the Azure Functions host's W3C trace context
+into your handler so that OpenTelemetry log records inherit the host invocation
+span's `trace_id` and `span_id`. This makes your structured logs correlate with
+the distributed trace in Application Insights — **without this package creating,
+recording, or exporting any spans**.
+
+## What this feature does
+
+- Reads the host-provided `traceparent` / `tracestate` from the invocation
+  `context` and **attaches** the extracted W3C context for the duration of the
+  handler (via `logging_context` / `with_context`).
+- While that context is active, any OpenTelemetry `LoggingHandler` stamps
+  emitted records with the host span's `trace_id` / `span_id`.
+- Emits `trace_id` and `span_id` in `JsonFormatter` output regardless of
+  OpenTelemetry availability (they are `null` when no context is present).
+
+## What this feature does not do
+
+- It does **not** start, record, or export spans — it only *activates* the
+  context the host already produced.
+- It does **not** replace `azure-monitor-opentelemetry` /
+  `configure_azure_monitor()`. You still configure the exporter yourself; this
+  package only ensures the host span context is active while your handler runs.
+- It is **not** a general distributed-tracing library.
+
+## Installation
+
+The base install stays zero-dependency. Trace-context activation requires the
+optional `[otel]` extra:
+
+```bash
+pip install "azure-functions-logging[otel]"
+```
+
+When OpenTelemetry is not installed, activation degrades to a **silent no-op** —
+your logs still emit `trace_id: null` / `span_id: null` and nothing raises.
+
+## Enabling activation
+
+Activation is **opt-in**. The value is resolved in this order (highest priority
+first):
+
+1. The per-call `activate_trace_context=` argument on `logging_context()` /
+   `@with_context(...)`, when not `None`.
+2. The process-wide default set by
+   `setup_logging(activate_trace_context=True)`.
+3. `False` (the built-in default — no activation).
+
+```python
+from azure_functions_logging import setup_logging, logging_context
+
+# Option A: process-wide default
+setup_logging(activate_trace_context=True)
+
+def handler(req, context):
+    with logging_context(context):  # inherits the default → activates
+        ...
+
+# Option B: per-call override (wins over the default either way)
+def handler(req, context):
+    with logging_context(context, activate_trace_context=True):
+        ...
+```
+
+You can also use the low-level `activated_trace_context()` context manager
+directly if you manage trace headers yourself.
+
+## Required call order
+
+The OpenTelemetry `LoggingHandler` is attached to the root logger by
+`configure_azure_monitor()`. `setup_logging()` only decorates handlers that
+already exist when it runs. **Call `configure_azure_monitor()` before
+`setup_logging()`** so that context filters — and any `RedactionFilter` /
+`SamplingFilter` you attach — actually land on the OTel handler:
+
+```python
+from azure.monitor.opentelemetry import configure_azure_monitor
+from azure_functions_logging import setup_logging
+
+configure_azure_monitor()                    # 1. attaches the OTel handler
+setup_logging(activate_trace_context=True)   # 2. decorates the now-present handler
+```
+
+> `configure_azure_monitor()` installs the non-deprecated
+> `opentelemetry.instrumentation.logging.LoggingHandler`. This package detects
+> **any** handler whose class lives under the `opentelemetry.*` namespace, so
+> both that handler and the older `opentelemetry.sdk._logs.LoggingHandler` are
+> recognised — you do not need to pin a specific handler class.
+
+If you reverse the order, the OTel handler is added *after* `setup_logging()`
+and never receives your filters — PII redaction is silently bypassed. See
+[Troubleshooting: PII appears in Application Insights attributes](troubleshooting.md#pii-appears-in-application-insights-attributes-opentelemetry-mode).
+
+For handlers that must be attached *after* `setup_logging()`, pass
+`use_record_factory=True` so context is injected at record-creation time instead
+of via handler filters.
+
+## Filters in OpenTelemetry mode
+
+In OTel mode the entire `extra` mapping is exported as log **attributes**, which
+makes `RedactionFilter` and `SamplingFilter` *more* important, not less — attach
+them to the OTel handler. Nested `dict` values in `extra` are silently dropped by
+the OTel SDK; use [`AttributeFlattenFilter`](api.md#attributeflattenfilter) to
+flatten them into dotted scalar keys (`order={"id": 1}` → `order.id=1`).
+
+```python
+import logging
+
+from azure_functions_logging import (
+    AttributeFlattenFilter,
+    RedactionFilter,
+    setup_logging,
+)
+
+setup_logging()
+for handler in logging.getLogger().handlers:
+    handler.addFilter(RedactionFilter())        # mask PII before export
+    handler.addFilter(AttributeFlattenFilter())  # keep nested dicts from being dropped
+```
+
+> **Scope `AttributeFlattenFilter` to the OTel handler.** The filter mutates the
+> shared `LogRecord` in place, so if the same filter also runs on a standalone
+> `JsonFormatter` stream handler your plain JSON output is flattened too: a
+> nested `extra={"order": {"id": 1}}` is emitted as `{"order.id": 1}` instead of
+> a nested object. That is what you want for OTel attribute export, but usually
+> not for local/standalone JSON logs — attach it to the specific OTel handler
+> rather than the root logger when both kinds of handler are present.
+
+## Known limitation: thread boundaries
+
+Trace-context activation uses `contextvars`, which do **not** automatically
+propagate across thread boundaries. Logs emitted from
+`loop.run_in_executor(...)` or a `ThreadPoolExecutor` worker lose the host span
+correlation unless you propagate the context yourself (e.g. by capturing
+`contextvars.copy_context()` and running the work inside it). Async code on the
+same event loop is unaffected.
+
+## Runnable example
+
+A minimal Function App wiring `azure-monitor-opentelemetry` together with this
+package lives in [`examples/otel_app`](https://github.com/yeongseon/azure-functions-logging-python/tree/main/examples/otel_app).

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -242,6 +242,48 @@ Azure/Core Tools setup installs filter-only behavior to avoid duplicate host out
 
 This difference is intentional and expected.
 
+## PII Appears in Application Insights Attributes (OpenTelemetry mode)
+
+### Symptoms
+
+You attached `RedactionFilter` (or `SamplingFilter`), yet sensitive values still
+appear as log **attributes** in Application Insights when using
+`azure-monitor-opentelemetry` / `configure_azure_monitor()`.
+
+### Root Cause
+
+In OpenTelemetry mode the OTel `LoggingHandler` is added to the root logger by
+`configure_azure_monitor()`. `setup_logging()` only decorates handlers that
+already exist when it runs, so if you call `setup_logging()` **before**
+`configure_azure_monitor()`, the OTel handler never receives your filters and
+the entire `extra` mapping is exported unfiltered.
+
+### Resolution
+
+1. Call `configure_azure_monitor()` **before** `setup_logging()` so the OTel
+   handler is present when filters are attached.
+2. Attach `RedactionFilter` to the OTel handler explicitly:
+
+   ```python
+   import logging
+
+   from azure.monitor.opentelemetry import configure_azure_monitor
+   from azure_functions_logging import RedactionFilter, setup_logging
+
+   configure_azure_monitor()          # attaches the OTel LoggingHandler to root
+   setup_logging()                    # decorates the now-present handler
+
+   redaction = RedactionFilter()
+   for handler in logging.getLogger().handlers:
+       handler.addFilter(redaction)   # ensure PII masking on the OTel handler
+   ```
+
+3. For handlers attached *after* `setup_logging()`, pass
+   `use_record_factory=True` so context is injected at record-creation time,
+   and re-attach filters to the late handler.
+
+See [OpenTelemetry correlation](opentelemetry.md) for the full ordering guide.
+
 ## Fast Diagnostic Checklist
 
 Run through this list during incidents:

--- a/examples/otel_app/function_app.py
+++ b/examples/otel_app/function_app.py
@@ -1,0 +1,65 @@
+"""Minimal Azure Functions app wiring azure-monitor-opentelemetry + this package.
+
+Demonstrates OpenTelemetry trace correlation (see docs/opentelemetry.md):
+
+- ``configure_azure_monitor()`` is called **before** ``setup_logging()`` so the
+  OTel ``LoggingHandler`` exists when context filters (and any PII filters) are
+  attached to it.
+- ``activate_trace_context=True`` makes ``logging_context`` attach the host's
+  W3C trace context, so emitted OTel log records inherit the invocation span's
+  ``trace_id`` / ``span_id`` — without this package ever creating a span.
+
+Deploy/run with the Azure Functions Core Tools:
+
+    func start --script-root examples/otel_app
+
+Requires ``pip install "azure-functions-logging[otel]"`` plus
+``azure-monitor-opentelemetry`` and an ``APPLICATIONINSIGHTS_CONNECTION_STRING``.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+
+import azure.functions as func
+from azure.monitor.opentelemetry import configure_azure_monitor
+
+from azure_functions_logging import (
+    RedactionFilter,
+    get_logger,
+    logging_context,
+    setup_logging,
+)
+
+# 1. Configure the exporter first — this attaches the OTel LoggingHandler to root.
+configure_azure_monitor()
+
+# 2. Now decorate the handler that already exists and enable trace activation.
+setup_logging(activate_trace_context=True)
+
+# 3. Attach PII redaction to the OTel handler so sensitive extras never export.
+_redaction = RedactionFilter()
+for _handler in logging.getLogger().handlers:
+    _handler.addFilter(_redaction)
+
+logger = get_logger(__name__)
+app = func.FunctionApp()
+
+
+@app.route(route="orders", auth_level=func.AuthLevel.ANONYMOUS)
+def process_order(req: func.HttpRequest, context: func.Context) -> func.HttpResponse:
+    """Emit a correlated, redacted, structured log for one invocation."""
+    order_id = req.params.get("order_id", "o-demo")
+
+    with logging_context(context):
+        # trace_id / span_id are inherited from the host invocation span.
+        # `password` is masked by RedactionFilter before it becomes an attribute.
+        logger.info(
+            "Processing order",
+            extra={"order_id": order_id, "password": "should-be-masked"},
+        )
+        return func.HttpResponse(
+            json.dumps({"processed": True, "order_id": order_id}),
+            mimetype="application/json",
+        )

--- a/examples/otel_app/host.json
+++ b/examples/otel_app/host.json
@@ -1,0 +1,15 @@
+{
+  "version": "2.0",
+  "telemetryMode": "OpenTelemetry",
+  "logging": {
+    "applicationInsights": {
+      "samplingSettings": {
+        "isEnabled": false
+      }
+    }
+  },
+  "extensionBundle": {
+    "id": "Microsoft.Azure.Functions.ExtensionBundle",
+    "version": "[4.*, 5.0.0)"
+  }
+}

--- a/examples/otel_app/requirements.txt
+++ b/examples/otel_app/requirements.txt
@@ -1,0 +1,3 @@
+azure-functions
+azure-functions-logging[otel]
+azure-monitor-opentelemetry

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -21,6 +21,7 @@ nav:
   - User Guide:
       - Usage: usage.md
       - Architecture: architecture.md
+      - OpenTelemetry: opentelemetry.md
   - Examples:
       - Basic Setup: examples/basic_setup.md
       - JSON Output: examples/json_output.md

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -111,3 +111,49 @@ class TestColdStartDetection:
         module.main()
         # After two inject_context calls, cold_start should be False
         assert ctx_mod._cold_start is False
+
+
+class TestOtelApp:
+    """Structural guard for examples/otel_app (a deployable Function App).
+
+    The app imports ``azure.functions`` and ``azure.monitor.opentelemetry``,
+    which are not test dependencies, so it cannot be imported here. Instead we
+    guard the wiring that the OpenTelemetry docs promise: the required call
+    order and the PII/redaction attachment.
+    """
+
+    def _source(self) -> str:
+        path = EXAMPLES_DIR / "otel_app" / "function_app.py"
+        return path.read_text(encoding="utf-8")
+
+    def test_app_files_exist(self) -> None:
+        app_dir = EXAMPLES_DIR / "otel_app"
+        assert (app_dir / "function_app.py").is_file()
+        assert (app_dir / "host.json").is_file()
+        assert (app_dir / "requirements.txt").is_file()
+
+    def test_configure_azure_monitor_called_before_setup_logging(self) -> None:
+        source = self._source()
+        configure_at = source.index("configure_azure_monitor()")
+        setup_at = source.index("setup_logging(")
+        assert configure_at < setup_at, (
+            "configure_azure_monitor() must run before setup_logging() so the "
+            "OTel handler exists when filters are attached"
+        )
+
+    def test_app_enables_trace_activation_and_redaction(self) -> None:
+        source = self._source()
+        assert "activate_trace_context=True" in source
+        assert "RedactionFilter()" in source
+        assert ".addFilter(" in source
+
+    def test_host_json_enables_opentelemetry_mode(self) -> None:
+        import json as _json
+
+        host = _json.loads((EXAMPLES_DIR / "otel_app" / "host.json").read_text(encoding="utf-8"))
+        assert host["telemetryMode"] == "OpenTelemetry"
+
+    def test_requirements_pin_otel_extra(self) -> None:
+        reqs = (EXAMPLES_DIR / "otel_app" / "requirements.txt").read_text(encoding="utf-8")
+        assert "azure-functions-logging[otel]" in reqs
+        assert "azure-monitor-opentelemetry" in reqs


### PR DESCRIPTION
Stacked PR **7/7** · base: `otel/259-filter-compose` (#259)

Add `docs/opentelemetry.md` (activation, resolution order, required call order, filters-in-OTel-mode, thread-boundary limitation), a PII-in-OTel troubleshooting entry, `examples/otel_app` (configure_azure_monitor before setup_logging, `activate_trace_context=True`, RedactionFilter on handlers), mkdocs nav, README link, and `api.md` entries for the new public symbols.

Closes #258 · Refs #252

> Review only the top commit; the diff is stacked on #259. Merging this whole stack bottom-up delivers the complete #252 feature.


---
> Recreated after renaming the head branch from `otel/*` to a CI-allowed prefix (`docs/258-otel-guide`); supersedes #268.
