### PR TITLE
ci: add tiered pre-publish runtime gate with real-Azure certification

### DIFF
--- a/.github/workflows/e2e-azure.yml
+++ b/.github/workflows/e2e-azure.yml
@@ -1,10 +1,20 @@
 name: e2e-azure
 
+# Azure Release Certification. Dispatch-only: deploys to real Azure, runs live
+# e2e, and records an azure-cert artifact for the exact release commit + version.
+# The publish-pypi.yml verify-azure-certification gate requires a fresh, matching
+# certification before it will publish.
 on:
-  push:
-    tags:
-      - 'v*'
   workflow_dispatch:
+    inputs:
+      ref:
+        description: Release commit SHA (or ref) to certify
+        required: false
+        type: string
+      version:
+        description: Expected package version (must match source __version__)
+        required: false
+        type: string
 
 permissions:
   id-token: write
@@ -27,6 +37,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: ${{ inputs.ref || github.ref }}
 
       - name: Compute resource names
         id: names
@@ -112,6 +124,39 @@ jobs:
           E2E_BASE_URL: https://${{ steps.names.outputs.app }}.azurewebsites.net
           APPINSIGHTS_NAME: ${{ steps.names.outputs.ai }}
           E2E_RESOURCE_GROUP: ${{ steps.names.outputs.rg }}
+
+      - name: Record certification
+        run: |
+          SHA=$(git rev-parse HEAD)
+          FILE_VERSION=$(grep -Po '(?<=__version__ = ")[^"]*' src/azure_functions_logging/__init__.py)
+          REQ_VERSION="${{ inputs.version }}"
+          if [ -n "$REQ_VERSION" ] && [ "$REQ_VERSION" != "$FILE_VERSION" ]; then
+            echo "::error ::Requested certification version ($REQ_VERSION) != source version ($FILE_VERSION)"
+            exit 1
+          fi
+          VERSION="${REQ_VERSION:-$FILE_VERSION}"
+          mkdir -p cert
+          cat > cert/certification.json <<EOF
+          {
+            "package": "azure-functions-logging",
+            "version": "$VERSION",
+            "commit": "$SHA",
+            "ref": "${{ inputs.ref || github.ref }}",
+            "workflow": "e2e-azure.yml",
+            "run_id": "${{ github.run_id }}",
+            "result": "success",
+            "certified_at": "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          }
+          EOF
+          cat cert/certification.json
+
+      - name: Upload certification record
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: azure-cert
+          path: cert/
+          if-no-files-found: error
+          retention-days: 30
 
       - name: Upload e2e report
         if: always()

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -14,13 +14,32 @@ on:
 
 permissions:
   contents: read
-  id-token: write
 
+# Verify-before-publish gate (see AGENTS.md):
+#   build -> lib-tests -> cookbook-smoke -> cookbook-host-smoke
+#         -> verify-azure-certification -> publish
+# Tiered runtime verification before any PyPI upload:
+#   * lib-tests            : the library's own unit suite (against the built wheel).
+#   * cookbook-smoke       : downstream module-import checks (catches registration/import drift).
+#   * cookbook-host-smoke  : install the candidate wheel into the cookbook, then boot a real func
+#                            host + Azurite and run the cookbook HTTP e2e. This proves the candidate
+#                            installs cleanly and the Functions host starts with it present in the
+#                            environment. NOTE: the cookbook HTTP examples do not import this package,
+#                            so this tier is a host-boot smoke, NOT proof of this package's own runtime
+#                            behavior. Package-native runtime coverage is tracked separately.
+#   * verify-azure-certification : requires the EXACT release commit to have passed a real-Azure
+#                            deploy+live-e2e certification (e2e-azure.yml) that is fresh and
+#                            version/SHA-matched. Real Azure is certified per release, not per publish.
+# The publish job uploads the EXACT artifact that was tested; it never rebuilds.
+# A tag whose gate fails is a failed release candidate: the version stays
+# unpublished. Recover by fixing forward and cutting the next patch tag
+# (never move a tag that may already have been consumed).
 jobs:
-  build-and-publish:
+  build:
+    name: Build & verify version
     runs-on: ubuntu-latest
-    environment: pypi
-
+    outputs:
+      version: ${{ steps.version.outputs.version }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
@@ -38,6 +57,7 @@ jobs:
           pip install build
 
       - name: Check if tag matches __version__
+        id: version
         run: |
           TAG_NAME="${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}"
           VERSION_FROM_FILE=$(grep -Po '(?<=__version__ = ")[^"]*' src/azure_functions_logging/__init__.py)
@@ -49,9 +69,240 @@ jobs:
             echo "::error ::Version in __init__.py ($VERSION_FROM_FILE) does not match git tag ($TAG_VERSION)"
             exit 1
           fi
+          echo "version=$TAG_VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Build distribution packages
         run: python -m build
+
+      - name: Upload distribution artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: dist
+          path: dist/
+          if-no-files-found: error
+          retention-days: 5
+
+  lib-tests:
+    name: Library tests
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref }}
+
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+
+      - name: Install Hatch
+        run: pip install hatch
+
+      - name: Run test suite
+        run: hatch run test
+
+  cookbook-smoke:
+    name: Cookbook dogfood smoke (candidate wheel)
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout cookbook (downstream consumer)
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+        with:
+          repository: yeongseon/azure-functions-cookbook-python
+          ref: main
+
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.10"
+
+      - name: Download candidate wheel
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: dist
+          path: candidate-dist
+
+      - name: Install cookbook environment
+        run: |
+          pip install hatch
+          make install
+
+      - name: Install candidate wheel over the PyPI floor
+        run: |
+          WHEEL=$(ls candidate-dist/*.whl | head -n1)
+          echo "Installing candidate wheel: $WHEEL"
+          hatch run pip install --force-reinstall --no-deps "$WHEEL"
+
+      - name: Verify candidate version is under test
+        run: |
+          EXPECTED="${{ needs.build.outputs.version }}"
+          ACTUAL=$(hatch run python -c "import importlib.metadata as m; print(m.version('azure-functions-logging'))")
+          echo "Expected candidate version: $EXPECTED"
+          echo "Installed version:          $ACTUAL"
+          if [ "$EXPECTED" != "$ACTUAL" ]; then
+            echo "::error ::Cookbook is not exercising the candidate wheel ($ACTUAL != $EXPECTED)"
+            exit 1
+          fi
+
+      - name: Run cookbook smoke tests against candidate
+        run: hatch run smoke
+
+  cookbook-host-smoke:
+    name: Cookbook host-boot smoke (func + Azurite, candidate wheel)
+    needs: build
+    runs-on: ubuntu-latest
+    env:
+      # Pin Core Tools; bump only after a verified run. npm is Microsoft's
+      # documented v4 install path (see e2e-azure.yml for rationale).
+      FUNCTIONS_CORE_TOOLS_VERSION: "4.12.0"
+    steps:
+      - name: Checkout cookbook (downstream consumer)
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+        with:
+          repository: yeongseon/azure-functions-cookbook-python
+          ref: main
+
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.10"
+
+      - name: Set up Node.js (func Core Tools + Azurite)
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: "22"
+
+      - name: Install Azure Functions Core Tools + Azurite
+        run: |
+          npm install -g "azure-functions-core-tools@${FUNCTIONS_CORE_TOOLS_VERSION}" azurite
+          func --version
+          azurite --version
+
+      - name: Download candidate wheel
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: dist
+          path: candidate-dist
+
+      - name: Install cookbook environment
+        run: |
+          pip install hatch
+          make install
+
+      - name: Install candidate wheel over the PyPI floor
+        run: |
+          WHEEL=$(ls candidate-dist/*.whl | head -n1)
+          echo "Installing candidate wheel: $WHEEL"
+          hatch run pip install --force-reinstall --no-deps "$WHEEL"
+
+      - name: Verify candidate version is under test
+        run: |
+          EXPECTED="${{ needs.build.outputs.version }}"
+          ACTUAL=$(hatch run python -c "import importlib.metadata as m; print(m.version('azure-functions-logging'))")
+          echo "Expected candidate version: $EXPECTED"
+          echo "Installed version:          $ACTUAL"
+          if [ "$EXPECTED" != "$ACTUAL" ]; then
+            echo "::error ::Cookbook is not exercising the candidate wheel ($ACTUAL != $EXPECTED)"
+            exit 1
+          fi
+
+      - name: Boot cookbook func host with candidate wheel (host-smoke)
+        run: hatch run e2e tests/e2e/test_http_examples.py
+        timeout-minutes: 15
+
+  verify-azure-certification:
+    name: Verify Azure release certification
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref }}
+
+      - name: Resolve release commit
+        id: commit
+        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Locate successful Azure certification for this commit
+        id: cert
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          COMMIT: ${{ steps.commit.outputs.sha }}
+        run: |
+          # A release may only publish if the EXACT commit was certified against
+          # real Azure by the trusted certification workflow (see e2e-azure.yml).
+          RUN_ID=$(gh run list \
+            --workflow e2e-azure.yml \
+            --json databaseId,headSha,conclusion \
+            --limit 50 \
+            --jq "[.[] | select(.headSha==\"$COMMIT\" and .conclusion==\"success\")] | first | .databaseId")
+          if [ -z "$RUN_ID" ] || [ "$RUN_ID" = "null" ]; then
+            echo "::error ::No successful Azure certification run found for commit $COMMIT. Dispatch the 'e2e-azure' workflow on this release commit before publishing."
+            exit 1
+          fi
+          echo "Found certification run: $RUN_ID"
+          echo "run_id=$RUN_ID" >> "$GITHUB_OUTPUT"
+
+      - name: Download certification record
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: azure-cert
+          path: cert
+          run-id: ${{ steps.cert.outputs.run_id }}
+          github-token: ${{ github.token }}
+
+      - name: Assert certification matches this release
+        env:
+          COMMIT: ${{ steps.commit.outputs.sha }}
+          VERSION: ${{ needs.build.outputs.version }}
+          FRESHNESS_DAYS: "14"
+        run: |
+          python3 - "$COMMIT" "$VERSION" "$FRESHNESS_DAYS" <<'PY'
+          import json, sys, datetime, pathlib
+          commit, version, fresh_days = sys.argv[1], sys.argv[2], int(sys.argv[3])
+          cert = json.loads(pathlib.Path("cert/certification.json").read_text())
+          def fail(m):
+              print(f"::error ::{m}")
+              sys.exit(1)
+          if cert.get("result") != "success":
+              fail("certification result is not success")
+          if cert.get("package") != "azure-functions-logging":
+              fail(f"cert package {cert.get('package')} != azure-functions-logging")
+          if cert.get("commit") != commit:
+              fail(f"cert commit {cert.get('commit')} != release commit {commit}")
+          if cert.get("version") != version:
+              fail(f"cert version {cert.get('version')} != release version {version}")
+          ts = cert.get("certified_at")
+          if not ts:
+              fail("cert missing certified_at")
+          certified = datetime.datetime.fromisoformat(ts.replace("Z", "+00:00"))
+          age = datetime.datetime.now(datetime.timezone.utc) - certified
+          if age > datetime.timedelta(days=fresh_days):
+              fail(f"certification is stale: {age.days}d > {fresh_days}d")
+          print(f"Azure certification verified: {version}@{commit[:12]} certified {age.days}d ago")
+          PY
+
+  publish:
+    name: Publish to PyPI
+    needs: [build, lib-tests, cookbook-smoke, cookbook-host-smoke, verify-azure-certification]
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write
+    steps:
+      - name: Download tested distribution artifact
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: dist
+          path: dist
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,8 +91,25 @@ When splitting a large piece of work into focused issues, keep the umbrella open
 ### Flow
 1. `make release-patch` (or `-minor` / `-major`) on `main`
 2. This runs: `hatch version` → `git commit` → `make changelog` → `git commit` → `git tag` → `git push`
-3. Tag push triggers **Publish to PyPI** GitHub Actions workflow automatically.
+3. Tag push triggers the **Publish to PyPI** GitHub Actions workflow. **Verification is a pre-publish gate, not a post-publish check.** The `publish` job runs only after `build → lib-tests → cookbook-smoke → cookbook-host-smoke → verify-azure-certification` all pass, and it uploads the exact artifact that was tested (it never rebuilds).
 4. Update `docs/changelog.md` separately if needed (different format from `CHANGELOG.md`).
+
+### Tiered runtime verification (what gates a release)
+
+Release verification is layered; each tier catches a different failure class, and **every tier is a pre-publish gate**:
+
+| Tier | Runs where | Catches |
+| --- | --- | --- |
+| `lib-tests` | publish-pypi.yml (per publish) | library unit regressions |
+| `cookbook-smoke` | publish-pypi.yml (per publish) | downstream import/registration drift |
+| `cookbook-host-smoke` | publish-pypi.yml (per publish) | candidate wheel installs cleanly and a real `func` host + Azurite boots with it present, no cloud. NOTE: the cookbook HTTP examples do not import this package, so this is a host-boot smoke, **not** proof of this package's own runtime behavior (tracked separately) |
+| `verify-azure-certification` | publish-pypi.yml (per publish) | requires a fresh, SHA+version-matched **real-Azure** certification for the exact release commit |
+| Azure Release Certification (`e2e-azure.yml`) | `workflow_dispatch`, per release | cloud-only drift — deploys to real Azure, runs live e2e, records a certification artifact. **Certified per release, not per publish.** |
+
+**Real-Azure certification (required once per release, before the final tag).** Before pushing the release tag, dispatch the **e2e-azure** workflow on the exact release commit and version:
+- `gh workflow run e2e-azure.yml --ref main -f ref=<release-sha> -f version=<x.y.z>`
+- The run deploys to real Azure, executes the live e2e suite, and uploads the `azure-cert` artifact (keyed by commit SHA + version).
+- `verify-azure-certification` in `publish-pypi.yml` later requires a successful, SHA+version-matched, non-stale (<14 day) certification for the release commit; without it the publish gate fails and the version stays unpublished.
 5. **Verify the release against the dogfood cookbook.** Once **Publish to PyPI** succeeds, confirm the downstream consumer still passes on the freshly published version:
    - In [`azure-functions-cookbook-python`](https://github.com/yeongseon/azure-functions-cookbook-python), upgrade to the new release (`hatch run pip install -U "azure-functions-logging>=X.Y,<1"`) and run `make test`.
    - Treat any new `RuntimeWarning`/`DeprecationWarning` surfaced by this library during the cookbook run as a release-blocking signal — decorator-order and API-drift problems are reported as warnings, so a clean run (zero warnings from this package) is part of the release gate.


### PR DESCRIPTION
## Context

Ports the tiered pre-publish runtime verification gate piloted on `azure-functions-validation` (yeongseon/azure-functions-validation#301, #302) to this repo. Part of the DX Toolkit rollout umbrella. Per the rollout decision, gate workflows are **vendored per-repo** (no reusable workflows / composite actions), so each repo keeps its own copy with pinned action SHAs kept identical across the toolkit.

Principle: **no version reaches PyPI without runtime verification**, and each release is certified against real Azure at least once.

## What changed

- **`publish-pypi.yml`** restructured from a single build-and-publish job into a verify-before-publish gate:
  `build → lib-tests → cookbook-smoke → cookbook-host-smoke → verify-azure-certification → publish`.
  The `publish` job downloads and uploads the **exact artifact that was tested** — it never rebuilds.
- **`cookbook-host-smoke`** installs the candidate wheel into the dogfood cookbook, asserts the installed version equals the candidate, then boots a real `func` host + Azurite. Honestly scoped: the cookbook HTTP examples do not import this package, so this is a host-boot smoke (install/dependency-resolution regression catch), **not** proof of this package's own runtime behavior — package-native HTTP e2e is tracked separately.
- **`e2e-azure.yml`** retrofitted to **dispatch-only** Azure Release Certification: deploys to real Azure, runs live e2e, and records a SHA+version-matched `azure-cert` artifact consumed by `verify-azure-certification`. No longer triggers on tag push (which used to race the publish and could not gate it).
- **`AGENTS.md`** documents the tiered model and the once-per-release real-Azure certification step.

## Acceptance Checklist

- [x] Job graph: `build → lib-tests → cookbook-smoke → cookbook-host-smoke → verify-azure-certification → publish`
- [x] `publish` downloads the tested `dist` artifact and never rebuilds
- [x] Each runtime tier asserts the installed version equals the candidate wheel version
- [x] `e2e-azure.yml` is dispatch-only and records a matching `azure-cert` record
- [x] `verify-azure-certification` requires a fresh (<14d), SHA+version-matched certification
- [x] Workflow YAML validated (`yaml.safe_load`)
- [ ] First real exercise occurs on the next release tag (vendored gate jobs are tag-triggered, so they do not run on this PR)

## Out of scope

- Package-native HTTP e2e for this package (deferred; tracked in cookbook #146).
- Drift lint across vendored copies (Phase C).

## References

- Pilot: yeongseon/azure-functions-validation#301, #302
- Sibling rollout PRs: db #229, doctor #256