### PR TITLE
fix(otel): normalize traceparent hex to lowercase and cache is_available

### DIFF
--- a/src/azure_functions_logging/_context.py
+++ b/src/azure_functions_logging/_context.py
@@ -111,9 +111,9 @@ def _is_hex(value: str, length: int) -> bool:
 class TraceContextParts(NamedTuple):
     """Parsed components of a W3C ``traceparent`` header.
 
-    ``trace_id`` and ``span_id`` preserve the original header casing (hex may
-    be upper or lower case per the W3C spec). ``trace_flags`` is the parsed
-    integer value of the 2-hex-digit trace-flags field.
+    ``trace_id`` and ``span_id`` are normalized to lowercase hex so they match
+    OpenTelemetry's W3C-canonical (lowercase-only) identifiers. ``trace_flags``
+    is the parsed integer value of the 2-hex-digit trace-flags field.
     """
 
     trace_id: str
@@ -149,7 +149,9 @@ def _extract_trace_context(trace_parent: str | None) -> TraceContextParts | None
             return None
         if not _is_hex(flags, 2):
             return None
-        return TraceContextParts(trace_id=trace_id, span_id=parent_id, trace_flags=int(flags, 16))
+        return TraceContextParts(
+            trace_id=trace_id.lower(), span_id=parent_id.lower(), trace_flags=int(flags, 16)
+        )
     except Exception:  # nosec B110 — Principle 3: context failures are silent
         return None
 

--- a/src/azure_functions_logging/_otel.py
+++ b/src/azure_functions_logging/_otel.py
@@ -28,19 +28,35 @@ from __future__ import annotations
 from collections.abc import Iterator
 from contextlib import contextmanager
 
+_available: bool | None = None
+
 
 def is_available() -> bool:
     """Return ``True`` when the OpenTelemetry API is importable.
 
     Only the API package (``opentelemetry-api``) is required — the SDK,
     exporters, and a ``TracerProvider`` are owned by the host or the user.
+
+    The result is cached after the first call: importability does not change
+    over a process lifetime, and this runs on the per-log hot path.
     """
+    global _available
+    if _available is not None:
+        return _available
     try:
         import opentelemetry.context  # noqa: F401
         import opentelemetry.propagate  # noqa: F401
     except Exception:  # nosec B110 — optional dependency; absence is expected
-        return False
-    return True
+        _available = False
+    else:
+        _available = True
+    return _available
+
+
+def _reset_availability() -> None:
+    """Clear the cached :func:`is_available` result (test-only helper)."""
+    global _available
+    _available = None
 
 
 @contextmanager

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -552,9 +552,10 @@ def test_extract_trace_id_rejects_malformed_headers(header: str) -> None:
     assert _extract_trace_id(header) is None
 
 
-def test_extract_trace_id_accepts_valid_uppercase_hex() -> None:
+def test_extract_trace_id_normalizes_valid_uppercase_hex() -> None:
+    # Uppercase input is accepted but normalized to lowercase (issue #278).
     upper = "00-1234567890ABCDEF1234567890ABCDEF-FEDCBA0987654321-01"
-    assert _extract_trace_id(upper) == "1234567890ABCDEF1234567890ABCDEF"
+    assert _extract_trace_id(upper) == "1234567890abcdef1234567890abcdef"
 
 
 def test_extract_trace_id_forward_compatible_future_version() -> None:
@@ -584,12 +585,15 @@ def test_extract_trace_context_is_a_named_tuple() -> None:
     assert parts.trace_flags == 1
 
 
-def test_extract_trace_context_preserves_uppercase_hex() -> None:
+def test_extract_trace_context_normalizes_uppercase_hex_to_lowercase() -> None:
+    # W3C mandates lowercase hex; OpenTelemetry's propagator rejects uppercase.
+    # A lenient parser must still normalize to lowercase so JSON logs and OTel
+    # emit identical trace/span ids (issue #278).
     upper = "00-1234567890ABCDEF1234567890ABCDEF-FEDCBA0987654321-0A"
     parts = _extract_trace_context(upper)
     assert parts == TraceContextParts(
-        trace_id="1234567890ABCDEF1234567890ABCDEF",
-        span_id="FEDCBA0987654321",
+        trace_id="1234567890abcdef1234567890abcdef",
+        span_id="fedcba0987654321",
         trace_flags=0x0A,
     )
 

--- a/tests/test_otel.py
+++ b/tests/test_otel.py
@@ -11,6 +11,7 @@ the base install stays zero-dependency.
 
 from __future__ import annotations
 
+from collections.abc import Iterator
 from types import SimpleNamespace
 
 import pytest
@@ -20,6 +21,15 @@ from azure_functions_logging import _otel
 _TRACE_ID_HEX = "4bf92f3577b34da6a3ce929d0e0e4736"
 _PARENT_ID_HEX = "00f067aa0ba902b7"
 _TRACEPARENT = f"00-{_TRACE_ID_HEX}-{_PARENT_ID_HEX}-01"
+
+
+@pytest.fixture(autouse=True)
+def _reset_otel_availability_cache() -> Iterator[None]:
+    # ``is_available`` caches its result process-wide; reset around every test
+    # so import-monkeypatching stays isolated and order-independent.
+    _otel._reset_availability()
+    yield
+    _otel._reset_availability()
 
 
 def test_is_available_reflects_otel_import() -> None:
@@ -267,6 +277,21 @@ def test_is_available_false_when_import_raises(monkeypatch: pytest.MonkeyPatch) 
 
     monkeypatch.setitem(sys.modules, "opentelemetry.context", None)
     assert _otel.is_available() is False
+
+
+def test_is_available_caches_result(monkeypatch: pytest.MonkeyPatch) -> None:
+    import sys
+
+    # First call with the import broken caches ``False``.
+    monkeypatch.setitem(sys.modules, "opentelemetry.context", None)
+    assert _otel.is_available() is False
+    # Restoring the import must NOT change the cached result until reset.
+    monkeypatch.undo()
+    assert _otel.is_available() is False
+    # Explicit reset re-evaluates importability.
+    _otel._reset_availability()
+    pytest.importorskip("opentelemetry.context")
+    assert _otel.is_available() is True
 
 
 def test_activated_trace_context_noop_when_extract_import_fails(


### PR DESCRIPTION
## Summary

Two P0 correctness/performance fixes for the v0.8.0 OpenTelemetry trace-correlation feature, both surfaced in the v0.8.0 code review and validated with Oracle.

- **fix(#278) — lowercase traceparent hex.** `_extract_trace_context` now returns lowercase `trace_id`/`span_id`. The W3C Trace Context spec mandates lowercase hex, and OpenTelemetry's `TraceContextTextMapPropagator` regex rejects uppercase. Previously an uppercase incoming `traceparent` produced **mismatched identifiers** — JSON logs emitted the uppercase id while the OTel `LoggingHandler` saw an invalid (zero) span context, silently breaking correlation. Parsing stays lenient (uppercase still accepted) but output is canonicalized. Docstring corrected (it previously claimed casing was preserved "per the W3C spec", which is factually wrong).
- **perf(#279) — cache `is_available()`.** `is_available()` now caches its result in a module-level sentinel instead of re-running a failing top-level import (which walks `sys.path`, ~50µs) on **every** log record via the `logging_context` hot path. Adds a test-only `_reset_availability()` helper.

## Behavior / compatibility

- KQL string comparisons for `trace_id` are case-insensitive, so no query breakage for existing users; this only makes JSON and OTel agree.
- No new dependencies; base install stays zero-dependency and Principle 3 ("context failures are silent") preserved.

## Tests

- Updated the two tests that asserted the old uppercase-preserving behavior to assert lowercase normalization.
- Added a caching test for `is_available()` and an autouse fixture that resets the cache per-test to keep import-monkeypatching isolated.
- `hatch run typecheck` clean, `hatch run style` clean, `hatch run pytest --cov` → **414 passed, 4 skipped, 96.69% coverage** (≥95% gate).

Closes #278
Closes #279