### PR TITLE
feat!: make trace-context activation strictly opt-in and remove factory shims

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -290,11 +290,10 @@ curl -s "https://<your-app>.azurewebsites.net/api/logme?correlation_id=demo-123"
 
 ### グローバル LogRecordFactory (オプトイン)
 
-> **Deprecated:** `setup_logging(use_record_factory=True)` を使用してください。単体の `install_context_factory()` は非推奨です。
 
-`install_context_factory()` はレコード生成時にコンテキストを注入し、ハンドラ/フィルタの構成に関係なく **すべての** `LogRecord` がコンテキストを持つようにします。`setup_logging()` 後にハンドラが追加されたり、ロガーがフィルタチェーンをバイパスする場合に便利です。デフォルトの `ContextFilter` モードとは相互排他的です。
+`setup_logging(use_record_factory=True)` はグローバルな `LogRecordFactory` をインストールし、レコード生成時にコンテキストを注入することで、ハンドラ/フィルタの構成に関係なく **すべての** `LogRecord` がコンテキストを持つようにします。`setup_logging()` 後にハンドラが追加されたり、ロガーがフィルタチェーンをバイパスする場合に便利です。デフォルトの `ContextFilter` モードとは相互排他的です。
 
-→ [設定: `use_record_factory`](https://yeongseon.github.io/azure-functions-logging-python/configuration/#parameter-use_record_factory) · [API: `install_context_factory`](https://yeongseon.github.io/azure-functions-logging-python/api/#install_context_factory)
+→ [設定: `use_record_factory`](https://yeongseon.github.io/azure-functions-logging-python/configuration/#parameter-use_record_factory)
 
 ### ローカル vs クラウド
 
@@ -347,7 +346,7 @@ curl -s "https://<your-app>.azurewebsites.net/api/logme?correlation_id=demo-123"
 
 **コード生成のための主要な実装詳細:**
 
-1. **ホスト構成を尊重** — Azure / Core Tools ではハンドラを追加せず、ルートロガーのレベルは `host.json` に委ねます。既存のルートハンドラとルートロガー自身に `ContextFilter` をインストールします（ルートロガーでの直接呼び出しはコンテキストを仲介する）。名前付きの子ロガーから伝搬されて後から追加されたハンドラへ到達するレコードにもコンテキストを保証したい場合は `install_context_factory()` を呼び出してください。ローカル単独モードでは `setup_logging(logger_name=None)` がルートロガーを構成します（レベル設定、ハンドラがなければ `StreamHandler` 追加）。
+1. **ホスト構成を尊重** — Azure / Core Tools ではハンドラを追加せず、ルートロガーのレベルは `host.json` に委ねます。既存のルートハンドラとルートロガー自身に `ContextFilter` をインストールします（ルートロガーでの直接呼び出しはコンテキストを仲介する）。名前付きの子ロガーから伝搬されて後から追加されたハンドラへ到達するレコードにもコンテキストを保証したい場合は `setup_logging()` に `use_record_factory=True` を渡してください。ローカル単独モードでは `setup_logging(logger_name=None)` がルートロガーを構成します（レベル設定、ハンドラがなければ `StreamHandler` 追加）。
 2. **コンテキスト注入は contextvar ベース** — thread-local ではなく、asyncio で動作
 3. **冪等な setup** — `setup_logging()` を複数回呼び出しても安全
 4. **2 つの環境、2 つの動作**:

--- a/README.ko.md
+++ b/README.ko.md
@@ -290,11 +290,10 @@ curl -s "https://<your-app>.azurewebsites.net/api/logme?correlation_id=demo-123"
 
 ### 글로벌 LogRecordFactory (opt-in)
 
-> **Deprecated:** `setup_logging(use_record_factory=True)`를 사용하세요. 독립형 `install_context_factory()`는 더 이상 권장되지 않습니다.
 
-`install_context_factory()`는 레코드 생성 시점에 컨텍스트를 주입하여 핸들러/필터 구성과 무관하게 **모든** `LogRecord`가 컨텍스트를 갖도록 합니다. `setup_logging()` 이후 핸들러가 추가되거나 로거가 필터 체인을 우회할 때 유용합니다. 기본 `ContextFilter` 모드와는 상호 배타적입니다.
+`setup_logging(use_record_factory=True)`는 전역 `LogRecordFactory`를 설치하여 레코드 생성 시점에 컨텍스트를 주입하므로, 핸들러/필터 구성과 무관하게 **모든** `LogRecord`가 컨텍스트를 갖도록 합니다. `setup_logging()` 이후 핸들러가 추가되거나 로거가 필터 체인을 우회할 때 유용합니다. 기본 `ContextFilter` 모드와는 상호 배타적입니다.
 
-→ [구성: `use_record_factory`](https://yeongseon.github.io/azure-functions-logging-python/configuration/#parameter-use_record_factory) · [API: `install_context_factory`](https://yeongseon.github.io/azure-functions-logging-python/api/#install_context_factory)
+→ [구성: `use_record_factory`](https://yeongseon.github.io/azure-functions-logging-python/configuration/#parameter-use_record_factory)
 
 ### 로컬 vs 클라우드
 
@@ -347,7 +346,7 @@ curl -s "https://<your-app>.azurewebsites.net/api/logme?correlation_id=demo-123"
 
 **코드 생성을 위한 핵심 구현 세부사항:**
 
-1. **호스트 구성 보존** — Azure / Core Tools에서는 핸들러를 추가하지 않고 루트 로거 레벨을 `host.json`에 위임하며, 기존 루트 핸들러와 루트 로거 자체에 `ContextFilter`를 설치합니다 (루트 로거에 직접 기록되는 레코드에도 컨텍스트가 실립니다). 이름 있는 자식 로거에서 이후 추가되는 핸들러로 전파되는 레코드까지 보장하려면 `install_context_factory()`를 호출하세요. 로컬 단독 모드에서는 `setup_logging(logger_name=None)`이 루트 로거를 구성합니다 (레벨 설정, 핸들러 없으면 `StreamHandler` 추가).
+1. **호스트 구성 보존** — Azure / Core Tools에서는 핸들러를 추가하지 않고 루트 로거 레벨을 `host.json`에 위임하며, 기존 루트 핸들러와 루트 로거 자체에 `ContextFilter`를 설치합니다 (루트 로거에 직접 기록되는 레코드에도 컨텍스트가 실립니다). 이름 있는 자식 로거에서 이후 추가되는 핸들러로 전파되는 레코드까지 보장하려면 `setup_logging()`에 `use_record_factory=True`를 전달하세요. 로컬 단독 모드에서는 `setup_logging(logger_name=None)`이 루트 로거를 구성합니다 (레벨 설정, 핸들러 없으면 `StreamHandler` 추가).
 2. **컨텍스트 주입은 contextvar 기반** — thread-local이 아니므로 asyncio와 호환
 3. **멱등성 보장 setup** — `setup_logging()`을 여러 번 호출해도 안전
 4. **두 환경, 두 동작**:

--- a/README.md
+++ b/README.md
@@ -314,9 +314,9 @@ At startup the library warns when your `host.json` — or `AzureFunctionsJobHost
 
 ### Global LogRecordFactory (opt-in)
 
-`install_context_factory()` injects context at record-creation time so **every** `LogRecord` carries it regardless of handler/filter wiring — useful when handlers are added after `setup_logging()` or loggers bypass the filter chain. It is mutually exclusive with the default `ContextFilter` mode.
+`setup_logging(use_record_factory=True)` installs a global `LogRecordFactory` that injects context at record-creation time so **every** `LogRecord` carries it regardless of handler/filter wiring — useful when handlers are added after `setup_logging()` or loggers bypass the filter chain. It is mutually exclusive with the default `ContextFilter` mode.
 
-→ [Configuration: `use_record_factory`](https://yeongseon.github.io/azure-functions-logging-python/configuration/#parameter-use_record_factory) · [API: `install_context_factory`](https://yeongseon.github.io/azure-functions-logging-python/api/#install_context_factory)
+→ [Configuration: `use_record_factory`](https://yeongseon.github.io/azure-functions-logging-python/configuration/#parameter-use_record_factory)
 
 ### Local vs cloud
 
@@ -369,7 +369,7 @@ This package provides structured logging for Azure Functions with zero modificat
 
 **Key Implementation Details for Code Generation:**
 
-1. **Preserves host configuration** — In Azure / Core Tools, no handlers are added and the root logger level is left to `host.json`; `ContextFilter` is installed on existing root handlers and on the root logger itself (so direct calls on the root logger carry context). For records that propagate from named child loggers to handlers attached later (e.g. by the host or third-party libraries), pass `use_record_factory=True` to `setup_logging()` to guarantee context coverage (the standalone `install_context_factory()` is deprecated). In standalone local mode, `setup_logging(logger_name=None)` configures the root logger (sets level, adds a `StreamHandler` if none exist).
+1. **Preserves host configuration** — In Azure / Core Tools, no handlers are added and the root logger level is left to `host.json`; `ContextFilter` is installed on existing root handlers and on the root logger itself (so direct calls on the root logger carry context). For records that propagate from named child loggers to handlers attached later (e.g. by the host or third-party libraries), pass `use_record_factory=True` to `setup_logging()` to guarantee context coverage. In standalone local mode, `setup_logging(logger_name=None)` configures the root logger (sets level, adds a `StreamHandler` if none exist).
 2. **Context injection is contextvar-based** — Not thread-local, works with asyncio
 3. **Idempotent setup** — Calling setup_logging() multiple times is safe
 4. **Two environments, two behaviors**:

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -290,11 +290,10 @@ curl -s "https://<your-app>.azurewebsites.net/api/logme?correlation_id=demo-123"
 
 ### 全局 LogRecordFactory（可选启用）
 
-> **Deprecated:** 请使用 `setup_logging(use_record_factory=True)`。独立的 `install_context_factory()` 已弃用。
 
-`install_context_factory()` 在记录创建时注入上下文，因此**每一条** `LogRecord` 都会携带上下文，而不受 handler/filter 接线方式的影响 —— 当 handler 在 `setup_logging()` 之后才添加，或 logger 绕过 filter 链时尤其有用。它与默认的 `ContextFilter` 模式互斥。
+`setup_logging(use_record_factory=True)` 会安装一个全局 `LogRecordFactory`，在记录创建时注入上下文，因此**每一条** `LogRecord` 都会携带上下文，而不受 handler/filter 接线方式的影响 —— 当 handler 在 `setup_logging()` 之后才添加，或 logger 绕过 filter 链时尤其有用。它与默认的 `ContextFilter` 模式互斥。
 
-→ [Configuration: `use_record_factory`](https://yeongseon.github.io/azure-functions-logging-python/configuration/#parameter-use_record_factory) · [API: `install_context_factory`](https://yeongseon.github.io/azure-functions-logging-python/api/#install_context_factory)
+→ [Configuration: `use_record_factory`](https://yeongseon.github.io/azure-functions-logging-python/configuration/#parameter-use_record_factory)
 
 ### 本地 vs 云端
 
@@ -346,7 +345,7 @@ curl -s "https://<your-app>.azurewebsites.net/api/logme?correlation_id=demo-123"
 
 **代码生成的关键实现细节:**
 
-1. **保留 host 配置** — 在 Azure / Core Tools 中不添加处理程序，root logger 级别交给 `host.json`；在已有 root 处理程序以及 root logger 自身上安装 `ContextFilter`（以便在 root logger 上的直接调用携带上下文）。若需覆盖从命名子 logger 传播到后续添加处理程序的记录，请调用 `install_context_factory()` 以保证上下文覆盖。在本地独立模式下，`setup_logging(logger_name=None)` 会配置 root logger（设置级别，无处理程序时添加 `StreamHandler`）。
+1. **保留 host 配置** — 在 Azure / Core Tools 中不添加处理程序，root logger 级别交给 `host.json`；在已有 root 处理程序以及 root logger 自身上安装 `ContextFilter`（以便在 root logger 上的直接调用携带上下文）。若需覆盖从命名子 logger 传播到后续添加处理程序的记录，请向 `setup_logging()` 传入 `use_record_factory=True` 以保证上下文覆盖。在本地独立模式下，`setup_logging(logger_name=None)` 会配置 root logger（设置级别，无处理程序时添加 `StreamHandler`）。
 2. **上下文注入基于 contextvar** — 不是 thread-local，与 asyncio 协同工作
 3. **幂等 setup** — 多次调用 `setup_logging()` 是安全的
 4. **两个环境，两种行为**:

--- a/docs/api.md
+++ b/docs/api.md
@@ -300,19 +300,6 @@ metadata = get_logging_metadata(handler)
 
 ::: azure_functions_logging.logging_context
 
-## install_context_factory
-
-::: azure_functions_logging.install_context_factory
-
-!!! warning "Deprecated"
-    Direct use of `install_context_factory()` is deprecated. Prefer
-    `setup_logging(use_record_factory=True)`, which selects the
-    `LogRecordFactory` injection strategy and manages teardown consistently.
-
-## uninstall_context_factory
-
-::: azure_functions_logging.uninstall_context_factory
-
 ## reset_context
 
 ::: azure_functions_logging.reset_context

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -286,7 +286,7 @@ Cold start detection uses a module-level boolean that starts `True` and flips to
 Two complementary mechanisms inject context variable values onto each `LogRecord`:
 
 - **`ContextFilter` (default)** runs during the filter phase, before the formatter, and reads context variables at handler-dispatch time. It works with both `ColorFormatter` and `JsonFormatter` but reflects the *current* contextvar state when the handler runs — not when the record was created.
-- **`setup_logging(use_record_factory=True)`** swaps the global `logging.LogRecordFactory` so context fields are captured at record-creation time. This snapshot survives thread hops, queued/delayed handlers, and contextvar resets between record creation and handler dispatch. (The standalone `install_context_factory()` function is deprecated — prefer this entry point.)
+- **`setup_logging(use_record_factory=True)`** swaps the global `logging.LogRecordFactory` so context fields are captured at record-creation time. This snapshot survives thread hops, queued/delayed handlers, and contextvar resets between record creation and handler dispatch.
 
 When `use_record_factory=True`, `ContextFilter` is intentionally **not** attached to handlers, so the factory snapshot is the single source of truth and cannot be overwritten downstream.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -116,7 +116,7 @@ setup_logging(format="json", use_record_factory=True)
 Behavior details:
 
 - Default is `False` to preserve the existing handler-filter-only behavior.
-- When `True`, the global `LogRecordFactory` injection strategy is installed once; repeated calls are no-ops. (Internally this used the now-deprecated `install_context_factory()`; prefer this `use_record_factory=True` entry point.)
+- When `True`, the global `LogRecordFactory` injection strategy is installed once; repeated calls are no-ops.
 - When `True`, `ContextFilter` is **not** attached to handlers. The global
   `LogRecordFactory` is the sole source of context fields, so values captured at
   record-creation time survive thread hops, queued handlers, and delayed flushes

--- a/docs/index.md
+++ b/docs/index.md
@@ -37,7 +37,7 @@ This library addresses those gaps with a small API surface.
 - Structured NDJSON output (`format="json"`) for production ingestion.
 - `logging_context(context)` context manager that always restores prior context on exit (recommended).
 - `inject_context(context)` returns `ContextTokens` for paired `restore_context(tokens)` use in middleware.
-- `setup_logging(use_record_factory=True)` opt-in global LogRecordFactory so context flows to every `LogRecord`. (The standalone `install_context_factory()` is deprecated.)
+- `setup_logging(use_record_factory=True)` opt-in global LogRecordFactory so context flows to every `LogRecord`.
 - `JsonFormatter` for host-managed handlers via `setup_logging(functions_formatter=JsonFormatter())`.
 - Automatic `cold_start` flag detection on first invocation per process.
 - `FunctionLogger.bind()` for immutable request-scoped context binding.
@@ -81,7 +81,7 @@ This combines context-managed invocation context and request binding in a safe, 
 Behavior changes intentionally by runtime:
 
 - Local standalone process: sets the target/root logger level; adds a `StreamHandler` (`color` or `json`) only if no handlers exist, otherwise just attaches filters to existing handlers.
-- Azure/Core Tools runtime: installs `ContextFilter` on existing root handlers **and on the root logger itself** (so direct calls on the root logger carry context); does not add handlers or change root level. To guarantee context on records that propagate from named child loggers to handlers attached later, pass `use_record_factory=True` to `setup_logging()` (the standalone `install_context_factory()` is deprecated).
+- Azure/Core Tools runtime: installs `ContextFilter` on existing root handlers **and on the root logger itself** (so direct calls on the root logger carry context); does not add handlers or change root level. To guarantee context on records that propagate from named child loggers to handlers attached later, pass `use_record_factory=True` to `setup_logging()`.
 
 !!! warning
     In Azure-hosted execution, host-level `host.json` settings can still suppress logs even when application-level setup appears correct.

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -37,7 +37,7 @@ def setup_logging(
     """Configure logging for the current environment.
 
     Behavior depends on detected environment:
-    - **Azure / Core Tools**: Installs ContextFilter on existing root handlers AND on the root logger itself (so direct calls on the root logger carry context). Does NOT add handlers or modify root logger level (respects host.json). If `functions_formatter` is provided, it is applied to host-managed handlers. NOTE: a filter on the root logger does not run for records that propagate from named child loggers to host/third-party handlers attached later — use `install_context_factory()` to guarantee context coverage in that case.
+    - **Azure / Core Tools**: Installs ContextFilter on existing root handlers AND on the root logger itself (so direct calls on the root logger carry context). Does NOT add handlers or modify root logger level (respects host.json). If `functions_formatter` is provided, it is applied to host-managed handlers. NOTE: a filter on the root logger does not run for records that propagate from named child loggers to host/third-party handlers attached later — pass `use_record_factory=True` to `setup_logging()` to guarantee context coverage in that case.
     - **Standalone local**: Sets the target/root logger level. Adds a StreamHandler (ColorFormatter or JsonFormatter) ONLY when no handlers exist; otherwise just attaches filters to existing handlers.
 
     This function is idempotent per logger_name.
@@ -241,7 +241,7 @@ from azure_functions_logging import (
     logging_context,
     restore_context,
     reset_context,
-    install_context_factory,
+
     get_logging_metadata,
     with_context,
 )
@@ -293,15 +293,6 @@ def logging_context(context: Any) -> Iterator[None]:
     """
     ...
 
-def install_context_factory() -> None:  # DEPRECATED: prefer setup_logging(use_record_factory=True)
-    """Opt-in: install a global logging.setLogRecordFactory() that copies
-    contextvars onto every LogRecord at creation time. Ensures coverage even
-    on handlers added after setup_logging() and on loggers that bypass the
-    filter chain. Once installed, invocation_id/function_name/trace_id/
-    cold_start become reserved LogRecord attributes—passing them via stdlib
-    extra= raises KeyError. Use FunctionLogger (auto-sanitizes) or rename keys.
-    """
-    ...
 
 def get_logging_metadata(func: Any) -> dict[str, Any] | None:
     """Return logging metadata attached to a function by ``@with_context``.
@@ -342,7 +333,7 @@ from azure_functions_logging import (
     inject_context,         # low-level: returns ContextTokens
     restore_context,        # low-level: pair with inject_context()
     reset_context,          # test teardown only
-    install_context_factory,  # opt-in global LogRecordFactory
+
     ContextTokens,          # type alias used by inject_context/restore_context
 )
 ```
@@ -356,7 +347,7 @@ helpers above instead of importing them directly.
 
 ## Design Principles
 
-1. **Narrow root logger contract** — In Azure/Core Tools, no handlers are added; `setup_logging()` installs `ContextFilter` on existing root handlers and on the root logger itself (so direct calls on the root logger carry context). To guarantee context on records that propagate from named child loggers to handlers attached later (host- or third-party-installed), call `install_context_factory()`. In standalone mode (`logger_name=None`), the root logger's level is set and a `StreamHandler` is added only when no handlers exist.
+1. **Narrow root logger contract** — In Azure/Core Tools, no handlers are added; `setup_logging()` installs `ContextFilter` on existing root handlers and on the root logger itself (so direct calls on the root logger carry context). To guarantee context on records that propagate from named child loggers to handlers attached later (host- or third-party-installed), pass `use_record_factory=True` to `setup_logging()`. In standalone mode (`logger_name=None`), the root logger's level is set and a `StreamHandler` is added only when no handlers exist.
 2. **Respects host.json** — In Azure/Core Tools, never changes root logger level or replaces existing handlers
 3. **No runtime dependency on azure-functions** — Works with any context-like object
 4. **Silent on context failures** — Missing attributes don't cause exceptions

--- a/llms.txt
+++ b/llms.txt
@@ -20,7 +20,7 @@ Key features:
 - **Structured JSON output** — Application Insights-ready NDJSON format for production
 - **Noise control** — `SamplingFilter` rate-limits chatty third-party loggers
 - **PII protection** — `RedactionFilter` masks sensitive fields before they reach log aggregation
-- **Root logger contract** — in Azure/Core Tools mode, no handlers are added; `ContextFilter` is installed on existing root handlers and on the root logger itself (so direct calls on the root logger carry context). To guarantee coverage for records that propagate from named child loggers to handlers attached later, call `install_context_factory()`. In standalone mode (`logger_name=None`), the root logger's level is set and a `StreamHandler` is added if none exist.
+- **Root logger contract** — in Azure/Core Tools mode, no handlers are added; `ContextFilter` is installed on existing root handlers and on the root logger itself (so direct calls on the root logger carry context). To guarantee coverage for records that propagate from named child loggers to handlers attached later, pass `use_record_factory=True` to `setup_logging()`. In standalone mode (`logger_name=None`), the root logger's level is set and a `StreamHandler` is added if none exist.
 - **Zero runtime dependency** — on azure-functions (works with any context-like object)
 
 ## Core API
@@ -36,7 +36,7 @@ Key features:
 - `restore_context(tokens)` — Restore previous contextvars from tokens (paired with `inject_context`)
 - `reset_context()` — Clear all context vars unconditionally (for test teardown)
 - `with_context` — Decorator to inject context per-request (sync/async)
-- `install_context_factory()` — **Deprecated**; prefer `setup_logging(use_record_factory=True)`. Opt-in global LogRecordFactory so context flows to every record
+- `setup_logging(use_record_factory=True)` — opt-in global LogRecordFactory so context flows to every record (mutually exclusive with the default `ContextFilter` mode)
 - `get_logging_metadata(func)` — Inspect `@with_context` metadata on a function; returns `dict[str, Any] | None`
 - `ContextTokens` — Type alias for the token bundle returned by `inject_context()`
 

--- a/scripts/render_mermaid.py
+++ b/scripts/render_mermaid.py
@@ -21,11 +21,11 @@ when ``mmdc`` is unavailable.
 
 from __future__ import annotations
 
+from pathlib import Path
 import shutil
 import subprocess
 import sys
 import tempfile
-from pathlib import Path
 
 # Files/globs to scan, relative to the repository root.
 TARGET_GLOBS = ("README*.md", "DESIGN.md", "docs/**/*.md")

--- a/src/azure_functions_logging/__init__.py
+++ b/src/azure_functions_logging/__init__.py
@@ -5,11 +5,9 @@ from __future__ import annotations
 from ._context import (
     ContextTokens,
     inject_context,
-    install_context_factory,
     logging_context,
     reset_context,
     restore_context,
-    uninstall_context_factory,
 )
 from ._decorator import get_logging_metadata, with_context
 from ._filters import AttributeFlattenFilter, RedactionFilter, SamplingFilter
@@ -25,7 +23,6 @@ __all__ = [
     "get_logger",
     "get_logging_metadata",
     "inject_context",
-    "install_context_factory",
     "JsonFormatter",
     "logging_context",
     "RedactionFilter",
@@ -33,7 +30,6 @@ __all__ = [
     "restore_context",
     "SamplingFilter",
     "setup_logging",
-    "uninstall_context_factory",
     "with_context",
 ]
 

--- a/src/azure_functions_logging/_context.py
+++ b/src/azure_functions_logging/_context.py
@@ -8,7 +8,6 @@ import contextvars
 import logging
 import threading
 from typing import Any, NamedTuple
-import warnings
 
 # Type alias for the token mapping returned by inject_context()
 ContextTokens = dict[contextvars.ContextVar[Any], contextvars.Token[Any]]
@@ -45,9 +44,9 @@ def _check_cold_start() -> bool:
 class ContextFilter(logging.Filter):
     """Logging filter that copies contextvars values onto LogRecord attributes.
 
-    For most new applications, prefer :func:`install_context_factory` because it
-    injects context at LogRecord creation time and does not depend on handler
-    filter configuration.
+    For most new applications, prefer ``setup_logging(use_record_factory=True)``
+    because it injects context at LogRecord creation time and does not depend on
+    handler filter configuration.
 
     ``ContextFilter`` remains supported for compatibility and for users who do
     not want to modify the global ``LogRecordFactory``.
@@ -55,7 +54,7 @@ class ContextFilter(logging.Filter):
     This filter is intended to be installed on handlers, so it applies to any
     record that reaches those handlers, including records from third-party
     loggers that propagate to them. For guaranteed record-creation-time
-    injection, prefer :func:`install_context_factory`.
+    injection, prefer ``setup_logging(use_record_factory=True)``.
     """
 
     CONTEXT_FIELDS: tuple[str, ...] = (
@@ -257,40 +256,29 @@ def restore_context(tokens: ContextTokens) -> None:
 # Process-wide default for OpenTelemetry trace-context activation. Toggled by
 # ``setup_logging(activate_trace_context=...)`` and consulted by
 # ``logging_context`` / ``with_context`` when their per-call flag is ``None``.
-# ``None`` selects the ``auto`` tier: enabled iff ``opentelemetry-api`` is
-# importable.
-_default_trace_context_activation: bool | None = None
+# Trace-context activation is strictly opt-in: the default is ``False`` so the
+# library never attaches the host trace context unless explicitly asked to.
+_default_trace_context_activation: bool = False
 
 
-def set_default_trace_context_activation(enabled: bool | None) -> None:
+def set_default_trace_context_activation(enabled: bool) -> None:
     """Set the process-wide default for OTel trace-context activation.
 
     Called by :func:`setup_logging`. When enabled, ``logging_context`` and
     ``with_context`` activate the host trace context unless a per-call
-    ``activate_trace_context`` argument overrides it. Passing ``None`` selects
-    the ``auto`` tier (enabled iff ``opentelemetry-api`` is importable).
+    ``activate_trace_context`` argument overrides it. Activation is opt-in;
+    the default is ``False`` until a caller explicitly enables it.
     """
     global _default_trace_context_activation
-    _default_trace_context_activation = enabled if enabled is None else bool(enabled)
-
-
-def _resolve_auto_trace_context_activation() -> bool:
-    """Resolve the ``auto`` tier: enabled iff ``opentelemetry-api`` is importable."""
-    try:
-        from ._otel import is_available
-    except ImportError:  # pragma: no cover - defensive; _otel always ships
-        return False
-    return is_available()
+    _default_trace_context_activation = bool(enabled)
 
 
 def get_default_trace_context_activation() -> bool:
-    """Return the resolved process-wide OTel trace-context activation default.
+    """Return the process-wide OTel trace-context activation default.
 
-    A stored default of ``None`` selects the ``auto`` tier: enabled iff
-    ``opentelemetry-api`` is importable.
+    Defaults to ``False`` (opt-in); toggled via
+    ``setup_logging(activate_trace_context=...)``.
     """
-    if _default_trace_context_activation is None:
-        return _resolve_auto_trace_context_activation()
     return _default_trace_context_activation
 
 
@@ -327,11 +315,9 @@ def logging_context(context: Any, *, activate_trace_context: bool | None = None)
             context (from ``context.trace_context``) via OpenTelemetry so log
             records emitted through an OTel ``LoggingHandler`` inherit the host
             span's ``trace_id``/``span_id``. Requires the ``[otel]`` extra;
-            degrades to a silent no-op when OpenTelemetry is unavailable. When
             ``None`` (default), the process-wide default configured via
             ``setup_logging(activate_trace_context=...)`` is used, which itself
-            defaults to the ``auto`` tier (enabled iff ``opentelemetry-api`` is
-            importable).
+            defaults to ``False`` (activation is strictly opt-in).
     """
     should_activate = (
         get_default_trace_context_activation()
@@ -414,29 +400,10 @@ def _install_context_factory() -> None:
     logging.setLogRecordFactory(context_record_factory)
 
 
-def install_context_factory() -> None:
-    """Deprecated shim for the LogRecordFactory injection strategy.
+def _uninstall_context_factory() -> bool:
+    """Restore the ``LogRecordFactory`` that preceded :func:`_install_context_factory`.
 
-    .. deprecated::
-        Direct use of ``install_context_factory`` is deprecated in favour of
-        the single ``setup_logging(use_record_factory=True)`` entry point,
-        which selects the ``LogRecordFactory`` injection strategy and manages
-        ``ContextFilter`` teardown consistently. This shim will be removed in
-        a future release.
-    """
-    warnings.warn(
-        "install_context_factory() is deprecated; use "
-        "setup_logging(use_record_factory=True) instead.",
-        DeprecationWarning,
-        stacklevel=2,
-    )
-    _install_context_factory()
-
-
-def uninstall_context_factory() -> bool:
-    """Restore the ``LogRecordFactory`` that preceded :func:`install_context_factory`.
-
-    This is the inverse of :func:`install_context_factory` and is primarily
+    This is the inverse of :func:`_install_context_factory` and is primarily
     intended for test teardown, where leaving a global factory installed would
     leak context injection into unrelated tests.
 

--- a/src/azure_functions_logging/_setup.py
+++ b/src/azure_functions_logging/_setup.py
@@ -120,9 +120,9 @@ def setup_logging(
             host's W3C trace context (via OpenTelemetry) — making OTel log
             records inherit the host span's ``trace_id``/``span_id``. Requires
             the ``[otel]`` extra; degrades to a silent no-op when OpenTelemetry
-            is not installed. ``True``/``False`` force the default on/off; the
-            default ``None`` selects the ``auto`` tier (enabled iff
-            ``opentelemetry-api`` is importable). A per-call
+            is not installed. ``True``/``False`` force the default on/off. The
+            default ``None`` leaves the stored default unchanged (which itself
+            defaults to ``False`` — activation is strictly opt-in). A per-call
             ``activate_trace_context`` argument overrides this default.
 
     .. warning::

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -15,17 +15,16 @@ from azure_functions_logging._context import (
     _extract_trace_context,
     _extract_trace_id,
     _install_context_factory,
+    _uninstall_context_factory,
     cold_start_var,
     function_name_var,
     inject_context,
-    install_context_factory,
     invocation_id_var,
     logging_context,
     reset_context,
     restore_context,
     span_id_var,
     trace_id_var,
-    uninstall_context_factory,
 )
 
 
@@ -377,7 +376,7 @@ def test_uninstall_context_factory_restores_previous() -> None:
         _install_context_factory()
         assert getattr(logging.getLogRecordFactory(), _CONTEXT_FACTORY_MARKER, False) is True
 
-        assert uninstall_context_factory() is True
+        assert _uninstall_context_factory() is True
         assert logging.getLogRecordFactory() is old_factory
         assert getattr(logging.getLogRecordFactory(), _CONTEXT_FACTORY_MARKER, False) is False
     finally:
@@ -396,7 +395,7 @@ def test_uninstall_context_factory_preserves_chained_factory() -> None:
     try:
         logging.setLogRecordFactory(custom_factory)
         _install_context_factory()
-        assert uninstall_context_factory() is True
+        assert _uninstall_context_factory() is True
         assert logging.getLogRecordFactory() is custom_factory
 
         record = logging.getLogRecordFactory()("test", logging.INFO, __file__, 1, "msg", (), None)
@@ -409,7 +408,7 @@ def test_uninstall_context_factory_noop_when_not_installed() -> None:
     """uninstall_context_factory is a no-op when the factory is not active."""
     old_factory = logging.getLogRecordFactory()
     try:
-        assert uninstall_context_factory() is False
+        assert _uninstall_context_factory() is False
         assert logging.getLogRecordFactory() is old_factory
     finally:
         logging.setLogRecordFactory(old_factory)
@@ -653,16 +652,6 @@ def test_context_filter_extra_collision_raises() -> None:
         ContextFilter({"trace_id": bad_var})
 
 
-def test_install_context_factory_is_deprecated() -> None:
-    try:
-        with pytest.warns(DeprecationWarning, match="setup_logging"):
-            install_context_factory()
-        # The deprecated shim still installs the package factory.
-        assert getattr(logging.getLogRecordFactory(), _CONTEXT_FACTORY_MARKER, False)
-    finally:
-        uninstall_context_factory()
-
-
 def test_span_id_is_a_context_field() -> None:
     assert "span_id" in ContextFilter.CONTEXT_FIELDS
 
@@ -713,7 +702,7 @@ def test_context_factory_injects_span_id() -> None:
         assert record.span_id == "00f067aa0ba902b7"  # type: ignore[attr-defined]
     finally:
         span_id_var.reset(token)
-        uninstall_context_factory()
+        _uninstall_context_factory()
 
 
 def test_reset_context_clears_span_id() -> None:

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -90,11 +90,9 @@ def test_public_api_exports() -> None:
         "get_logging_metadata",
         "get_logger",
         "inject_context",
-        "install_context_factory",
         "logging_context",
         "reset_context",
         "restore_context",
-        "uninstall_context_factory",
         "setup_logging",
         "with_context",
     }

--- a/tests/test_otel.py
+++ b/tests/test_otel.py
@@ -136,32 +136,31 @@ def test_logging_context_does_not_activate_when_explicitly_disabled() -> None:
     from azure_functions_logging import logging_context
     from azure_functions_logging._context import set_default_trace_context_activation
 
-    # An explicit per-call ``False`` must override the auto default and stay off,
-    # even when OpenTelemetry is importable.
+    # An explicit per-call ``False`` must keep activation off, even when
+    # OpenTelemetry is importable.
     try:
-        set_default_trace_context_activation(None)
+        set_default_trace_context_activation(False)
         with logging_context(_make_context(), activate_trace_context=False):
             assert not trace.get_current_span().get_span_context().is_valid
     finally:
-        set_default_trace_context_activation(None)
+        set_default_trace_context_activation(False)
 
 
-def test_logging_context_auto_activates_when_otel_available() -> None:
+def test_logging_context_does_not_activate_by_default() -> None:
     pytest.importorskip("opentelemetry.context")
     from opentelemetry import trace
 
     from azure_functions_logging import logging_context
     from azure_functions_logging._context import set_default_trace_context_activation
 
-    # Auto tier (#255): with no explicit flag and no configured default,
-    # activation is enabled iff opentelemetry-api is importable — which it is
-    # in this test env.
+    # Opt-in contract (#290): with no explicit flag and the default (False),
+    # activation stays off even when opentelemetry-api is importable.
     try:
-        set_default_trace_context_activation(None)
+        set_default_trace_context_activation(False)
         with logging_context(_make_context()):
-            assert trace.get_current_span().get_span_context().is_valid
+            assert not trace.get_current_span().get_span_context().is_valid
     finally:
-        set_default_trace_context_activation(None)
+        set_default_trace_context_activation(False)
 
 
 def test_with_context_activates_host_span_when_enabled() -> None:
@@ -194,7 +193,7 @@ def test_setup_logging_sets_default_activation() -> None:
         with logging_context(_make_context()):
             assert trace.get_current_span().get_span_context().is_valid
     finally:
-        set_default_trace_context_activation(None)
+        set_default_trace_context_activation(False)
 
 
 def test_setup_logging_bare_call_preserves_explicit_activation() -> None:
@@ -209,62 +208,46 @@ def test_setup_logging_bare_call_preserves_explicit_activation() -> None:
     try:
         setup_logging(logger_name="afl.otel.idempotent", activate_trace_context=True)
         # A bare call (activate_trace_context defaults to None) must leave the
-        # explicitly-set default intact rather than silently reverting to auto.
+        # explicitly-set default intact rather than silently reverting to the
+        # opt-in default.
         setup_logging(logger_name="afl.otel.idempotent.b")
         assert get_default_trace_context_activation() is True
     finally:
-        set_default_trace_context_activation(None)
+        set_default_trace_context_activation(False)
 
 
 # ---------------------------------------------------------------------------
-# Auto tier (#255): default None resolves to "enabled iff opentelemetry-api
-# is importable".
+# Activation default (#290): activation is strictly opt-in — the process-wide
+# default is False and is never inferred from OTel importability.
 # ---------------------------------------------------------------------------
 
 
-def test_get_default_activation_auto_enabled_when_otel_available(
+def test_default_activation_is_false() -> None:
+    from azure_functions_logging import _context
+
+    assert _context._default_trace_context_activation is False
+    assert _context.get_default_trace_context_activation() is False
+
+
+def test_get_default_activation_reflects_explicit_true(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     from azure_functions_logging import _context
 
-    monkeypatch.setattr(_context, "_default_trace_context_activation", None)
-    monkeypatch.setattr(_otel, "is_available", lambda: True)
+    monkeypatch.setattr(_context, "_default_trace_context_activation", True)
     assert _context.get_default_trace_context_activation() is True
 
 
-def test_get_default_activation_auto_disabled_when_otel_absent(
+def test_default_activation_ignores_otel_availability(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     from azure_functions_logging import _context
 
-    monkeypatch.setattr(_context, "_default_trace_context_activation", None)
-    monkeypatch.setattr(_otel, "is_available", lambda: False)
-    assert _context.get_default_trace_context_activation() is False
-
-
-def test_get_default_activation_explicit_overrides_auto(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    from azure_functions_logging import _context
-
-    # An explicit stored default short-circuits the auto probe entirely.
+    # Even when OTel is importable, a bare install must not auto-activate:
+    # activation stays False until explicitly enabled (#290 opt-in contract).
     monkeypatch.setattr(_context, "_default_trace_context_activation", False)
     monkeypatch.setattr(_otel, "is_available", lambda: True)
     assert _context.get_default_trace_context_activation() is False
-
-
-def test_resolve_auto_returns_false_when_otel_import_missing(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    import sys
-
-    from azure_functions_logging import _context
-
-    # Simulate the base (zero-dependency) install where importing the helper's
-    # ``is_available`` path is fine but OTel itself is absent.
-    monkeypatch.setitem(sys.modules, "opentelemetry.context", None)
-    monkeypatch.setitem(sys.modules, "opentelemetry.propagate", None)
-    assert _context._resolve_auto_trace_context_activation() is False
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -18,11 +18,9 @@ class TestAPISurface:
             "get_logging_metadata",
             "get_logger",
             "inject_context",
-            "install_context_factory",
             "logging_context",
             "reset_context",
             "restore_context",
-            "uninstall_context_factory",
             "setup_logging",
             "with_context",
         }
@@ -46,11 +44,9 @@ class TestAPISurface:
             get_logger,
             get_logging_metadata,
             inject_context,
-            install_context_factory,
             logging_context,
             reset_context,
             restore_context,
-            uninstall_context_factory,
         )
 
     def test_get_logger_is_callable(self) -> None:


### PR DESCRIPTION
## Priority: P1 (target v0.9.0)

## Context
Trace-context activation previously auto-enabled itself based on OpenTelemetry importability, making behavior implicit and surprising. The public `install_context_factory()` / `uninstall_context_factory()` shims were deprecated in favor of `setup_logging(use_record_factory=True)`. This PR completes the breaking cleanup for v0.9.0.

## Changes (BREAKING)
- **Opt-in activation** — `activate_trace_context` now defaults to `False` and is **never** inferred from OTel availability. `None` (per-call or process default) inherits the stored default (`False`); `True`/`False` set it explicitly.
- **Removed factory shims** — public `install_context_factory()` / `uninstall_context_factory()` deleted from the public API. Use `setup_logging(use_record_factory=True)`. Private `_install_context_factory` / `_uninstall_context_factory` retained for internal wiring and test teardown.
- Removed the now-dead `_resolve_auto_trace_context_activation()` auto-tier logic and `warnings` import from `_context.py`.

## Docs & Translations
- Updated English `README.md`, `llms.txt`, `llms-full.txt`, and `docs/{api,index,architecture,configuration}.md`.
- Synced `README.ko.md`, `README.ja.md`, `README.zh-CN.md` in the same PR (removed deprecated callouts, reworded the LogRecordFactory section around `setup_logging(use_record_factory=True)`).

## Acceptance Checklist
- [x] Default trace-context activation is `False`, independent of OTel availability
- [x] Explicit `activate_trace_context=True` still works (process default + per-call)
- [x] Public factory shims removed from `__init__.py` `__all__`
- [x] Tests updated (auto-tier assertions replaced with opt-in-False coverage)
- [x] Translations synced (ko/ja/zh-CN)
- [x] `make lint`, `make typecheck` clean; full suite green at 96.45% coverage

## References
- Closes #290