### PR TITLE
fix(filters): harden dict flattening; add OTel correlation test and docs

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -201,7 +201,21 @@ for handler in logging.getLogger().handlers:
 - Intended for OpenTelemetry pipelines, where nested `dict` attributes are
   silently dropped by the OTel SDK.
 - Lists / heterogeneous arrays are left unchanged (emitted as-is under their
-  dotted key).
+  dotted key). Flattening does **not** recurse into lists, so a
+  list-of-dicts such as `items=[{"id": 1}]` is passed through verbatim rather
+  than expanded into `items.0.id`.
+- Non-string dict keys are skipped (they cannot form a queryable dotted path).
+- On key collision — e.g. a nested `{"a": {"b": 1}}` and a literal
+  `{"a.b": 2}` both mapping to `a.b` — the first value in iteration order wins
+  and later collisions are dropped silently.
+
+!!! warning "Attach to specific handlers, not the root logger blindly"
+    This filter mutates the `LogRecord` in place, rewriting nested-`dict`
+    attributes into new dotted-key attributes. Attach it only to the handlers
+    that need flattened output (e.g. your OpenTelemetry handler). Installing it
+    on the root logger changes the record schema for **every** downstream
+    handler, which can surprise formatters that expect the original nested
+    attribute.
 
 ```python
 from azure_functions_logging import AttributeFlattenFilter

--- a/src/azure_functions_logging/_filters.py
+++ b/src/azure_functions_logging/_filters.py
@@ -41,7 +41,11 @@ def _flatten_dict(
       dotted key.
 
     Lists (and any non-dict leaf) are emitted unchanged under their dotted key.
-    Empty dicts contribute no keys.
+    Empty dicts contribute no keys. Non-string keys are skipped (they cannot
+    form a queryable dotted path). On key collision — e.g. a nested ``{"a":
+    {"b": 1}}`` and a literal ``{"a.b": 2}`` both mapping to ``a.b`` — the
+    first value encountered in iteration order wins and later collisions are
+    dropped silently (never overwritten).
     """
     if _depth >= max_depth:
         return {prefix: value}
@@ -52,12 +56,16 @@ def _flatten_dict(
     seen = seen | {obj_id}
     result: dict[str, Any] = {}
     for key, item in value.items():
+        if not isinstance(key, str):
+            continue  # non-string keys cannot form a queryable dotted path
         new_key = f"{prefix}{separator}{key}"
         if isinstance(item, dict):
-            result.update(
-                _flatten_dict(new_key, item, separator, max_depth, _seen=seen, _depth=_depth + 1)
-            )
-        else:
+            for sub_key, sub_item in _flatten_dict(
+                new_key, item, separator, max_depth, _seen=seen, _depth=_depth + 1
+            ).items():
+                if sub_key not in result:  # keep-first-wins on collision
+                    result[sub_key] = sub_item
+        elif new_key not in result:  # keep-first-wins on collision
             result[new_key] = item
     return result
 

--- a/src/azure_functions_logging/_host_config.py
+++ b/src/azure_functions_logging/_host_config.py
@@ -323,8 +323,10 @@ def warn_otel_logging_misconfig(
     Emits up to three independent warnings:
 
     - **6a** — an OTel handler is present **and** ``functions_formatter`` was
-      passed: the formatter is never invoked (the OTel handler formats records
-      itself), so the argument is silently ignored.
+      passed: the OTel handler formats and exports its own records, so the
+      formatter does not affect what OpenTelemetry emits. It still applies to
+      any non-OTel handler that coexists on the root logger, so this is a
+      heads-up rather than an absolute "formatter has no effect" claim.
     - **6b** — an OTel handler is present but neither telemetry env var is set:
       the host may not export these logs. Worded tentatively because the
       environment is not fully observable from inside the worker.
@@ -339,9 +341,11 @@ def warn_otel_logging_misconfig(
     if has_otel_handler and functions_formatter is not None:
         warnings.warn(
             (
-                "An OpenTelemetry logging handler is attached, so the "
-                "'functions_formatter' passed to setup_logging() is ignored "
-                "— the OpenTelemetry handler formats and exports records itself."
+                "An OpenTelemetry logging handler is attached; the "
+                "'functions_formatter' passed to setup_logging() does not "
+                "affect what OpenTelemetry exports — the OpenTelemetry handler "
+                "formats and exports its records itself. It still applies to "
+                "any non-OpenTelemetry handler on the root logger."
             ),
             stacklevel=stacklevel,
         )

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -980,6 +980,33 @@ def test_flatten_filter_handles_cyclic_dict_without_raising() -> None:
     assert flt.filter(record) is True
 
 
+def test_flatten_filter_keeps_first_on_key_collision() -> None:
+    """A nested key and a literal dotted key mapping to the same dotted path:
+    the first in iteration order wins; the later one is dropped (issue #280)."""
+    flt = AttributeFlattenFilter()
+    record = _make_record()
+    # "a" (nested) is inserted before the literal "a.b"; nested wins.
+    setattr(record, "meta", {"a": {"b": 1}, "a.b": 999})
+
+    flt.filter(record)
+
+    assert getattr(record, "meta.a.b") == 1
+
+
+def test_flatten_filter_skips_non_string_keys() -> None:
+    """Non-string dict keys cannot form a queryable dotted path and are
+    skipped rather than coerced into unqueryable keys (issue #281)."""
+    flt = AttributeFlattenFilter()
+    record = _make_record()
+    setattr(record, "meta", {2: "int-key", None: "none-key", "ok": "kept"})
+
+    flt.filter(record)
+
+    assert getattr(record, "meta.ok") == "kept"
+    assert not hasattr(record, "meta.2")
+    assert not hasattr(record, "meta.None")
+
+
 def test_flatten_filter_always_returns_true() -> None:
     flt = AttributeFlattenFilter()
     assert flt.filter(_make_record()) is True

--- a/tests/test_otel.py
+++ b/tests/test_otel.py
@@ -341,3 +341,74 @@ def test_activated_trace_context_swallows_detach_error(
     # A failing detach on cleanup must never propagate.
     with _otel.activated_trace_context(_TRACEPARENT):
         pass
+
+
+# ---------------------------------------------------------------------------
+# End-to-end correlation: a real OTel LoggingHandler must stamp records emitted
+# inside ``activated_trace_context`` with the host span's trace_id/span_id.
+# ---------------------------------------------------------------------------
+
+
+def test_otel_logging_handler_stamps_host_trace_ids() -> None:
+    pytest.importorskip("opentelemetry.sdk._logs")
+    import logging
+
+    from opentelemetry.sdk._logs import LoggerProvider, LoggingHandler
+    from opentelemetry.sdk._logs.export import (
+        InMemoryLogExporter,
+        SimpleLogRecordProcessor,
+    )
+
+    exporter = InMemoryLogExporter()  # type: ignore[no-untyped-call]
+    provider = LoggerProvider()
+    provider.add_log_record_processor(SimpleLogRecordProcessor(exporter))
+    handler = LoggingHandler(level=logging.INFO, logger_provider=provider)
+
+    logger = logging.getLogger("afl.otel.correlation")
+    logger.setLevel(logging.INFO)
+    logger.addHandler(handler)
+    logger.propagate = False
+    try:
+        with _otel.activated_trace_context(_TRACEPARENT):
+            logger.info("correlated")
+    finally:
+        logger.removeHandler(handler)
+        provider.shutdown()
+
+    emitted = exporter.get_finished_logs()
+    assert len(emitted) == 1
+    record = emitted[0].log_record
+    # The handler inherits the host's remote span context (issue #282).
+    assert format(record.trace_id, "032x") == _TRACE_ID_HEX
+    assert format(record.span_id, "016x") == _PARENT_ID_HEX
+
+
+def test_otel_logging_handler_has_no_trace_ids_outside_activation() -> None:
+    pytest.importorskip("opentelemetry.sdk._logs")
+    import logging
+
+    from opentelemetry.sdk._logs import LoggerProvider, LoggingHandler
+    from opentelemetry.sdk._logs.export import (
+        InMemoryLogExporter,
+        SimpleLogRecordProcessor,
+    )
+
+    exporter = InMemoryLogExporter()  # type: ignore[no-untyped-call]
+    provider = LoggerProvider()
+    provider.add_log_record_processor(SimpleLogRecordProcessor(exporter))
+    handler = LoggingHandler(level=logging.INFO, logger_provider=provider)
+
+    logger = logging.getLogger("afl.otel.correlation.none")
+    logger.setLevel(logging.INFO)
+    logger.addHandler(handler)
+    logger.propagate = False
+    try:
+        logger.info("uncorrelated")
+    finally:
+        logger.removeHandler(handler)
+        provider.shutdown()
+
+    emitted = exporter.get_finished_logs()
+    assert len(emitted) == 1
+    # No active host span -> invalid (zero) ids, proving activation is the source.
+    assert emitted[0].log_record.trace_id in (0, None)


### PR DESCRIPTION
## Summary

Addresses the remaining v0.8.0 code-review findings (#280–#285) in one PR.

### Bug fixes (`_filters.py`)
- **#280 — collision data loss.** `_flatten_dict` now keeps the **first** value on a dotted-key collision instead of silently overwriting. Previously a nested `{"a": {"b": 1}}` colliding with a literal `{"a.b": 2}` dropped one value unpredictably.
- **#281 — non-string keys.** Non-string dict keys are now skipped rather than coerced into unqueryable dotted paths (e.g. `meta.None`).

### Tests (`test_otel.py`, `test_filters.py`)
- **#282 — correlation.** New end-to-end tests emit a record through a **real** OpenTelemetry `LoggingHandler` inside `activated_trace_context` and assert the exported record carries the host span's `trace_id`/`span_id` (and carries none outside activation). Skips cleanly when the OTel SDK is absent.
- Added collision + non-string-key tests for the flatten fixes.

### Docs
- **#283 — `_host_config.py`.** Reworded the 6a OTel-misconfig warning: `functions_formatter` still applies to any non-OTel handler on the root logger, so the message is now a heads-up rather than an absolute "ignored" claim.
- **#284 / #285 — `docs/api.md`.** Documented list non-recursion (`items=[{...}]` passthrough), non-string-key skipping, collision precedence, and added a warning against attaching `AttributeFlattenFilter` to the root logger blindly.

## Validation
`hatch run typecheck` clean · `hatch run style` clean · `hatch run pytest --cov` → **418 passed, 4 skipped, 96.64% coverage** (≥95% gate).

## Translations
No README behavior/table changes, so translated READMEs are unaffected (per AGENTS.md).

Closes #280
Closes #281
Closes #282
Closes #283
Closes #284
Closes #285