### PR TITLE
chore: drop stale noqa on opentelemetry.context import

### DIFF
--- a/src/azure_functions_logging/_otel.py
+++ b/src/azure_functions_logging/_otel.py
@@ -44,7 +44,7 @@ def is_available() -> bool:
     if _available is not None:
         return _available
     try:
-        import opentelemetry.context  # noqa: F401
+        import opentelemetry.context
         import opentelemetry.propagate  # noqa: F401
     except Exception:  # nosec B110 — optional dependency; absence is expected
         _available = False


### PR DESCRIPTION
## Context

A static-analysis pass (ruff `RUF100`) flagged the `# noqa: F401` on the `opentelemetry.context` probe import in `_otel.py` as an **unused** suppression — the module is referenced elsewhere in the file, so `F401` never fires there and the noqa is dead.

## Change

Drop the redundant `# noqa: F401` from the `opentelemetry.context` import. The `opentelemetry.propagate` import **keeps** its noqa: that one is a genuine availability-probe import with no other use, so `F401` correctly applies.

```diff
-        import opentelemetry.context  # noqa: F401
+        import opentelemetry.context
         import opentelemetry.propagate  # noqa: F401
```

## Verification
- `make check-all` — fully green (lint/typecheck/tests/security), coverage unchanged.

## Acceptance Checklist
- [x] Stale noqa removed
- [x] Genuine probe noqa preserved
- [x] `make check-all` green