### PR TITLE
feat(metadata): document logging namespace key as cross-repo ordering contract (#310)

### DIFF
--- a/src/azure_functions_logging/_metadata.py
+++ b/src/azure_functions_logging/_metadata.py
@@ -24,6 +24,18 @@ METADATA_ATTR = "_azure_functions_metadata"
 #: Namespace owned by this package.
 NAMESPACE = "logging"
 
+#: Public, stable alias for :data:`NAMESPACE`.
+#:
+#: The presence of this key inside a handler's ``_azure_functions_metadata``
+#: dict is a **stable cross-repo contract**: sibling DX Toolkit decorators (e.g.
+#: ``@validate_http`` in ``azure-functions-validation``) may inspect it, using
+#: the literal string ``"logging"``, to detect decorator ordering *without
+#: importing this package*. In particular, when ``@validate_http`` receives a
+#: function that already carries this key, ``@with_context`` was applied first
+#: (inner), which is the wrong order (see logging#310). Do not rename this key
+#: without a coordinated change across the toolkit.
+LOGGING_METADATA_KEY = NAMESPACE
+
 #: Schema version for the ``logging`` namespace payload.
 LOGGING_METADATA_VERSION = 1
 
@@ -52,6 +64,9 @@ def set_logging_metadata(
     ``logging`` namespace, and writes the result onto ``wrapper`` only. The
     original ``func`` is left untouched so the metadata never leaks onto
     undecorated references.
+
+    Writing the ``"logging"`` key here is also what makes cross-repo decorator
+    ordering detection possible: see :data:`LOGGING_METADATA_KEY`.
     """
     existing = getattr(func, METADATA_ATTR, None)
     base: dict[str, Any] = dict(existing) if isinstance(existing, dict) else {}

--- a/tests/test_metadata_contract.py
+++ b/tests/test_metadata_contract.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from azure_functions_logging._metadata import (
+    LOGGING_METADATA_KEY,
     LOGGING_METADATA_VERSION,
     METADATA_ATTR,
     NAMESPACE,
@@ -98,3 +99,42 @@ class TestReadLoggingMetadata:
 
         setattr(func, METADATA_ATTR, {"logging": "not-a-dict"})
         assert read_logging_metadata(func) is None
+
+
+class TestOrderingDetectionContract:
+    """The ``"logging"`` key is a stable marker sibling packages inspect.
+
+    See logging#310 and the validation-repo follow-up for the full cross-repo
+    decorator-ordering contract.
+    """
+
+    def test_key_alias_matches_namespace(self) -> None:
+        assert LOGGING_METADATA_KEY == NAMESPACE == "logging"
+
+    def test_with_context_publishes_detectable_marker(self) -> None:
+        """After ``@with_context``, the shared attr carries the ``"logging"`` key.
+
+        This is the contract that lets ``@validate_http`` (in the validation
+        package) detect the wrong decorator order without importing this
+        package — it checks for exactly this key on the function it receives.
+        """
+        from azure_functions_logging import with_context
+
+        @with_context
+        def handler(req: object, context: object) -> None:
+            pass
+
+        meta = getattr(handler, METADATA_ATTR)
+        assert LOGGING_METADATA_KEY in meta
+        assert meta[LOGGING_METADATA_KEY]
+
+    def test_with_context_marker_present_async(self) -> None:
+        from azure_functions_logging import with_context
+
+        @with_context
+        async def handler(req: object, context: object) -> None:
+            pass
+
+        meta = getattr(handler, METADATA_ATTR)
+        assert LOGGING_METADATA_KEY in meta
+        assert meta[LOGGING_METADATA_KEY]


### PR DESCRIPTION
## Summary
Implements the **contract half** of #310 (umbrella #270). Per Oracle design gate, the wrong `@with_context` / `@validate_http` order **cannot be reliably detected from `with_context`** without false positives (a solo `@with_context` is indistinguishable from the wrong-order case at decoration time). The authoritative `RuntimeWarning` therefore lands in the **validation** repo, keyed off the shared metadata contract this PR stabilizes.

This PR:
- Adds `LOGGING_METADATA_KEY` (public, stable alias for the `"logging"` namespace) with a docstring declaring it a cross-repo ordering-detection contract.
- Notes in `set_logging_metadata` that writing the `"logging"` key is what enables cross-repo ordering detection.
- Adds `TestOrderingDetectionContract` proving `@with_context` publishes the `"logging"` marker on both sync and async handlers.

## Design rationale
`@validate_http` (validation repo) detects the wrong order by checking `func._azure_functions_metadata` for the `"logging"` key — using the literal string, **no import** of this package. When present, `@with_context` was applied inner (wrong order). No false positives: solo `@validate_http` sees no `"logging"` key; solo `@with_context` never hits that path.

## Verification
- `make check-all` green — 441 passed, coverage 96.47% (gate 95%), ruff + mypy strict + bandit clean.

## Follow-up
A separate validation-repo PR emits the actual `RuntimeWarning` using this contract.

Refs #310 #270