### PR TITLE
docs(otel): reframe distributed-tracing non-goal as correlation-not-tracing

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -174,7 +174,7 @@ traces
 このパッケージは以下を所有しません:
 
 - **stdlib logging の置き換え** — Python 標準の `logging` をラップして強化するだけで、決して置き換えません
-- **分散トレーシング** — エンドツーエンドのトレース相関には OpenTelemetry または Application Insights SDK を使用してください
+- **分散トレーシング** — Azure Functions ホストの W3C トレースコンテキストを**バインド**して、既存の OpenTelemetry ログレコードが呼び出し span の `trace_id` / `span_id` を継承するようにしますが、このライブラリ自身が span を作成・記録・エクスポートすることはありません — トレーシングではなく相関（correlation）です。span の生成には OpenTelemetry または Application Insights SDK を使用してください。[OpenTelemetry トレース相関](https://yeongseon.github.io/azure-functions-logging-python/opentelemetry/) を参照
 - **API ドキュメント** — API ドキュメントと spec 生成には [`azure-functions-openapi`](https://github.com/yeongseon/azure-functions-openapi-python) を使用してください
 
 ## インストール

--- a/README.ko.md
+++ b/README.ko.md
@@ -174,7 +174,7 @@ traces
 이 패키지는 다음을 책임지지 않습니다:
 
 - **stdlib logging 대체** — Python 표준 `logging`을 감싸고 보강할 뿐, 절대 대체하지 않습니다
-- **분산 트레이싱** — end-to-end trace 상관에는 OpenTelemetry나 Application Insights SDK를 사용하세요
+- **분산 트레이싱** — Azure Functions 호스트의 W3C trace context를 **바인딩**하여 기존 OpenTelemetry 로그 레코드가 호출 span의 `trace_id` / `span_id`를 상속하도록 하지만, 이 라이브러리가 직접 span을 생성·기록·내보내지는 않습니다 — 트레이싱이 아니라 상관(correlation)입니다. span 생성에는 OpenTelemetry나 Application Insights SDK를 사용하세요. [OpenTelemetry trace 상관](https://yeongseon.github.io/azure-functions-logging-python/opentelemetry/) 참고
 - **API 문서** — API 문서 및 spec 생성에는 [`azure-functions-openapi`](https://github.com/yeongseon/azure-functions-openapi-python)를 사용하세요
 
 ## 설치

--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ traces
 This package does not own:
 
 - **Replacing stdlib logging** — it wraps and enriches Python's standard `logging`, never replaces it
-- **Distributed tracing** — it does not create, record, or export spans; use OpenTelemetry or the Application Insights SDK for that. It *can* correlate your logs with the host invocation span — see [OpenTelemetry trace correlation](https://yeongseon.github.io/azure-functions-logging-python/opentelemetry/)
+- **Distributed tracing** — it **binds** the Azure Functions host's W3C trace context so your existing OpenTelemetry log records inherit the invocation span's `trace_id` / `span_id`, but it never creates, records, or exports spans itself — correlation, not tracing. Use OpenTelemetry or the Application Insights SDK to produce spans. See [OpenTelemetry trace correlation](https://yeongseon.github.io/azure-functions-logging-python/opentelemetry/)
 - **API documentation** — use [`azure-functions-openapi`](https://github.com/yeongseon/azure-functions-openapi-python) for API documentation and spec generation
 
 ## Installation

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -174,7 +174,7 @@ traces
 本包不拥有:
 
 - **替换 stdlib logging** — 它包装并丰富 Python 标准 `logging`，从不替换它
-- **分布式追踪** — 端到端追踪关联请使用 OpenTelemetry 或 Application Insights SDK
+- **分布式追踪** — 它会**绑定** Azure Functions 主机的 W3C 追踪上下文，使你已有的 OpenTelemetry 日志记录继承调用 span 的 `trace_id` / `span_id`，但它自身绝不创建、记录或导出 span —— 是关联（correlation）而非追踪。请使用 OpenTelemetry 或 Application Insights SDK 来生成 span。参见 [OpenTelemetry 追踪关联](https://yeongseon.github.io/azure-functions-logging-python/opentelemetry/)
 - **API 文档** — API 文档和 spec 生成请使用 [`azure-functions-openapi`](https://github.com/yeongseon/azure-functions-openapi-python)
 
 ## 安装


### PR DESCRIPTION
## Priority: P1 (epic #252)

## Context
Completes the documentation portion of the OTel trace-correlation epic (#252). The core feature (context extraction + `activate_trace_context`, `[otel]` extra) already shipped in #254/#255; `docs/opentelemetry.md` and `examples/otel_app` already exist and are runnable.

## Changes
- Reframe the **"Distributed tracing"** non-goal bullet to the epic's canonical **"binds host trace context, does not trace"** wording: it binds the host's W3C trace context so existing OTel log records inherit the invocation span's `trace_id`/`span_id`, but never creates/records/exports spans — correlation, not tracing.
- **Re-sync the drifted translations** (`README.ko.md`, `README.ja.md`, `README.zh-CN.md`), which lagged the English wording and omitted the host-span correlation capability entirely.

## Epic #252 acceptance status
- [x] #253 spike / #254 extract / #255 core (already merged)
- [x] `docs/opentelemetry.md` + runnable `examples/otel_app` (thread-boundary limitation + `configure_azure_monitor()` → `setup_logging()` ordering already documented; further sharpened in #296)
- [x] README non-goal text updated to "binds host trace context, does not trace" framing **(this PR)**
- [ ] **`docs/assets/portal-otel-correlated.png`** — requires a real Azure deployment + App Insights end-to-end transaction screenshot. **Cannot be produced from code; needs a maintainer with the deployed app** (same as the existing portal-before/after screenshots).
- [x] Coverage stays ≥ 95% (96.48%)

## Notes
Marked `Refs #252` rather than `Closes #252` — the epic stays open until the portal correlation screenshot lands.

## References
- Refs #252