### PR TITLE
fix(host-config): treat Azure Monitor connection string as an OTel export signal

### DIFF
--- a/src/azure_functions_logging/_host_config.py
+++ b/src/azure_functions_logging/_host_config.py
@@ -308,6 +308,18 @@ _OTEL_GENERIC_EXPORT_ENV_VARS: tuple[str, ...] = (
 )
 
 
+# Azure Monitor export settings. ``configure_azure_monitor()`` wires its
+# exporter from ``APPLICATIONINSIGHTS_CONNECTION_STRING`` and does not set any
+# ``PYTHON_*`` or ``OTEL_*_EXPORTER`` variable, so on the Microsoft-documented
+# ``configure_azure_monitor()`` -> ``setup_logging()`` path these logs are in
+# fact exported. Treat a connection string as a "user manages export" signal so
+# 6b does not cry wolf (issue #303).
+_AZURE_MONITOR_EXPORT_ENV_VARS: tuple[str, ...] = (
+    "APPLICATIONINSIGHTS_CONNECTION_STRING",
+    "AZURE_MONITOR_CONNECTION_STRING",
+)
+
+
 def warn_otel_logging_misconfig(
     *,
     functions_formatter: logging.Formatter | None = None,
@@ -327,9 +339,11 @@ def warn_otel_logging_misconfig(
       formatter does not affect what OpenTelemetry emits. It still applies to
       any non-OTel handler that coexists on the root logger, so this is a
       heads-up rather than an absolute "formatter has no effect" claim.
-    - **6b** — an OTel handler is present but neither telemetry env var is set:
-      the host may not export these logs. Worded tentatively because the
-      environment is not fully observable from inside the worker.
+    - **6b** — an OTel handler is present but no export signal is observable
+      (no telemetry env var, no generic OTLP exporter, and no Azure Monitor
+      connection string): the host may not export these logs. Worded
+      tentatively because the environment is not fully observable from inside
+      the worker.
     - **6c** — ``host.json`` requests ``telemetryMode: OpenTelemetry`` but no
       OTel handler is attached: most often a call-order mistake. Worded as an
       ordering hint rather than a definitive "worker unconfigured" claim, so it
@@ -350,9 +364,14 @@ def warn_otel_logging_misconfig(
             stacklevel=stacklevel,
         )
 
-    # 6b: OTel handler present but neither telemetry env var is set (tentative).
+    # 6b: OTel handler present but no export signal is observable (tentative).
     if has_otel_handler and not any(
-        os.environ.get(name) for name in (*_OTEL_TELEMETRY_ENV_VARS, *_OTEL_GENERIC_EXPORT_ENV_VARS)
+        os.environ.get(name)
+        for name in (
+            *_OTEL_TELEMETRY_ENV_VARS,
+            *_OTEL_GENERIC_EXPORT_ENV_VARS,
+            *_AZURE_MONITOR_EXPORT_ENV_VARS,
+        )
     ):
         joined = " or ".join(_OTEL_TELEMETRY_ENV_VARS)
         warnings.warn(

--- a/tests/test_host_config_otel.py
+++ b/tests/test_host_config_otel.py
@@ -83,6 +83,8 @@ def _clear_otel_env(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("PYTHON_APPLICATIONINSIGHTS_ENABLE_TELEMETRY", raising=False)
     monkeypatch.delenv("OTEL_LOGS_EXPORTER", raising=False)
     monkeypatch.delenv("OTEL_TRACES_EXPORTER", raising=False)
+    monkeypatch.delenv("APPLICATIONINSIGHTS_CONNECTION_STRING", raising=False)
+    monkeypatch.delenv("AZURE_MONITOR_CONNECTION_STRING", raising=False)
 
 
 # --------------------------------------------------------------------------- #
@@ -229,6 +231,24 @@ def test_6b_silent_when_env_var_set(
 ) -> None:
     clean_root.addHandler(_FakeOtelHandler())
     monkeypatch.setenv(env_name, "1")
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        warn_otel_logging_misconfig()
+
+
+@pytest.mark.parametrize(
+    "env_name",
+    ["APPLICATIONINSIGHTS_CONNECTION_STRING", "AZURE_MONITOR_CONNECTION_STRING"],
+)
+def test_6b_silent_when_azure_monitor_connection_string_set(
+    clean_root: logging.Logger,
+    monkeypatch: pytest.MonkeyPatch,
+    env_name: str,
+) -> None:
+    """Regression (#303): configure_azure_monitor() exports via the connection
+    string and sets no PYTHON_*/OTEL_*_EXPORTER var, so 6b must stay silent."""
+    clean_root.addHandler(_FakeOtelHandler())
+    monkeypatch.setenv(env_name, "InstrumentationKey=abc;IngestionEndpoint=https://x/")
     with warnings.catch_warnings():
         warnings.simplefilter("error")
         warn_otel_logging_misconfig()


### PR DESCRIPTION
## Context
The 6b diagnostic warned "these logs may not be exported" on the Microsoft-documented order `configure_azure_monitor()` → `setup_logging()`. `configure_azure_monitor()` wires its exporter from `APPLICATIONINSIGHTS_CONNECTION_STRING` and sets none of `PYTHON_ENABLE_OPENTELEMETRY`, `PYTHON_APPLICATIONINSIGHTS_ENABLE_TELEMETRY`, `OTEL_LOGS_EXPORTER`, `OTEL_TRACES_EXPORTER` — so the warning fired even though export was correctly configured. This is the cry-wolf scenario #256 explicitly warned against.

## Change
- Add `_AZURE_MONITOR_EXPORT_ENV_VARS` (`APPLICATIONINSIGHTS_CONNECTION_STRING`, `AZURE_MONITOR_CONNECTION_STRING`) to the export-signal set checked by 6b.
- Reword the 6b docstring: "no export signal is observable" (env var, generic OTLP exporter, **or** Azure Monitor connection string).

## Tests
- Regression: OTel handler attached + connection string set + no telemetry env var → **no** UserWarning (parametrized over both connection-string vars).
- Fixture `_clear_otel_env` now also clears the two connection-string vars for isolation.
- Existing 6a/6b/6c tests unchanged and green. Coverage 96.47% (≥95%). lint / format / typecheck clean.

Closes #303