### PR TITLE
docs: soften OpenTelemetry trace-correlation gap wording

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -35,7 +35,7 @@ Azure Functions Python のロギングには、汎用的なロギングライブ
 | サードパーティロガーがうるさい | `azure-core`, `urllib3` が Application Insights を埋め尽くす | `SamplingFilter` / `RedactionFilter` |
 | ローカルとクラウドの出力不一致 | 色付き出力が本番パイプラインを壊す | 環境認識フォーマッタ自動切替 |
 | PII がログに漏洩 | extra フィールド経由で機密値が誤って記録される | キーベースの redaction を行う `RedactionFilter` |
-| ログが呼び出しトレースから分離される | Python は OpenTelemetry 呼び出しミドルウェアを内蔵しない唯一の Functions worker ランタイムのため、worker のログレコードが `span_id=0` を持つ | host の W3C trace context をバインドし、OpenTelemetry ログが呼び出しの `trace_id` / `span_id` を継承する |
+| ログが呼び出しトレースから分離される | Python は OpenTelemetry 呼び出しミドルウェアを内蔵しない唯一の Functions worker ランタイムのため、ハンドラごとに自分で span をアクティベートしない限り worker のログレコードは `span_id=0` で分離される | host の W3C trace context をバインドし、OpenTelemetry ログが呼び出しの `trace_id` / `span_id` を継承する |
 
 ## 何をするのか
 
@@ -48,9 +48,9 @@ Azure Functions Python のロギングには、汎用的なロギングライブ
 
 ## OpenTelemetry トレース相関付け
 
-> **Python は OpenTelemetry 呼び出しミドルウェアを内蔵しない唯一の Azure Functions worker ランタイムです。** host はすべての呼び出しに W3C `traceparent` を発行しますが、Python worker はそれをプロセス内でアクティベートしません — そのため worker のログレコードは `span_id=0` でスタンプされ、host の呼び出し span から分離されます。
+> **Python は OpenTelemetry 呼び出しミドルウェアを内蔵しない唯一の Azure Functions worker ランタイムです。** host はすべての呼び出しに W3C `traceparent` を発行しますが、Python worker はそれをプロセス内でアクティベートしません — そのため自分で span をアクティベートしない限り、worker のログレコードは `span_id=0` でスタンプされ、host の呼び出し span から分離されます。
 
-これは一般的な logging ライブラリが単独では埋められないギャップです。structlog、Loguru、stdlib `logging` は `trace_id` / `span_id` を付与するために OpenTelemetry の `LoggingHandler` / `LoggingInstrumentor` に依存しますが、これらはプロセス内に **アクティブな span がある場合にのみ** 機能します — Python worker はそれを提供しません。結果はどこでも同じです: `trace_id=0`、`span_id=0`、呼び出しとの相関なし。
+このギャップは手作業で埋めることは *できます* が、手間がかかり忘れやすいものです。structlog、Loguru、stdlib `logging` はいずれも OpenTelemetry の `LoggingHandler` / `LoggingInstrumentor` に依存し、これらはプロセス内に **アクティブな span がある場合にのみ** `trace_id` / `span_id` を付与します。Python worker はそれをアクティベートしないため、Microsoft が文書化しているパターンは host の `traceparent` を抽出し **すべてのハンドラで** 自分で span を開始することです。1つの経路でも忘れると、それらのレコードは静かに `span_id=0` にフォールバックします。
 
 `azure-functions-logging` はそのギャップを埋めます。`activate_trace_context=True`（`[otel]` extra が必要）でオプトインすると、ライブラリがハンドラ実行中に host の W3C trace context をバインドし、既存の OpenTelemetry ログレコードが呼び出しの `trace_id` / `span_id` を継承します:
 
@@ -64,6 +64,8 @@ with logging_context(context):
 ```
 
 これは **相関付けであってトレーシングではありません** — ライブラリは span を生成・記録・エクスポートしません。OpenTelemetry や Application Insights SDK を置き換えるのではなく補完し、span の生成は引き続きそれらの責任です。[OpenTelemetry トレース相関付けガイド](https://yeongseon.github.io/azure-functions-logging-python/opentelemetry/)を参照してください。
+
+呼び出しごとのアクティベーションを好みますか？ プロセス全体のデフォルトをスキップして直接渡します: `with logging_context(context, activate_trace_context=True):`。
 
 
 ## パイプライン概要

--- a/README.ko.md
+++ b/README.ko.md
@@ -35,7 +35,7 @@ Azure Functions Python의 logging에는 일반 logging 라이브러리가 다루
 | 시끄러운 서드파티 로거 | `azure-core`, `urllib3` 등이 Application Insights를 채움 | `SamplingFilter` / `RedactionFilter` |
 | 로컬과 클라우드 출력 불일치 | 색상 출력이 프로덕션 파이프라인을 깨뜨림 | 환경 인지 포매터 자동 전환 |
 | PII가 로그에 유출 | extra 필드를 통해 민감 값이 우발적으로 기록 | 키 기반 redaction을 수행하는 `RedactionFilter` |
-| 로그가 호출 트레이스에서 분리됨 | Python은 OpenTelemetry 호출 미들웨어가 내장되지 않은 유일한 Functions worker 런타임이라, worker 로그 레코드가 `span_id=0`을 가짐 | host의 W3C trace context를 바인딩해 OpenTelemetry 로그가 호출의 `trace_id` / `span_id`를 상속하도록 함 |
+| 로그가 호출 트레이스에서 분리됨 | Python은 OpenTelemetry 호출 미들웨어가 내장되지 않은 유일한 Functions worker 런타임이라, 핸들러마다 직접 span을 활성화하지 않으면 worker 로그 레코드가 `span_id=0`으로 분리됨 | host의 W3C trace context를 바인딩해 OpenTelemetry 로그가 호출의 `trace_id` / `span_id`를 상속하도록 함 |
 
 ## 무엇을 하는가
 
@@ -48,9 +48,9 @@ Azure Functions Python의 logging에는 일반 logging 라이브러리가 다루
 
 ## OpenTelemetry 트레이스 상관관계
 
-> **Python은 OpenTelemetry 호출 미들웨어가 내장되지 않은 유일한 Azure Functions worker 런타임입니다.** host는 모든 호출에 대해 W3C `traceparent`를 발행하지만 Python worker는 이를 프로세스 안에서 활성화하지 않습니다 — 그래서 worker 로그 레코드는 `span_id=0`으로 기록되고 host의 호출 span에서 분리됩니다.
+> **Python은 OpenTelemetry 호출 미들웨어가 내장되지 않은 유일한 Azure Functions worker 런타임입니다.** host는 모든 호출에 대해 W3C `traceparent`를 발행하지만 Python worker는 이를 프로세스 안에서 활성화하지 않습니다 — 그래서 span을 직접 활성화하지 않는 한 worker 로그 레코드는 `span_id=0`으로 기록되고 host의 호출 span에서 분리됩니다.
 
-이는 일반 logging 라이브러리가 스스로 메울 수 **없는** 간극입니다. structlog, Loguru, stdlib `logging`은 `trace_id` / `span_id`를 붙이기 위해 OpenTelemetry의 `LoggingHandler` / `LoggingInstrumentor`에 의존하지만, 이들은 프로세스에 **활성 span이 있을 때만** 동작합니다 — Python worker는 그것을 제공하지 않습니다. 결과는 어디서나 동일합니다: `trace_id=0`, `span_id=0`, 호출과의 상관관계 없음.
+직접 메꿀 수는 있지만, 수작업이고 까먹기 쉽습니다. structlog, Loguru, stdlib `logging`은 `trace_id` / `span_id`를 붙이기 위해 OpenTelemetry의 `LoggingHandler` / `LoggingInstrumentor`에 의존하지만, 이들은 프로세스에 **활성 span이 있을 때만** 동작합니다. Python worker는 span을 활성화하지 않기 때문에, Microsoft가 문서화한 패턴은 host의 `traceparent`를 추출해 **모든 핸들러에서** 직접 span을 시작하는 것입니다. 한 경로라도 놓치면 해당 레코드는 조용히 `span_id=0`으로 돌아갑니다.
 
 `azure-functions-logging`은 그 간극을 메웁니다. `activate_trace_context=True`(`[otel]` extra 필요)로 옵트인하면 라이브러리가 핸들러 실행 동안 host의 W3C trace context를 바인딩하여, 기존 OpenTelemetry 로그 레코드가 호출의 `trace_id` / `span_id`를 상속하게 합니다:
 
@@ -64,6 +64,8 @@ with logging_context(context):
 ```
 
 이는 **상관관계이지 트레이싱이 아닙니다** — 라이브러리는 결코 span을 생성, 기록, 내보내지 않습니다. OpenTelemetry나 Application Insights SDK를 대체하지 않고 보완하며, span 생성은 여전히 그들의 책임입니다. [OpenTelemetry 트레이스 상관관계 가이드](https://yeongseon.github.io/azure-functions-logging-python/opentelemetry/)를 참고하세요.
+
+호출단위 활성화를 선호하시나요? 프로세스 전역 기본값 대신 인자로 직접 전달하세요: `with logging_context(context, activate_trace_context=True):`.
 
 
 ## 파이프라인 개요

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Azure Functions Python logging has specific failure modes that generic logging l
 | Noisy third-party loggers | `azure-core`, `urllib3` flood your Application Insights | `SamplingFilter` / `RedactionFilter` |
 | Local vs cloud output mismatch | Colorized output breaks in production pipelines | Environment-aware formatter switching |
 | PII leaking into logs | Sensitive values accidentally logged as extra fields | `RedactionFilter` with key-based redaction |
-| Worker logs orphaned from the invocation trace | Python is the only Functions worker runtime without built-in OpenTelemetry invocation middleware, so worker log records carry `span_id=0` | Binds the host's W3C trace context so your OpenTelemetry logs inherit the invocation's `trace_id` / `span_id` |
+| Worker logs orphaned from the invocation trace | Python is the only Functions worker runtime without built-in OpenTelemetry invocation middleware, so worker log records are orphaned with `span_id=0` unless you activate a span in every handler yourself | Binds the host's W3C trace context so your OpenTelemetry logs inherit the invocation's `trace_id` / `span_id` |
 
 ## What it does
 
@@ -48,9 +48,9 @@ Azure Functions Python logging has specific failure modes that generic logging l
 
 ## OpenTelemetry trace correlation
 
-> **Python is the only Azure Functions worker runtime without built-in OpenTelemetry invocation middleware.** The host emits a W3C `traceparent` for every invocation, but the Python worker never activates it in-process — so worker log records are stamped with `span_id=0` and get orphaned from the host's invocation span.
+> **Python is the only Azure Functions worker runtime without built-in OpenTelemetry invocation middleware.** The host emits a W3C `traceparent` for every invocation, but the Python worker never activates it in-process — so unless you activate a span yourself, worker log records are stamped with `span_id=0` and get orphaned from the host's invocation span.
 
-This is a gap that generic logging libraries **cannot** close on their own. structlog, Loguru, and stdlib `logging` rely on OpenTelemetry's `LoggingHandler` / `LoggingInstrumentor` to attach `trace_id` / `span_id` — but those only work when there is an **active span in the process**, which the Python worker does not provide. The result is the same everywhere: `trace_id=0`, `span_id=0`, no correlation to the invocation.
+You *can* close this gap by hand, but it's manual and easy to forget. structlog, Loguru, and stdlib `logging` all rely on OpenTelemetry's `LoggingHandler` / `LoggingInstrumentor`, which only stamp `trace_id` / `span_id` when there is an **active span in the process**. Because the Python worker never activates one, Microsoft's documented pattern is to extract the host's `traceparent` and start a span yourself — in **every handler**. Miss it in one path and those records silently fall back to `span_id=0`.
 
 `azure-functions-logging` fills that gap. Opt in with `activate_trace_context=True` (requires the `[otel]` extra) and the library binds the host's W3C trace context for the duration of the handler, so your existing OpenTelemetry log records inherit the invocation's `trace_id` / `span_id`:
 
@@ -64,6 +64,8 @@ with logging_context(context):
 ```
 
 This is **correlation, not tracing** — the library never creates, records, or exports spans itself. It is complementary to (not a replacement for) OpenTelemetry or the Application Insights SDK, which remain responsible for producing spans. See the [OpenTelemetry trace correlation guide](https://yeongseon.github.io/azure-functions-logging-python/opentelemetry/).
+
+Prefer per-call activation? Skip the process-wide default and pass it directly: `with logging_context(context, activate_trace_context=True):`.
 
 
 ## Pipeline at a glance

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -35,7 +35,7 @@ Azure Functions Python 的日志记录有一些通用日志库无法处理的特
 | 嘈杂的第三方日志 | `azure-core`、`urllib3` 充斥 Application Insights | `SamplingFilter` / `RedactionFilter` |
 | 本地与云端输出不匹配 | 彩色输出在生产管道中崩溃 | 环境感知的格式化器自动切换 |
 | PII 泄露到日志 | 敏感值通过 extra 字段被意外记录 | 基于键的脱敏 `RedactionFilter` |
-| 日志与调用追踪脱离 | Python 是唯一没有内置 OpenTelemetry 调用中间件的 Functions worker 运行时，所以 worker 日志记录携带 `span_id=0` | 绑定 host 的 W3C trace context，使 OpenTelemetry 日志继承调用的 `trace_id` / `span_id` |
+| 日志与调用追踪脱离 | Python 是唯一没有内置 OpenTelemetry 调用中间件的 Functions worker 运行时，除非你在每个处理器中自行激活 span，否则 worker 日志记录会携带 `span_id=0` 而被脱离 | 绑定 host 的 W3C trace context，使 OpenTelemetry 日志继承调用的 `trace_id` / `span_id` |
 
 ## 它做什么
 
@@ -48,9 +48,9 @@ Azure Functions Python 的日志记录有一些通用日志库无法处理的特
 
 ## OpenTelemetry 追踪关联
 
-> **Python 是唯一没有内置 OpenTelemetry 调用中间件的 Azure Functions worker 运行时。** host 为每次调用发出 W3C `traceparent`，但 Python worker 从不在进程内激活它 — 因此 worker 日志记录被标记为 `span_id=0`，并与 host 的调用 span 脱离。
+> **Python 是唯一没有内置 OpenTelemetry 调用中间件的 Azure Functions worker 运行时。** host 为每次调用发出 W3C `traceparent`，但 Python worker 从不在进程内激活它 — 因此除非你自行激活 span，否则 worker 日志记录会被标记为 `span_id=0`，并与 host 的调用 span 脱离。
 
-这是通用日志库无法自行弥补的缺口。structlog、Loguru 和 stdlib `logging` 依靠 OpenTelemetry 的 `LoggingHandler` / `LoggingInstrumentor` 来附加 `trace_id` / `span_id`，但它们只有在进程中 **存在活动 span 时** 才生效 — 而 Python worker 并不提供它。结果到处都一样：`trace_id=0`、`span_id=0`、与调用无关联。
+你 *可以* 手动弥补这个缺口，但这是手工操作且容易遗忘。structlog、Loguru 和 stdlib `logging` 都依靠 OpenTelemetry 的 `LoggingHandler` / `LoggingInstrumentor`，它们只有在进程中 **存在活动 span 时** 才会附加 `trace_id` / `span_id`。由于 Python worker 从不激活 span，Microsoft 文档化的模式是提取 host 的 `traceparent` 并在 **每个处理器中** 自行启动 span。只要在一个路径中遗漏，那些记录就会静默地回退到 `span_id=0`。
 
 `azure-functions-logging` 弥补了这个缺口。通过 `activate_trace_context=True`（需要 `[otel]` extra）选择开启，库会在处理器运行期间绑定 host 的 W3C trace context，使你现有的 OpenTelemetry 日志记录继承调用的 `trace_id` / `span_id`：
 
@@ -64,6 +64,8 @@ with logging_context(context):
 ```
 
 这是 **关联，而非追踪** — 库从不创建、记录或导出 span。它补充而非替代 OpenTelemetry 或 Application Insights SDK，后者仍负责产生 span。参见 [OpenTelemetry 追踪关联指南](https://yeongseon.github.io/azure-functions-logging-python/opentelemetry/)。
+
+更倾向于按调用激活？跳过进程级默认设置，直接传入：`with logging_context(context, activate_trace_context=True):`。
 
 
 ## 流水线一览


### PR DESCRIPTION
## Context
Closes #304. PR #301's OpenTelemetry section overstated the correlation gap: phrases like "a gap that generic logging libraries **cannot** close on their own" and "The result is the same everywhere: `trace_id=0`, `span_id=0`" imply the gap is unclosable. In reality, Microsoft's documented pattern — extract the host `traceparent` and start a span per handler — *does* close it. The real friction is that this is manual boilerplate that's easy to forget in one code path.

## Changes
- Reword the "Why this exists" table row, the blockquote, and the explanation paragraph to say the gap is closable by hand but manual and easy to forget (records silently fall back to `span_id=0` when missed).
- Document the per-call activation form: `with logging_context(context, activate_trace_context=True):`.
- Synced identically across `README.md`, `README.ko.md`, `README.ja.md`, `README.zh-CN.md` (AGENTS.md translation-sync rule).

## Out of scope
- No code or behavior changes — documentation only.

## References
- #304, PR #301