### PR TITLE
fix(otel): skip attaching invalid extracted span context

### DIFF
--- a/src/azure_functions_logging/_otel.py
+++ b/src/azure_functions_logging/_otel.py
@@ -79,6 +79,8 @@ def activated_trace_context(
 
     * *trace_parent* is empty/``None``;
     * OpenTelemetry is not installed (:func:`is_available` is ``False``);
+    * the extracted span context is invalid (a no-op span) -- attaching it
+      would break the trace tree, so the current context is left untouched;
     * extraction/attach fails for any reason (malformed header, etc.).
 
     Args:
@@ -91,6 +93,7 @@ def activated_trace_context(
 
     try:
         from opentelemetry import context as otel_context
+        from opentelemetry import trace as otel_trace
         from opentelemetry.propagate import extract as otel_extract
     except Exception:  # nosec B110 — optional dependency; degrade to no-op
         yield
@@ -102,7 +105,14 @@ def activated_trace_context(
 
     token = None
     try:
-        token = otel_context.attach(otel_extract(carrier))
+        extracted = otel_extract(carrier)
+        # Only attach a valid remote span context. An invalid/no-op span
+        # context (e.g. the host emitted no real trace) must not be attached,
+        # otherwise downstream log records get parented to an invalid context
+        # and the trace tree breaks. Leave the current context untouched.
+        span_context = otel_trace.get_current_span(extracted).get_span_context()
+        if span_context.is_valid:
+            token = otel_context.attach(extracted)
     except Exception:  # nosec B110 — Principle 3: context failures are silent
         token = None
 

--- a/tests/test_otel.py
+++ b/tests/test_otel.py
@@ -21,6 +21,9 @@ from azure_functions_logging import _otel
 _TRACE_ID_HEX = "4bf92f3577b34da6a3ce929d0e0e4736"
 _PARENT_ID_HEX = "00f067aa0ba902b7"
 _TRACEPARENT = f"00-{_TRACE_ID_HEX}-{_PARENT_ID_HEX}-01"
+# All-zero trace-id/span-id: structurally well-formed but an INVALID (no-op)
+# span context once extracted.
+_INVALID_TRACEPARENT = "00-00000000000000000000000000000000-0000000000000000-00"
 
 
 @pytest.fixture(autouse=True)
@@ -94,6 +97,36 @@ def test_activated_trace_context_survives_malformed_traceparent() -> None:
     # A structurally invalid traceparent must never raise out of the CM.
     with _otel.activated_trace_context("not-a-valid-traceparent"):
         pass
+
+
+def test_activated_trace_context_skips_invalid_span_context() -> None:
+    # An extracted but INVALID (no-op) span context must not be attached;
+    # attaching it would parent downstream records to an invalid context and
+    # break the trace tree. The current context must be left untouched.
+    pytest.importorskip("opentelemetry.context")
+    from opentelemetry import trace
+
+    assert not trace.get_current_span().get_span_context().is_valid
+    with _otel.activated_trace_context(_INVALID_TRACEPARENT):
+        assert not trace.get_current_span().get_span_context().is_valid
+    assert not trace.get_current_span().get_span_context().is_valid
+
+
+def test_activated_trace_context_invalid_preserves_existing_context() -> None:
+    # A nested activation with an invalid traceparent must NOT detach or clear
+    # an already-active valid host span context (Oracle risk: no accidental
+    # clobber of the surrounding context).
+    pytest.importorskip("opentelemetry.context")
+    from opentelemetry import trace
+
+    with _otel.activated_trace_context(_TRACEPARENT):
+        assert trace.get_current_span().get_span_context().is_valid
+        with _otel.activated_trace_context(_INVALID_TRACEPARENT):
+            inner = trace.get_current_span().get_span_context()
+            assert inner.is_valid
+            assert format(inner.trace_id, "032x") == _TRACE_ID_HEX
+        assert trace.get_current_span().get_span_context().is_valid
+    assert not trace.get_current_span().get_span_context().is_valid
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
`activated_trace_context` attached whatever `opentelemetry.propagate.extract` returned from the host `traceparent`, without checking span validity. When the host emits no real trace (an invalid/no-op span context), attaching it parents downstream log records to an invalid context and breaks the trace tree under `telemetryMode: OpenTelemetry`.

- Guard the attach with `get_current_span(extracted).get_span_context().is_valid`: only attach a valid remote span context; otherwise leave the current context untouched (silent no-op, no detach).
- Preserves the package's Principle 3 (context failures are silent) — no warning by default, since an invalid/absent trace context is normal host behavior.

## Tests
- `test_activated_trace_context_skips_invalid_span_context` — invalid traceparent is not attached, current context stays invalid.
- `test_activated_trace_context_invalid_preserves_existing_context` — a nested invalid activation does not clobber an already-active valid host span context.
- `make test` (456 passed, 4 skipped, 96.58% coverage), `make lint`, `make typecheck` all green.