### PR TITLE
ci: normalize release-gate action pins to canonical SHAs

### DIFF
--- a/.github/workflows/e2e-azure.yml
+++ b/.github/workflows/e2e-azure.yml
@@ -36,7 +36,7 @@ jobs:
       appinsights_name: ${{ steps.names.outputs.ai }}
 
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ inputs.ref || github.ref }}
 
@@ -160,7 +160,7 @@ jobs:
 
       - name: Upload e2e report
         if: always()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: e2e-report-${{ github.run_id }}-${{ github.run_attempt }}
           path: e2e-report/

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -42,7 +42,7 @@ jobs:
       version: ${{ steps.version.outputs.version }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref }}
 
@@ -88,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref }}
 
@@ -109,7 +109,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout cookbook (downstream consumer)
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: yeongseon/azure-functions-cookbook-python
           ref: main
@@ -160,7 +160,7 @@ jobs:
       FUNCTIONS_CORE_TOOLS_VERSION: "4.12.0"
     steps:
       - name: Checkout cookbook (downstream consumer)
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: yeongseon/azure-functions-cookbook-python
           ref: main
@@ -222,7 +222,7 @@ jobs:
       actions: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref }}
 


### PR DESCRIPTION
## Summary
- Normalize `actions/checkout` (and `actions/setup-python` where drifted) annotations to canonical (`# v7.0.1` / `# v7.0.0`); SHAs unchanged.
- Normalize `actions/upload-artifact` `043fb46d # v7.0.1` → `ea165f8d # v4`, keeping it major-paired with `download-artifact@v4`.
- `azure/login` already at canonical `f5d393ae # v3.0.1`.

Closes #325 · Refs yeongseon/azure-functions-validation-python#306