### PR TITLE
docs(i18n): adopt best-effort translation policy with staleness banners

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,9 +27,9 @@
 - Keep documentation examples and tests synchronized with any behavior changes.
 
 ### Documentation & Translations
-- When a change touches `README.md` or any English documentation, update the translated READMEs (`README.ko.md`, `README.ja.md`, `README.zh-CN.md`) **in the same PR** so translations never drift from the English source.
-- This applies to any code change that alters documented behavior, CLI output, or the ecosystem/package table — not just direct edits to prose.
-- If a full translation cannot land in the same PR, add a short "translation pending" note to the affected translated file and open a tracking issue before merging.
+- English (`README.md`) is the **canonical** source of truth for all documentation. Translated READMEs (`README.ko.md`, `README.ja.md`, `README.zh-CN.md`) are **best-effort**, community-maintained, and may lag the English source.
+- Translation sync is **not** required in the same PR as an English change, and a PR is **never** blocked by translation drift. Update translations opportunistically; when you do, keep them faithful to the current English source.
+- Each translated README carries a staleness banner linking back to the canonical English README. Keep that banner in place so readers always know the translation may be out of date.
 
 ## Issue Conventions
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -15,6 +15,8 @@
 
 他の言語で読む: [English](README.md) | [한국어](README.ko.md) | [简体中文](README.zh-CN.md)
 
+> ℹ️ この翻訳はコミュニティによる参考用であり、最新の [English README](README.md) より古い場合があります。正確な最新情報は英語版を参照してください。
+
 **Azure Functions Python v2 のための、呼び出し（invocation）認識可能なオブザーバビリティ。**
 `invocation_id` を表面化し、コールドスタートを検出し、`host.json` の設定不備を警告し、Application Insights にすぐに使える構造化ログを出力します — Python 標準の `logging` を置き換えることなく。
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -15,6 +15,8 @@
 
 다른 언어로 보기: [English](README.md) | [日本語](README.ja.md) | [简体中文](README.zh-CN.md)
 
+> ℹ️ 이 번역은 커뮤니티가 관리하는 참고용 문서로, 최신 [English README](README.md)보다 뒤처질 수 있습니다. 정확한 최신 정보는 영어 원문을 기준으로 하세요.
+
 **Azure Functions Python v2를 위한 호출(invocation) 인지 가능한 관측성(observability).**
 `invocation_id`를 노출하고, cold start를 감지하며, `host.json` 설정 오류를 경고하고, Application Insights에 바로 사용 가능한 구조화된 로그를 출력합니다 — Python 표준 `logging`을 대체하지 않습니다.
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -15,6 +15,8 @@
 
 阅读其他语言版本: [English](README.md) | [한국어](README.ko.md) | [日本語](README.ja.md)
 
+> ℹ️ 本翻译由社区维护，仅供参考，可能落后于最新的 [English README](README.md)。请以英文版为准。
+
 **面向 Azure Functions Python v2 的、感知调用（invocation-aware）的可观测性。**
 暴露 `invocation_id`，检测冷启动，对 `host.json` 错误配置发出警告，并输出可直接用于 Application Insights 的结构化日志 — 不替换 Python 标准 `logging`。
 


### PR DESCRIPTION
## Context
Closes #329. Fleet rollout of the best-effort translation policy from azure-functions-validation#314 (Option B): English README is canonical, translations are best-effort and may lag, and a PR is never blocked by translation drift. No translations are deleted.

## Changes
- AGENTS.md: rewrite Documentation & Translations to the best-effort policy.
- README.ko.md / README.ja.md / README.zh-CN.md: add a localized staleness banner linking to the canonical README.md.