### PR TITLE
docs: emphasize Python-only OpenTelemetry invocation-middleware gap

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -35,6 +35,7 @@ Azure Functions Python のロギングには、汎用的なロギングライブ
 | サードパーティロガーがうるさい | `azure-core`, `urllib3` が Application Insights を埋め尽くす | `SamplingFilter` / `RedactionFilter` |
 | ローカルとクラウドの出力不一致 | 色付き出力が本番パイプラインを壊す | 環境認識フォーマッタ自動切替 |
 | PII がログに漏洩 | extra フィールド経由で機密値が誤って記録される | キーベースの redaction を行う `RedactionFilter` |
+| ログが呼び出しトレースから分離される | Python は OpenTelemetry 呼び出しミドルウェアを内蔵しない唯一の Functions worker ランタイムのため、worker のログレコードが `span_id=0` を持つ | host の W3C trace context をバインドし、OpenTelemetry ログが呼び出しの `trace_id` / `span_id` を継承する |
 
 ## 何をするのか
 
@@ -44,6 +45,26 @@ Azure Functions Python のロギングには、汎用的なロギングライブ
 - **PII 保護** — `RedactionFilter` が機密フィールドをログ集約に到達する前にマスキング
 
 > **スコープ免責事項。** このパッケージは Python `logging` / stdout に構造化 JSON を書き込みます。これらのフィールドが Application Insights にどう現れるかは、Azure Functions host、worker、ロギング設定、および ingestion パイプラインに依存します。ライブラリは ingestion やスキーマ マッピングを所有しません — `customDimensions` にパースされる形式と、生の `message` 内に残る形式の両方が本番環境で有効です。
+
+## OpenTelemetry トレース相関付け
+
+> **Python は OpenTelemetry 呼び出しミドルウェアを内蔵しない唯一の Azure Functions worker ランタイムです。** host はすべての呼び出しに W3C `traceparent` を発行しますが、Python worker はそれをプロセス内でアクティベートしません — そのため worker のログレコードは `span_id=0` でスタンプされ、host の呼び出し span から分離されます。
+
+これは一般的な logging ライブラリが単独では埋められないギャップです。structlog、Loguru、stdlib `logging` は `trace_id` / `span_id` を付与するために OpenTelemetry の `LoggingHandler` / `LoggingInstrumentor` に依存しますが、これらはプロセス内に **アクティブな span がある場合にのみ** 機能します — Python worker はそれを提供しません。結果はどこでも同じです: `trace_id=0`、`span_id=0`、呼び出しとの相関なし。
+
+`azure-functions-logging` はそのギャップを埋めます。`activate_trace_context=True`（`[otel]` extra が必要）でオプトインすると、ライブラリがハンドラ実行中に host の W3C trace context をバインドし、既存の OpenTelemetry ログレコードが呼び出しの `trace_id` / `span_id` を継承します:
+
+```python
+from azure_functions_logging import logging_context, setup_logging
+
+setup_logging(activate_trace_context=True)  # 必要: pip install azure-functions-logging[otel]
+
+with logging_context(context):
+    logger.info("processing")  # OpenTelemetry レコードが呼び出しの trace_id / span_id を継承
+```
+
+これは **相関付けであってトレーシングではありません** — ライブラリは span を生成・記録・エクスポートしません。OpenTelemetry や Application Insights SDK を置き換えるのではなく補完し、span の生成は引き続きそれらの責任です。[OpenTelemetry トレース相関付けガイド](https://yeongseon.github.io/azure-functions-logging-python/opentelemetry/)を参照してください。
+
 
 ## パイプライン概要
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -35,6 +35,7 @@ Azure Functions Python의 logging에는 일반 logging 라이브러리가 다루
 | 시끄러운 서드파티 로거 | `azure-core`, `urllib3` 등이 Application Insights를 채움 | `SamplingFilter` / `RedactionFilter` |
 | 로컬과 클라우드 출력 불일치 | 색상 출력이 프로덕션 파이프라인을 깨뜨림 | 환경 인지 포매터 자동 전환 |
 | PII가 로그에 유출 | extra 필드를 통해 민감 값이 우발적으로 기록 | 키 기반 redaction을 수행하는 `RedactionFilter` |
+| 로그가 호출 트레이스에서 분리됨 | Python은 OpenTelemetry 호출 미들웨어가 내장되지 않은 유일한 Functions worker 런타임이라, worker 로그 레코드가 `span_id=0`을 가짐 | host의 W3C trace context를 바인딩해 OpenTelemetry 로그가 호출의 `trace_id` / `span_id`를 상속하도록 함 |
 
 ## 무엇을 하는가
 
@@ -44,6 +45,26 @@ Azure Functions Python의 logging에는 일반 logging 라이브러리가 다루
 - **PII 보호** — `RedactionFilter`로 민감 필드를 로그 집계에 도달하기 전에 마스킹
 
 > **범위 면책.** 이 패키지는 Python `logging` / stdout으로 구조화된 JSON을 씁니다. Application Insights에서 어떻게 표시되는지는 Azure Functions host, worker, logging 구성, ingestion 파이프라인에 따라 달라집니다. 라이브러리는 ingestion이나 schema mapping을 책임지지 않습니다 — `customDimensions`로 파싱되는 형태와 raw `message`에 들어가는 형태 모두 프로덕션에서 유효합니다.
+
+## OpenTelemetry 트레이스 상관관계
+
+> **Python은 OpenTelemetry 호출 미들웨어가 내장되지 않은 유일한 Azure Functions worker 런타임입니다.** host는 모든 호출에 대해 W3C `traceparent`를 발행하지만 Python worker는 이를 프로세스 안에서 활성화하지 않습니다 — 그래서 worker 로그 레코드는 `span_id=0`으로 기록되고 host의 호출 span에서 분리됩니다.
+
+이는 일반 logging 라이브러리가 스스로 메울 수 **없는** 간극입니다. structlog, Loguru, stdlib `logging`은 `trace_id` / `span_id`를 붙이기 위해 OpenTelemetry의 `LoggingHandler` / `LoggingInstrumentor`에 의존하지만, 이들은 프로세스에 **활성 span이 있을 때만** 동작합니다 — Python worker는 그것을 제공하지 않습니다. 결과는 어디서나 동일합니다: `trace_id=0`, `span_id=0`, 호출과의 상관관계 없음.
+
+`azure-functions-logging`은 그 간극을 메웁니다. `activate_trace_context=True`(`[otel]` extra 필요)로 옵트인하면 라이브러리가 핸들러 실행 동안 host의 W3C trace context를 바인딩하여, 기존 OpenTelemetry 로그 레코드가 호출의 `trace_id` / `span_id`를 상속하게 합니다:
+
+```python
+from azure_functions_logging import logging_context, setup_logging
+
+setup_logging(activate_trace_context=True)  # 필요: pip install azure-functions-logging[otel]
+
+with logging_context(context):
+    logger.info("processing")  # OpenTelemetry 레코드가 호출의 trace_id / span_id를 상속
+```
+
+이는 **상관관계이지 트레이싱이 아닙니다** — 라이브러리는 결코 span을 생성, 기록, 내보내지 않습니다. OpenTelemetry나 Application Insights SDK를 대체하지 않고 보완하며, span 생성은 여전히 그들의 책임입니다. [OpenTelemetry 트레이스 상관관계 가이드](https://yeongseon.github.io/azure-functions-logging-python/opentelemetry/)를 참고하세요.
+
 
 ## 파이프라인 개요
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Azure Functions Python logging has specific failure modes that generic logging l
 | Noisy third-party loggers | `azure-core`, `urllib3` flood your Application Insights | `SamplingFilter` / `RedactionFilter` |
 | Local vs cloud output mismatch | Colorized output breaks in production pipelines | Environment-aware formatter switching |
 | PII leaking into logs | Sensitive values accidentally logged as extra fields | `RedactionFilter` with key-based redaction |
+| Worker logs orphaned from the invocation trace | Python is the only Functions worker runtime without built-in OpenTelemetry invocation middleware, so worker log records carry `span_id=0` | Binds the host's W3C trace context so your OpenTelemetry logs inherit the invocation's `trace_id` / `span_id` |
 
 ## What it does
 
@@ -44,6 +45,26 @@ Azure Functions Python logging has specific failure modes that generic logging l
 - **PII protection** — `RedactionFilter` masks sensitive fields before they reach log aggregation
 
 > **Scope disclaimer.** This package writes structured JSON to Python `logging` / stdout. How those fields appear in Application Insights depends on the Azure Functions host, worker, logging configuration, and ingestion pipeline. The library does not own ingestion or schema mapping — both `customDimensions`-parsed and raw-`message` shapes are valid in production.
+
+## OpenTelemetry trace correlation
+
+> **Python is the only Azure Functions worker runtime without built-in OpenTelemetry invocation middleware.** The host emits a W3C `traceparent` for every invocation, but the Python worker never activates it in-process — so worker log records are stamped with `span_id=0` and get orphaned from the host's invocation span.
+
+This is a gap that generic logging libraries **cannot** close on their own. structlog, Loguru, and stdlib `logging` rely on OpenTelemetry's `LoggingHandler` / `LoggingInstrumentor` to attach `trace_id` / `span_id` — but those only work when there is an **active span in the process**, which the Python worker does not provide. The result is the same everywhere: `trace_id=0`, `span_id=0`, no correlation to the invocation.
+
+`azure-functions-logging` fills that gap. Opt in with `activate_trace_context=True` (requires the `[otel]` extra) and the library binds the host's W3C trace context for the duration of the handler, so your existing OpenTelemetry log records inherit the invocation's `trace_id` / `span_id`:
+
+```python
+from azure_functions_logging import logging_context, setup_logging
+
+setup_logging(activate_trace_context=True)  # requires: pip install azure-functions-logging[otel]
+
+with logging_context(context):
+    logger.info("processing")  # OpenTelemetry record inherits the invocation trace_id / span_id
+```
+
+This is **correlation, not tracing** — the library never creates, records, or exports spans itself. It is complementary to (not a replacement for) OpenTelemetry or the Application Insights SDK, which remain responsible for producing spans. See the [OpenTelemetry trace correlation guide](https://yeongseon.github.io/azure-functions-logging-python/opentelemetry/).
+
 
 ## Pipeline at a glance
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -35,6 +35,7 @@ Azure Functions Python 的日志记录有一些通用日志库无法处理的特
 | 嘈杂的第三方日志 | `azure-core`、`urllib3` 充斥 Application Insights | `SamplingFilter` / `RedactionFilter` |
 | 本地与云端输出不匹配 | 彩色输出在生产管道中崩溃 | 环境感知的格式化器自动切换 |
 | PII 泄露到日志 | 敏感值通过 extra 字段被意外记录 | 基于键的脱敏 `RedactionFilter` |
+| 日志与调用追踪脱离 | Python 是唯一没有内置 OpenTelemetry 调用中间件的 Functions worker 运行时，所以 worker 日志记录携带 `span_id=0` | 绑定 host 的 W3C trace context，使 OpenTelemetry 日志继承调用的 `trace_id` / `span_id` |
 
 ## 它做什么
 
@@ -44,6 +45,26 @@ Azure Functions Python 的日志记录有一些通用日志库无法处理的特
 - **PII 保护** — `RedactionFilter` 在敏感字段到达日志聚合之前进行脱敏
 
 > **范围免责声明。** 本包将结构化 JSON 写入 Python `logging` / stdout。这些字段在 Application Insights 中如何呈现取决于 Azure Functions host、worker、日志配置和 ingestion 管道。本库不拥有 ingestion 或 schema 映射 — `customDimensions` 解析形式和原始 `message` 形式在生产中都是有效的。
+
+## OpenTelemetry 追踪关联
+
+> **Python 是唯一没有内置 OpenTelemetry 调用中间件的 Azure Functions worker 运行时。** host 为每次调用发出 W3C `traceparent`，但 Python worker 从不在进程内激活它 — 因此 worker 日志记录被标记为 `span_id=0`，并与 host 的调用 span 脱离。
+
+这是通用日志库无法自行弥补的缺口。structlog、Loguru 和 stdlib `logging` 依靠 OpenTelemetry 的 `LoggingHandler` / `LoggingInstrumentor` 来附加 `trace_id` / `span_id`，但它们只有在进程中 **存在活动 span 时** 才生效 — 而 Python worker 并不提供它。结果到处都一样：`trace_id=0`、`span_id=0`、与调用无关联。
+
+`azure-functions-logging` 弥补了这个缺口。通过 `activate_trace_context=True`（需要 `[otel]` extra）选择开启，库会在处理器运行期间绑定 host 的 W3C trace context，使你现有的 OpenTelemetry 日志记录继承调用的 `trace_id` / `span_id`：
+
+```python
+from azure_functions_logging import logging_context, setup_logging
+
+setup_logging(activate_trace_context=True)  # 需要: pip install azure-functions-logging[otel]
+
+with logging_context(context):
+    logger.info("processing")  # OpenTelemetry 记录继承调用的 trace_id / span_id
+```
+
+这是 **关联，而非追踪** — 库从不创建、记录或导出 span。它补充而非替代 OpenTelemetry 或 Application Insights SDK，后者仍负责产生 span。参见 [OpenTelemetry 追踪关联指南](https://yeongseon.github.io/azure-functions-logging-python/opentelemetry/)。
+
 
 ## 流水线一览
 


### PR DESCRIPTION
## Context
Python is the only Azure Functions worker runtime **without built-in OpenTelemetry invocation middleware**. The host emits a W3C `traceparent` per invocation, but the Python worker never activates it in-process, so worker log records are stamped with `span_id=0` and orphaned from the host invocation span. Generic logging libraries (structlog, Loguru, stdlib `logging`) can't close this gap — OTel's `LoggingHandler`/`LoggingInstrumentor` only stamp `trace_id`/`span_id` when there is an active span in the process, which the Python worker doesn't provide. `azure-functions-logging` uniquely fills this by binding the host's W3C trace context (correlation, not tracing).

This surfaces that differentiator prominently in the README instead of a single bullet buried in "What this package does not do".

## Changes
- Add a row to the **Why this exists** table about worker logs orphaned from the invocation trace.
- Add a dedicated **## OpenTelemetry trace correlation** section (after "What it does", before "Pipeline at a glance") with rationale + opt-in snippet + docs link.
- Mirror both changes across all translations (`README.ko.md`, `README.ja.md`, `README.zh-CN.md`) in the same PR per AGENTS.md translation-sync rule.

## Out of scope
- Live App Insights end-to-end correlation proof (tracked in #298).

## References
- Docs: https://yeongseon.github.io/azure-functions-logging-python/opentelemetry/
- Related tests: PR #300