### PR TITLE
fix(redaction): mask any sensitive dotted segment to prevent PII leak

### DIFF
--- a/src/azure_functions_logging/_redaction.py
+++ b/src/azure_functions_logging/_redaction.py
@@ -58,21 +58,25 @@ def is_sensitive(key: str, sensitive_keys: frozenset[str] = SENSITIVE_KEYS) -> b
     Matches when either:
 
     - the full normalized key is in ``sensitive_keys``, or
-    - the **final dotted segment** of the normalized key is in ``sensitive_keys``.
+    - **any** dotted segment of the normalized key is in ``sensitive_keys``.
 
     The dotted-segment check is a safety net for keys produced by
     :class:`~azure_functions_logging._filters.AttributeFlattenFilter`, which
     rewrites ``{"order": {"password": "x"}}`` into the scalar key
-    ``order.password``. Without it, a flatten-before-redact filter ordering
-    would ship nested secrets unmasked. Only the final segment is considered,
-    so non-sensitive leaves like ``password.hint`` are left untouched.
+    ``order.password`` and ``{"token": {"raw": "x"}}`` into ``token.raw``.
+    Without matching *any* segment, a flatten-before-redact ordering would ship
+    nested secrets unmasked whenever the sensitive name is a parent and the leaf
+    is benign (e.g. ``token.raw``, ``secret.value``, ``credential.blob``).
+    Segment matching is against ``.``-delimited whole segments, not substrings,
+    so non-sensitive keys like ``partition.key``, ``metrics.token_count``, and
+    ``tokenizer.name`` are left untouched. A benign leaf under a sensitive parent
+    (e.g. ``password.hint``) is fail-closed masked, which is the correct posture
+    for a security control.
     """
     normalized = normalize_key(key)
     if normalized in sensitive_keys:
         return True
-    if "." in normalized:
-        return normalized.rsplit(".", 1)[-1] in sensitive_keys
-    return False
+    return any(seg in sensitive_keys for seg in normalized.split("."))
 
 
 def mask_value(

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -1111,8 +1111,8 @@ def test_redaction_masks_deep_flattened_dotted_key() -> None:
     assert getattr(record, "payload.outer.inner.secret") == "***"
 
 
-def test_redaction_does_not_over_redact_non_final_sensitive_segment() -> None:
-    """Only the final dotted segment matters: ``password.hint`` stays visible."""
+def test_redaction_masks_sensitive_parent_segment_fail_closed() -> None:
+    """Any sensitive segment masks the key: ``password.hint`` is fail-closed masked."""
     flt = RedactionFilter()
     record = _make_record(msg="hint")
     setattr(record, "password.hint", "first pet name")
@@ -1120,7 +1120,9 @@ def test_redaction_does_not_over_redact_non_final_sensitive_segment() -> None:
 
     flt.filter(record)
 
-    assert getattr(record, "password.hint") == "first pet name"
+    # Sensitive parent segment -> masked (security control is fail-closed).
+    assert getattr(record, "password.hint") == "***"
+    # No dotted boundary and not a whole sensitive key -> left visible.
     assert getattr(record, "password_hint") == "underscore form"
 
 
@@ -1132,3 +1134,89 @@ def test_redaction_dotted_key_matching_is_case_and_hyphen_insensitive() -> None:
     flt.filter(record)
 
     assert getattr(record, "Order.X-Functions-Key") == "***"
+
+
+@pytest.mark.parametrize(
+    ("parent", "leaf"),
+    [
+        ("token", "raw"),
+        ("secret", "value"),
+        ("credential", "blob"),
+        ("authorization", "header"),
+    ],
+)
+def test_redaction_masks_sensitive_parent_with_benign_leaf(parent: str, leaf: str) -> None:
+    """Regression (#302): sensitive parent + benign leaf must not leak after flatten."""
+    flatten = AttributeFlattenFilter()
+    redact = RedactionFilter()
+    record = _make_record(msg="leak")
+    setattr(record, parent, {leaf: "eyJhbGciSECRET"})
+
+    # Unsafe ordering: flatten first (produces parent.leaf), then redact.
+    flatten.filter(record)
+    redact.filter(record)
+
+    assert getattr(record, f"{parent}.{leaf}") == "***"
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"token": {"raw": "eyJhbGci"}},
+        {"secret": {"value": "hunter2"}},
+        {"credential": {"blob": "AAA"}},
+        {"order": {"password": "p@ss", "id": 7}},
+    ],
+)
+def test_redaction_filter_ordering_is_independent(payload: dict[str, object]) -> None:
+    """Regression (#302): flatten->redact and redact->flatten mask the same secrets.
+
+    The two orderings may yield different key *shapes* (nested vs dotted), but no
+    secret value may survive in either ordering.
+    """
+    secret_values = {"eyJhbGci", "hunter2", "AAA", "p@ss"}
+
+    def surviving_values(order: str) -> set[str]:
+        record = _make_record(msg="order")
+        for key, value in payload.items():
+            setattr(record, key, dict(value) if isinstance(value, dict) else value)
+        flatten = AttributeFlattenFilter()
+        redact = RedactionFilter()
+        if order == "flatten_redact":
+            flatten.filter(record)
+            redact.filter(record)
+        else:
+            redact.filter(record)
+            flatten.filter(record)
+        found: set[str] = set()
+        for value in record.__dict__.values():
+            if isinstance(value, str):
+                found.add(value)
+            elif isinstance(value, dict):
+                found.update(str(v) for v in value.values())
+        return found & secret_values
+
+    assert surviving_values("flatten_redact") == set()
+    assert surviving_values("redact_flatten") == set()
+
+
+@pytest.mark.parametrize(
+    "key",
+    [
+        "partition.key",
+        "row.key",
+        "metrics.token_count",
+        "tokenizer.name",
+        "order.id",
+        "user.name",
+    ],
+)
+def test_redaction_does_not_over_redact_benign_dotted_keys(key: str) -> None:
+    """Regression (#302): whole-segment matching must not touch benign dotted keys."""
+    flt = RedactionFilter()
+    record = _make_record(msg="benign")
+    setattr(record, key, "visible-value")
+
+    flt.filter(record)
+
+    assert getattr(record, key) == "visible-value"


### PR DESCRIPTION
## Context
`is_sensitive()` only checked the **final** dotted segment, so a sensitive **parent** with a benign leaf leaked unmasked when `AttributeFlattenFilter` ran before `RedactionFilter`, and the two orderings diverged. Reproduced on `main`:

```
flatten→redact  {'token':  {'raw': ...}}   -> token.raw       = 'eyJhbGci'  ❌ LEAK
flatten→redact  {'secret': {'value': ...}} -> secret.value    = 'hunter2'   ❌ LEAK
flatten→redact  {'credential': {'blob':.}} -> credential.blob = 'AAA'       ❌ LEAK
```

## Change
- `is_sensitive()` now matches **any** whole `.`-delimited segment against `sensitive_keys`.
- Whole-segment matching avoids substring false positives — `partition.key`, `row.key`, `metrics.token_count`, `tokenizer.name`, `order.id` stay visible.
- A benign leaf under a sensitive parent (`password.hint`) is now **fail-closed masked** — correct for a security control. Docstring updated accordingly.
- The recursive `_redact_value` path is unaffected (bare single-segment keys).

## Tests
- Parametrized regression: sensitive parent + benign leaf (`token.raw`, `secret.value`, `credential.blob`, `authorization.header`) masked after flatten.
- **Order-independence**: `flatten→redact` and `redact→flatten` leave zero secret values in either ordering.
- False-positive guard: benign dotted keys remain visible.
- Updated the former `password.hint`-stays-visible test to assert fail-closed masking.
- Full suite green, coverage **96.47%** (≥95%). lint / format / typecheck clean.

Closes #302