### PR TITLE
docs(otel): clarify record mutation, late-handler filters, and root-logger wording

### DIFF
--- a/.github/workflows/otel-nightly.yml
+++ b/.github/workflows/otel-nightly.yml
@@ -1,0 +1,45 @@
+name: OTel Nightly (latest opentelemetry-*)
+
+# Catches breakage from OpenTelemetry upgrades early — in particular the
+# private `opentelemetry.sdk._logs` import used only by the OTel test suite
+# (tests/test_otel_spike.py). Runtime code imports only stable public APIs.
+
+on:
+  schedule:
+    - cron: "0 5 * * *" # daily at 05:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  otel-latest:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+
+      - name: Install package with dev extras
+        run: |
+          pip install hatch
+          make install
+
+      - name: Upgrade to the latest opentelemetry-* packages
+        run: |
+          pip install --upgrade \
+            "opentelemetry-api" \
+            "opentelemetry-sdk"
+          pip show opentelemetry-api opentelemetry-sdk | grep -E "^(Name|Version):"
+
+      - name: Run OTel-focused test suite
+        run: |
+          hatch run pytest -q \
+            tests/test_otel.py \
+            tests/test_otel_spike.py \
+            tests/test_otel_filters.py \
+            tests/test_host_config_otel.py

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -109,7 +109,7 @@ Use Makefile entry points only. Do not bypass the Makefile in CI or contributor 
 
 ## Design Constraints
 
-- The root logger is never modified by this library.
+- The root logger's handlers and level are never modified in Azure mode; the library may add package-owned filters (e.g. `ContextFilter`) to existing handlers and to the root logger for late-handler coverage.
 - In Azure environments, behavior is safe by default — no forced colors, no excessive handler additions, no interference with the worker's `AsyncLoggingHandler`.
 - Context injection failures never cause application failures.
 - The API surface stays as close to standard `logging` as possible.

--- a/PRD.md
+++ b/PRD.md
@@ -29,7 +29,7 @@ specifically designed to work safely within the Azure Functions worker architect
 
 ### Design Principles
 
-- **Principle 1**: The root logger is never modified. All configuration targets named child loggers or installs safe filters.
+- **Principle 1**: The root logger's handlers and level are never modified in Azure mode. The library may add package-owned filters (e.g. `ContextFilter`) to existing handlers and to the root logger itself; all other configuration targets named child loggers.
 - **Principle 2**: In Azure environments, behavior is safe by default — no forced colors, no handler additions, no interference with the worker's `AsyncLoggingHandler`.
 - **Principle 3**: Context injection failures never cause application failures. Logging helpers are auxiliary tools.
 - **Principle 4**: The API surface stays as close to standard `logging` as possible.

--- a/docs/opentelemetry.md
+++ b/docs/opentelemetry.md
@@ -97,6 +97,14 @@ For handlers that must be attached *after* `setup_logging()`, pass
 `use_record_factory=True` so context is injected at record-creation time instead
 of via handler filters.
 
+> **`use_record_factory=True` covers context injection only.** It guarantees that
+> `trace_id` / `span_id` / invocation fields reach records emitted through
+> late-attached handlers, but it does **not** attach `RedactionFilter`,
+> `SamplingFilter`, or `AttributeFlattenFilter` to those handlers. Security and
+> noise filters must still be added explicitly to any OTel handler created after
+> `setup_logging()` (e.g. by a later `configure_azure_monitor()`) — otherwise PII
+> redaction and sampling are silently bypassed on that handler.
+
 ## Filters in OpenTelemetry mode
 
 In OTel mode the entire `extra` mapping is exported as log **attributes**, which
@@ -127,6 +135,14 @@ for handler in logging.getLogger().handlers:
 > a nested object. That is what you want for OTel attribute export, but usually
 > not for local/standalone JSON logs — attach it to the specific OTel handler
 > rather than the root logger when both kinds of handler are present.
+
+> **Handler scoping reduces blast radius but does not isolate mutation.** stdlib
+> `logging` passes the *same* `LogRecord` object to every handler in sequence, so
+> if the OTel handler runs **before** a JSON/stdout handler on the same logger,
+> that later handler still sees the flattened record. Scoping the filter to the
+> OTel handler shrinks the window but cannot fully isolate in-place mutation when
+> multiple handlers process one record. To keep plain JSON output nested, emit it
+> on a separate logger (not sharing handlers with the OTel path).
 
 ## Known limitation: thread boundaries
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -284,6 +284,46 @@ the entire `extra` mapping is exported unfiltered.
 
 See [OpenTelemetry correlation](opentelemetry.md) for the full ordering guide.
 
+## OpenTelemetry Appears "Not Installed" After a Broken Upgrade
+
+### Symptoms
+
+Trace-context activation silently no-ops (`trace_id` / `span_id` stay `null`) even
+though you installed the `[otel]` extra.
+
+### Root Cause
+
+`azure_functions_logging` gates OTel behavior on an internal `is_available()`
+probe that imports `opentelemetry.context` / `opentelemetry.propagate`. That probe
+catches **any** import exception and caches the result as "unavailable" for the
+rest of the process lifetime. A *partial or broken* OpenTelemetry install (e.g. a
+half-finished upgrade, or a version mismatch between `opentelemetry-api` and
+`opentelemetry-sdk`) therefore looks identical to "OTel is not installed" — the
+activation path is skipped and nothing is raised, by design (context injection
+must never crash your app).
+
+### Resolution
+
+1. Verify the import works in isolation:
+
+   ```bash
+   python -c "import opentelemetry.context, opentelemetry.propagate; print('ok')"
+   ```
+
+   If this raises anything other than `ModuleNotFoundError`, your OTel install is
+   broken — reinstall a consistent set of `opentelemetry-*` packages.
+2. Restart the worker process after fixing the install: the `is_available()`
+   result is cached per process and will not re-probe until restart.
+
+### Note on the OTel test path
+
+The `[otel]` extra pins only `opentelemetry-api>=1.24` (no upper bound). Runtime
+code imports **only** the stable public `opentelemetry.context` /
+`opentelemetry.propagate` APIs. The test suite (`tests/test_otel_spike.py`)
+additionally imports the **private** `opentelemetry.sdk._logs` path, which remains
+underscore-private upstream and can break on OTel upgrades. This affects tests
+only — it is never imported by shipped runtime code.
+
 ## Fast Diagnostic Checklist
 
 Run through this list during incidents:


### PR DESCRIPTION
## Priority: P2 (target v0.8.2)

## Context
Follow-up to the OpenTelemetry design review (#292). Several documented statements were imprecise relative to actual code behavior. None are functional bugs — this PR reconciles docs/principles with the code and adds an early-warning CI job.

## Changes
- **`docs/opentelemetry.md`**
  - Item 1: handler scoping *reduces blast radius but does not isolate* shared-`LogRecord` mutation — stdlib `logging` passes the same record to handlers sequentially, so an OTel handler running before a JSON handler still exposes the flattened record.
  - Item 2: `use_record_factory=True` covers **context injection only**; `RedactionFilter` / `SamplingFilter` / `AttributeFlattenFilter` must still be attached to OTel handlers created after `setup_logging()`.
- **`PRD.md` / `AGENTS.md`** (Item 3): reword "root logger is never modified" → "handlers and level are never modified in Azure mode; may add package-owned filters." (`DESIGN.md` was already precise.)
- **`docs/troubleshooting.md`** (Items 4 & 5): new section documenting that `is_available()` caches `False` for the process lifetime (a broken OTel install looks like "not installed"), plus a note that `opentelemetry.sdk._logs` is a private, test-only import path.
- **`.github/workflows/otel-nightly.yml`** (Item 5): nightly job installing the latest `opentelemetry-*` and running the OTel test suite, to catch private `_logs` breakage early.

## Acceptance Checklist
- [x] Shared-record mutation isolation caveat documented
- [x] `use_record_factory=True` context-only scope documented
- [x] Root-logger principle wording reconciled (PRD/AGENTS)
- [x] `is_available()` caching diagnostic limitation documented
- [x] Private `_logs` test-only path documented + nightly OTel CI added

## Notes
Docs-only + new workflow — no runtime/test code changed. No README/translation impact (site docs and internal docs have no translated variants).

## References
- Closes #292