### PR TITLE
docs(otel): document in-handler spans become children of the host span

### DIFF
--- a/docs/opentelemetry.md
+++ b/docs/opentelemetry.md
@@ -137,6 +137,17 @@ correlation unless you propagate the context yourself (e.g. by capturing
 `contextvars.copy_context()` and running the work inside it). Async code on the
 same event loop is unaffected.
 
+## Behavior change: spans you create become children of the host span
+
+While activation is on, the host invocation span is the **current** span for
+the duration of your handler. Any span you start *inside* the handler — e.g.
+`tracer.start_as_current_span("work")` — is therefore parented to the host span
+instead of becoming a new top-level (root) span. This is usually what you want
+(your work nests under the invocation in the Application Insights end-to-end
+transaction), but it **is** a trace-structure change for code that previously
+created top-level spans. If you need a detached root span, capture a fresh
+root context yourself before starting it.
+
 ## Runnable example
 
 A minimal Function App wiring `azure-monitor-opentelemetry` together with this


### PR DESCRIPTION
## Summary

Completes the remaining non-deployment acceptance item of #252 / #255.

Adds a **Behavior change** section to `docs/opentelemetry.md` explaining that while trace-context activation is on, a span the user starts *inside* the handler (e.g. `tracer.start_as_current_span(...)`) is parented to the host invocation span rather than becoming a new top-level span — with guidance for detaching a root span when that's not wanted.

## Context

Auditing #252/#255 against the current repo, every acceptance item is already satisfied (code shipped in v0.8.0, `[otel]` extra, `_otel.py`, `activate_trace_context` params, resolution order, `examples/otel_app`, `docs/opentelemetry.md`, README non-goal text, mkdocs nav, CHANGELOG entries) **except** this behavior-change note and the deployment-gated portal screenshot.

## Out of scope

- `docs/assets/portal-otel-correlated.png` — requires a live Azure deployment + App Insights end-to-end transaction capture; tracked as the sole remaining item on #252.

Refs #252, #255