### PR TITLE
docs: consolidate official documentation URL onto yeongseon.dev

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -10,7 +10,7 @@
 [![Security Scans](https://github.com/yeongseon/azure-functions-logging-python/actions/workflows/security.yml/badge.svg)](https://github.com/yeongseon/azure-functions-logging-python/actions/workflows/security.yml)
 [![codecov](https://codecov.io/gh/yeongseon/azure-functions-logging-python/branch/main/graph/badge.svg)](https://codecov.io/gh/yeongseon/azure-functions-logging-python)
 [![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit)](https://pre-commit.com/)
-[![Docs](https://img.shields.io/badge/docs-gh--pages-blue)](https://yeongseon.github.io/azure-functions-logging-python/)
+[![Docs](https://img.shields.io/badge/docs-yeongseon.dev-blue)](https://yeongseon.dev/azure-functions-python/logging/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
 他の言語で読む: [English](README.md) | [한국어](README.ko.md) | [简体中文](README.zh-CN.md)
@@ -65,7 +65,7 @@ with logging_context(context):
     logger.info("processing")  # OpenTelemetry レコードが呼び出しの trace_id / span_id を継承
 ```
 
-これは **相関付けであってトレーシングではありません** — ライブラリは span を生成・記録・エクスポートしません。OpenTelemetry や Application Insights SDK を置き換えるのではなく補完し、span の生成は引き続きそれらの責任です。[OpenTelemetry トレース相関付けガイド](https://yeongseon.github.io/azure-functions-logging-python/opentelemetry/)を参照してください。
+これは **相関付けであってトレーシングではありません** — ライブラリは span を生成・記録・エクスポートしません。OpenTelemetry や Application Insights SDK を置き換えるのではなく補完し、span の生成は引き続きそれらの責任です。[OpenTelemetry トレース相関付けガイド](https://yeongseon.dev/azure-functions-python/logging/opentelemetry/)を参照してください。
 
 呼び出しごとのアクティベーションを好みますか？ プロセス全体のデフォルトをスキップして直接渡します: `with logging_context(context, activate_trace_context=True):`。
 
@@ -200,7 +200,7 @@ traces
 このパッケージは以下を所有しません:
 
 - **stdlib logging の置き換え** — Python 標準の `logging` をラップして強化するだけで、決して置き換えません
-- **分散トレーシング** — Azure Functions ホストの W3C トレースコンテキストを**バインド**して、既存の OpenTelemetry ログレコードが呼び出し span の `trace_id` / `span_id` を継承するようにしますが、このライブラリ自身が span を作成・記録・エクスポートすることはありません — トレーシングではなく相関（correlation）です。span の生成には OpenTelemetry または Application Insights SDK を使用してください。[OpenTelemetry トレース相関](https://yeongseon.github.io/azure-functions-logging-python/opentelemetry/) を参照
+- **分散トレーシング** — Azure Functions ホストの W3C トレースコンテキストを**バインド**して、既存の OpenTelemetry ログレコードが呼び出し span の `trace_id` / `span_id` を継承するようにしますが、このライブラリ自身が span を作成・記録・エクスポートすることはありません — トレーシングではなく相関（correlation）です。span の生成には OpenTelemetry または Application Insights SDK を使用してください。[OpenTelemetry トレース相関](https://yeongseon.dev/azure-functions-python/logging/opentelemetry/) を参照
 - **API ドキュメント** — API ドキュメントと spec 生成には [`azure-functions-openapi`](https://github.com/yeongseon/azure-functions-openapi-python) を使用してください
 
 ## インストール
@@ -280,7 +280,7 @@ curl -s "https://<your-app>.azurewebsites.net/api/logme?correlation_id=demo-123"
 
 ## 主要機能
 
-以下の各機能には [ドキュメントサイト](https://yeongseon.github.io/azure-functions-logging-python/) に完全なガイドがあります。このセクションは各機能が何をするかを要約して単一の情報源にリンクし、README がドキュメントのコピーではなく簡潔な概要として保たれるようにします。
+以下の各機能には [ドキュメントサイト](https://yeongseon.dev/azure-functions-python/logging/) に完全なガイドがあります。このセクションは各機能が何をするかを要約して単一の情報源にリンクし、README がドキュメントのコピーではなく簡潔な概要として保たれるようにします。
 
 ### 呼び出しコンテキスト
 
@@ -290,44 +290,44 @@ curl -s "https://<your-app>.azurewebsites.net/api/logme?correlation_id=demo-123"
 
 > **ワーカーインスタンス。** すべてのレコードには、ログを生成したワーカーインスタンスを示すベストエフォートの識別子 `host_instance_id` も含まれます（`WEBSITE_INSTANCE_ID` → `WEBSITE_POD_NAME` → `CONTAINER_NAME` → `socket.gethostname()` の順で解決）。これは Application Insights の `cloud_RoleInstance` を補完しますが、常に一致することは保証されません。
 
-→ [使い方: コンテキスト注入](https://yeongseon.github.io/azure-functions-logging-python/usage/#3-context-injection-in-azure-functions) · [API: `with_context`](https://yeongseon.github.io/azure-functions-logging-python/api/#with_context)
+→ [使い方: コンテキスト注入](https://yeongseon.dev/azure-functions-python/logging/usage/#3-context-injection-in-azure-functions) · [API: `with_context`](https://yeongseon.dev/azure-functions-python/logging/api/#with_context)
 
 ### 構造化 JSON 出力
 
 `setup_logging(functions_formatter=JsonFormatter())` を渡すと、ホスト管理のハンドラで Application Insights 向け NDJSON を出力します（スタンドアロン実行/CI では `format="json"`）。追加フィールドは `extra` の下に入り、`truncate_native_strings=True` で長い文字列値を切り詰められます。
 
-→ [使い方: JSON 出力](https://yeongseon.github.io/azure-functions-logging-python/usage/#2-json-output-for-production) · [API: `JsonFormatter`](https://yeongseon.github.io/azure-functions-logging-python/api/#jsonformatter)
+→ [使い方: JSON 出力](https://yeongseon.dev/azure-functions-python/logging/usage/#2-json-output-for-production) · [API: `JsonFormatter`](https://yeongseon.dev/azure-functions-python/logging/api/#jsonformatter)
 
 ### host.json 衝突検出
 
 起動時、`host.json`（または `AzureFunctionsJobHost__logging__logLevel__...` アプリ設定のオーバーライド）がアプリの発行するレベルを抑制する場合に警告します。`host.json` は作業ディレクトリ（または `AzureWebJobsScriptRoot`）から上位に探索して自動発見され、`host_json_path=` で上書きできます。
 
-→ [設定: host.json 衝突](https://yeongseon.github.io/azure-functions-logging-python/configuration/#hostjson-level-conflict-warning) · [トラブルシューティング](https://yeongseon.github.io/azure-functions-logging-python/troubleshooting/#hostjson-conflict-warning-appears)
+→ [設定: host.json 衝突](https://yeongseon.dev/azure-functions-python/logging/configuration/#hostjson-level-conflict-warning) · [トラブルシューティング](https://yeongseon.dev/azure-functions-python/logging/troubleshooting/#hostjson-conflict-warning-appears)
 
 ### ノイズ制御と PII Redaction
 
 `SamplingFilter` は冗長なサードパーティロガー（`azure-core`、`urllib3` など）のレートを制限し、`RedactionFilter` は機密キー（パスワード、トークン、シークレット、接続文字列など — 大文字小文字を区別せず、再帰的）をログ集約前にマスクします。どちらもルートハンドラにアタッチし、`sensitive_keys=[...]` でカスタマイズできます。
 
-→ [API: `SamplingFilter`](https://yeongseon.github.io/azure-functions-logging-python/api/#samplingfilter) · [API: `RedactionFilter`](https://yeongseon.github.io/azure-functions-logging-python/api/#redactionfilter)
+→ [API: `SamplingFilter`](https://yeongseon.dev/azure-functions-python/logging/api/#samplingfilter) · [API: `RedactionFilter`](https://yeongseon.dev/azure-functions-python/logging/api/#redactionfilter)
 
 ### コンテキストバインディング
 
 `logger.bind(key=value)` は、以降のすべてのログにリクエストスコープのメタデータを付与するロガーを返します。呼び出しごとにバインドされたロガーを作成し、モジュールレベルでキャッシュしないでください。
 
-→ [使い方: コンテキストバインディング](https://yeongseon.github.io/azure-functions-logging-python/usage/#4-context-binding-with-functionloggerbind)
+→ [使い方: コンテキストバインディング](https://yeongseon.dev/azure-functions-python/logging/usage/#4-context-binding-with-functionloggerbind)
 
 ### グローバル LogRecordFactory (オプトイン)
 
 
 `setup_logging(use_record_factory=True)` はグローバルな `LogRecordFactory` をインストールし、レコード生成時にコンテキストを注入することで、ハンドラ/フィルタの構成に関係なく **すべての** `LogRecord` がコンテキストを持つようにします。`setup_logging()` 後にハンドラが追加されたり、ロガーがフィルタチェーンをバイパスする場合に便利です。デフォルトの `ContextFilter` モードとは相互排他的です。
 
-→ [設定: `use_record_factory`](https://yeongseon.github.io/azure-functions-logging-python/configuration/#parameter-use_record_factory)
+→ [設定: `use_record_factory`](https://yeongseon.dev/azure-functions-python/logging/configuration/#parameter-use_record_factory)
 
 ### ローカル vs クラウド
 
 `setup_logging()` は `FUNCTIONS_WORKER_RUNTIME` を検出します：ローカルでは色付きの人間が読みやすい出力、Azure / Core Tools ではホスト管理の NDJSON（コンテキストフィルタのみ — ハンドラ重複なし）、CI では機械可読な JSON。
 
-→ [設定: 環境検出](https://yeongseon.github.io/azure-functions-logging-python/configuration/#environment-detection)
+→ [設定: 環境検出](https://yeongseon.dev/azure-functions-python/logging/configuration/#environment-detection)
 
 ## いつ使うか
 
@@ -339,10 +339,10 @@ curl -s "https://<your-app>.azurewebsites.net/api/logme?correlation_id=demo-123"
 
 ## ドキュメント
 
-- 完全なドキュメント: [yeongseon.github.io/azure-functions-logging-python](https://yeongseon.github.io/azure-functions-logging-python/)
-- [Configuration reference](https://yeongseon.github.io/azure-functions-logging-python/configuration/)
-- [Troubleshooting guide](https://yeongseon.github.io/azure-functions-logging-python/troubleshooting/)
-- [API reference](https://yeongseon.github.io/azure-functions-logging-python/api/)
+- 完全なドキュメント: [yeongseon.dev/azure-functions-python/logging](https://yeongseon.dev/azure-functions-python/logging/)
+- [Configuration reference](https://yeongseon.dev/azure-functions-python/logging/configuration/)
+- [Troubleshooting guide](https://yeongseon.dev/azure-functions-python/logging/troubleshooting/)
+- [API reference](https://yeongseon.dev/azure-functions-python/logging/api/)
 
 ## エコシステム
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -10,7 +10,7 @@
 [![Security Scans](https://github.com/yeongseon/azure-functions-logging-python/actions/workflows/security.yml/badge.svg)](https://github.com/yeongseon/azure-functions-logging-python/actions/workflows/security.yml)
 [![codecov](https://codecov.io/gh/yeongseon/azure-functions-logging-python/branch/main/graph/badge.svg)](https://codecov.io/gh/yeongseon/azure-functions-logging-python)
 [![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit)](https://pre-commit.com/)
-[![Docs](https://img.shields.io/badge/docs-gh--pages-blue)](https://yeongseon.github.io/azure-functions-logging-python/)
+[![Docs](https://img.shields.io/badge/docs-yeongseon.dev-blue)](https://yeongseon.dev/azure-functions-python/logging/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
 다른 언어로 보기: [English](README.md) | [日本語](README.ja.md) | [简体中文](README.zh-CN.md)
@@ -65,7 +65,7 @@ with logging_context(context):
     logger.info("processing")  # OpenTelemetry 레코드가 호출의 trace_id / span_id를 상속
 ```
 
-이는 **상관관계이지 트레이싱이 아닙니다** — 라이브러리는 결코 span을 생성, 기록, 내보내지 않습니다. OpenTelemetry나 Application Insights SDK를 대체하지 않고 보완하며, span 생성은 여전히 그들의 책임입니다. [OpenTelemetry 트레이스 상관관계 가이드](https://yeongseon.github.io/azure-functions-logging-python/opentelemetry/)를 참고하세요.
+이는 **상관관계이지 트레이싱이 아닙니다** — 라이브러리는 결코 span을 생성, 기록, 내보내지 않습니다. OpenTelemetry나 Application Insights SDK를 대체하지 않고 보완하며, span 생성은 여전히 그들의 책임입니다. [OpenTelemetry 트레이스 상관관계 가이드](https://yeongseon.dev/azure-functions-python/logging/opentelemetry/)를 참고하세요.
 
 호출단위 활성화를 선호하시나요? 프로세스 전역 기본값 대신 인자로 직접 전달하세요: `with logging_context(context, activate_trace_context=True):`.
 
@@ -200,7 +200,7 @@ traces
 이 패키지는 다음을 책임지지 않습니다:
 
 - **stdlib logging 대체** — Python 표준 `logging`을 감싸고 보강할 뿐, 절대 대체하지 않습니다
-- **분산 트레이싱** — Azure Functions 호스트의 W3C trace context를 **바인딩**하여 기존 OpenTelemetry 로그 레코드가 호출 span의 `trace_id` / `span_id`를 상속하도록 하지만, 이 라이브러리가 직접 span을 생성·기록·내보내지는 않습니다 — 트레이싱이 아니라 상관(correlation)입니다. span 생성에는 OpenTelemetry나 Application Insights SDK를 사용하세요. [OpenTelemetry trace 상관](https://yeongseon.github.io/azure-functions-logging-python/opentelemetry/) 참고
+- **분산 트레이싱** — Azure Functions 호스트의 W3C trace context를 **바인딩**하여 기존 OpenTelemetry 로그 레코드가 호출 span의 `trace_id` / `span_id`를 상속하도록 하지만, 이 라이브러리가 직접 span을 생성·기록·내보내지는 않습니다 — 트레이싱이 아니라 상관(correlation)입니다. span 생성에는 OpenTelemetry나 Application Insights SDK를 사용하세요. [OpenTelemetry trace 상관](https://yeongseon.dev/azure-functions-python/logging/opentelemetry/) 참고
 - **API 문서** — API 문서 및 spec 생성에는 [`azure-functions-openapi`](https://github.com/yeongseon/azure-functions-openapi-python)를 사용하세요
 
 ## 설치
@@ -280,7 +280,7 @@ curl -s "https://<your-app>.azurewebsites.net/api/logme?correlation_id=demo-123"
 
 ## 핵심 기능
 
-아래 모든 기능은 [문서 사이트](https://yeongseon.github.io/azure-functions-logging-python/)에 전체 사용법이 있습니다. 이 섹션은 각 기능이 무엇을 하는지 요약하고 단일 출처로 링크하여, README가 문서의 사본이 아니라 빠른 개요로 유지되도록 합니다.
+아래 모든 기능은 [문서 사이트](https://yeongseon.dev/azure-functions-python/logging/)에 전체 사용법이 있습니다. 이 섹션은 각 기능이 무엇을 하는지 요약하고 단일 출처로 링크하여, README가 문서의 사본이 아니라 빠른 개요로 유지되도록 합니다.
 
 ### 호출 컨텍스트
 
@@ -290,44 +290,44 @@ curl -s "https://<your-app>.azurewebsites.net/api/logme?correlation_id=demo-123"
 
 > **워커 인스턴스.** 모든 레코드는 로그를 생성한 워커 인스턴스를 나타내는 베스트 에포트 식별자인 `host_instance_id`도 함께 담습니다(`WEBSITE_INSTANCE_ID` → `WEBSITE_POD_NAME` → `CONTAINER_NAME` → `socket.gethostname()` 순으로 해석). 이는 Application Insights의 `cloud_RoleInstance`를 보완하지만 항상 동일하다고 보장하지는 않습니다.
 
-→ [사용법: 컨텍스트 주입](https://yeongseon.github.io/azure-functions-logging-python/usage/#3-context-injection-in-azure-functions) · [API: `with_context`](https://yeongseon.github.io/azure-functions-logging-python/api/#with_context)
+→ [사용법: 컨텍스트 주입](https://yeongseon.dev/azure-functions-python/logging/usage/#3-context-injection-in-azure-functions) · [API: `with_context`](https://yeongseon.dev/azure-functions-python/logging/api/#with_context)
 
 ### 구조화된 JSON 출력
 
 `setup_logging(functions_formatter=JsonFormatter())`를 전달하면 호스트 관리 핸들러에서 Application Insights용 NDJSON을 출력합니다(독립 실행/CI에서는 `format="json"`). 추가 필드는 `extra` 아래에 들어가며, `truncate_native_strings=True`로 긴 문자열 값을 자를 수 있습니다.
 
-→ [사용법: JSON 출력](https://yeongseon.github.io/azure-functions-logging-python/usage/#2-json-output-for-production) · [API: `JsonFormatter`](https://yeongseon.github.io/azure-functions-logging-python/api/#jsonformatter)
+→ [사용법: JSON 출력](https://yeongseon.dev/azure-functions-python/logging/usage/#2-json-output-for-production) · [API: `JsonFormatter`](https://yeongseon.dev/azure-functions-python/logging/api/#jsonformatter)
 
 ### host.json 충돌 감지
 
 시작 시 `host.json`(또는 `AzureFunctionsJobHost__logging__logLevel__...` 앱 설정 오버라이드)이 앱이 방출하는 레벨을 억제하면 경고합니다. `host.json`은 작업 디렉터리(또는 `AzureWebJobsScriptRoot`)에서 상위로 탐색하여 자동 발견되며, `host_json_path=`로 재정의할 수 있습니다.
 
-→ [구성: host.json 충돌](https://yeongseon.github.io/azure-functions-logging-python/configuration/#hostjson-level-conflict-warning) · [문제 해결](https://yeongseon.github.io/azure-functions-logging-python/troubleshooting/#hostjson-conflict-warning-appears)
+→ [구성: host.json 충돌](https://yeongseon.dev/azure-functions-python/logging/configuration/#hostjson-level-conflict-warning) · [문제 해결](https://yeongseon.dev/azure-functions-python/logging/troubleshooting/#hostjson-conflict-warning-appears)
 
 ### 노이즈 제어 및 PII Redaction
 
 `SamplingFilter`는 시끄러운 서드파티 로거(`azure-core`, `urllib3` 등)의 속도를 제한하고, `RedactionFilter`는 민감한 키(비밀번호, 토큰, 시크릿, 연결 문자열 등 — 대소문자 무시, 재귀적)를 로그 집계 전에 마스킹합니다. 둘 다 루트 핸들러에 연결하며, `sensitive_keys=[...]`로 사용자 지정할 수 있습니다.
 
-→ [API: `SamplingFilter`](https://yeongseon.github.io/azure-functions-logging-python/api/#samplingfilter) · [API: `RedactionFilter`](https://yeongseon.github.io/azure-functions-logging-python/api/#redactionfilter)
+→ [API: `SamplingFilter`](https://yeongseon.dev/azure-functions-python/logging/api/#samplingfilter) · [API: `RedactionFilter`](https://yeongseon.dev/azure-functions-python/logging/api/#redactionfilter)
 
 ### 컨텍스트 바인딩
 
 `logger.bind(key=value)`는 이후 모든 로그에 요청 범위 메타데이터를 첨부하는 로거를 반환합니다. 호출당 바운드 로거를 생성하고 모듈 레벨에서 캐싱하지 마세요.
 
-→ [사용법: 컨텍스트 바인딩](https://yeongseon.github.io/azure-functions-logging-python/usage/#4-context-binding-with-functionloggerbind)
+→ [사용법: 컨텍스트 바인딩](https://yeongseon.dev/azure-functions-python/logging/usage/#4-context-binding-with-functionloggerbind)
 
 ### 글로벌 LogRecordFactory (opt-in)
 
 
 `setup_logging(use_record_factory=True)`는 전역 `LogRecordFactory`를 설치하여 레코드 생성 시점에 컨텍스트를 주입하므로, 핸들러/필터 구성과 무관하게 **모든** `LogRecord`가 컨텍스트를 갖도록 합니다. `setup_logging()` 이후 핸들러가 추가되거나 로거가 필터 체인을 우회할 때 유용합니다. 기본 `ContextFilter` 모드와는 상호 배타적입니다.
 
-→ [구성: `use_record_factory`](https://yeongseon.github.io/azure-functions-logging-python/configuration/#parameter-use_record_factory)
+→ [구성: `use_record_factory`](https://yeongseon.dev/azure-functions-python/logging/configuration/#parameter-use_record_factory)
 
 ### 로컬 vs 클라우드
 
 `setup_logging()`은 `FUNCTIONS_WORKER_RUNTIME`을 감지합니다: 로컬에서는 색상이 있는 사람이 읽기 쉬운 출력, Azure / Core Tools에서는 호스트 관리 NDJSON(컨텍스트 필터만 — 핸들러 중복 없음), CI에서는 기계가 파싱 가능한 JSON.
 
-→ [구성: 환경 감지](https://yeongseon.github.io/azure-functions-logging-python/configuration/#environment-detection)
+→ [구성: 환경 감지](https://yeongseon.dev/azure-functions-python/logging/configuration/#environment-detection)
 
 ## 언제 사용하는가
 
@@ -339,10 +339,10 @@ curl -s "https://<your-app>.azurewebsites.net/api/logme?correlation_id=demo-123"
 
 ## 문서
 
-- 전체 문서: [yeongseon.github.io/azure-functions-logging-python](https://yeongseon.github.io/azure-functions-logging-python/)
-- [Configuration reference](https://yeongseon.github.io/azure-functions-logging-python/configuration/)
-- [Troubleshooting guide](https://yeongseon.github.io/azure-functions-logging-python/troubleshooting/)
-- [API reference](https://yeongseon.github.io/azure-functions-logging-python/api/)
+- 전체 문서: [yeongseon.dev/azure-functions-python/logging](https://yeongseon.dev/azure-functions-python/logging/)
+- [Configuration reference](https://yeongseon.dev/azure-functions-python/logging/configuration/)
+- [Troubleshooting guide](https://yeongseon.dev/azure-functions-python/logging/troubleshooting/)
+- [API reference](https://yeongseon.dev/azure-functions-python/logging/api/)
 
 ## 생태계 (Ecosystem)
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![Security Scans](https://github.com/yeongseon/azure-functions-logging-python/actions/workflows/security.yml/badge.svg)](https://github.com/yeongseon/azure-functions-logging-python/actions/workflows/security.yml)
 [![codecov](https://codecov.io/gh/yeongseon/azure-functions-logging-python/branch/main/graph/badge.svg)](https://codecov.io/gh/yeongseon/azure-functions-logging-python)
 [![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit)](https://pre-commit.com/)
-[![Docs](https://img.shields.io/badge/docs-gh--pages-blue)](https://yeongseon.github.io/azure-functions-logging-python/)
+[![Docs](https://img.shields.io/badge/docs-yeongseon.dev-blue)](https://yeongseon.dev/azure-functions-python/logging/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
 Read this in: [한국어](README.ko.md) | [日本語](README.ja.md) | [简体中文](README.zh-CN.md)
@@ -63,7 +63,7 @@ with logging_context(context):
     logger.info("processing")  # OpenTelemetry record inherits the invocation trace_id / span_id
 ```
 
-This is **correlation, not tracing** — the library never creates, records, or exports spans itself. It is complementary to (not a replacement for) OpenTelemetry or the Application Insights SDK, which remain responsible for producing spans. See the [OpenTelemetry trace correlation guide](https://yeongseon.github.io/azure-functions-logging-python/opentelemetry/).
+This is **correlation, not tracing** — the library never creates, records, or exports spans itself. It is complementary to (not a replacement for) OpenTelemetry or the Application Insights SDK, which remain responsible for producing spans. See the [OpenTelemetry trace correlation guide](https://yeongseon.dev/azure-functions-python/logging/opentelemetry/).
 
 Prefer per-call activation? Skip the process-wide default and pass it directly: `with logging_context(context, activate_trace_context=True):`.
 
@@ -221,7 +221,7 @@ traces
 This package does not own:
 
 - **Replacing stdlib logging** — it wraps and enriches Python's standard `logging`, never replaces it
-- **Distributed tracing** — it **binds** the Azure Functions host's W3C trace context so your existing OpenTelemetry log records inherit the invocation span's `trace_id` / `span_id`, but it never creates, records, or exports spans itself — correlation, not tracing. Use OpenTelemetry or the Application Insights SDK to produce spans. See [OpenTelemetry trace correlation](https://yeongseon.github.io/azure-functions-logging-python/opentelemetry/)
+- **Distributed tracing** — it **binds** the Azure Functions host's W3C trace context so your existing OpenTelemetry log records inherit the invocation span's `trace_id` / `span_id`, but it never creates, records, or exports spans itself — correlation, not tracing. Use OpenTelemetry or the Application Insights SDK to produce spans. See [OpenTelemetry trace correlation](https://yeongseon.dev/azure-functions-python/logging/opentelemetry/)
 - **API documentation** — use [`azure-functions-openapi`](https://github.com/yeongseon/azure-functions-openapi-python) for API documentation and spec generation
 
 ## Installation
@@ -301,7 +301,7 @@ curl -s "https://<your-app>.azurewebsites.net/api/logme?correlation_id=demo-123"
 
 ## Core capabilities
 
-Every capability below has a full how-to on the [documentation site](https://yeongseon.github.io/azure-functions-logging-python/) — this section summarizes what each does and links to the single source, so the README stays a quick overview rather than a second copy of the docs.
+Every capability below has a full how-to on the [documentation site](https://yeongseon.dev/azure-functions-python/logging/) — this section summarizes what each does and links to the single source, so the README stays a quick overview rather than a second copy of the docs.
 
 ### Invocation context
 
@@ -311,43 +311,43 @@ Every capability below has a full how-to on the [documentation site](https://yeo
 
 > **Worker instance.** Every record also carries `host_instance_id`, a best-effort identifier of the worker instance that produced the log (resolved from `WEBSITE_INSTANCE_ID` → `WEBSITE_POD_NAME` → `CONTAINER_NAME` → `socket.gethostname()`). It is complementary to, but not guaranteed equal to, Application Insights' `cloud_RoleInstance`.
 
-→ [Usage: context injection](https://yeongseon.github.io/azure-functions-logging-python/usage/#3-context-injection-in-azure-functions) · [API: `with_context`](https://yeongseon.github.io/azure-functions-logging-python/api/#with_context)
+→ [Usage: context injection](https://yeongseon.dev/azure-functions-python/logging/usage/#3-context-injection-in-azure-functions) · [API: `with_context`](https://yeongseon.dev/azure-functions-python/logging/api/#with_context)
 
 ### Structured JSON output
 
 Pass `setup_logging(functions_formatter=JsonFormatter())` to emit Application Insights-ready NDJSON on host-managed handlers (or `format="json"` for standalone/CI). Extra fields land under `extra`; opt into `truncate_native_strings=True` to clip long string values.
 
-→ [Usage: JSON output](https://yeongseon.github.io/azure-functions-logging-python/usage/#2-json-output-for-production) · [API: `JsonFormatter`](https://yeongseon.github.io/azure-functions-logging-python/api/#jsonformatter)
+→ [Usage: JSON output](https://yeongseon.dev/azure-functions-python/logging/usage/#2-json-output-for-production) · [API: `JsonFormatter`](https://yeongseon.dev/azure-functions-python/logging/api/#jsonformatter)
 
 ### host.json conflict detection
 
 At startup the library warns when your `host.json` — or `AzureFunctionsJobHost__logging__logLevel__...` app-setting overrides — suppresses levels your app emits. `host.json` is auto-discovered by walking up from the working directory (or `AzureWebJobsScriptRoot`); pass `host_json_path=` to override.
 
-→ [Configuration: host.json conflict](https://yeongseon.github.io/azure-functions-logging-python/configuration/#hostjson-level-conflict-warning) · [Troubleshooting](https://yeongseon.github.io/azure-functions-logging-python/troubleshooting/#hostjson-conflict-warning-appears)
+→ [Configuration: host.json conflict](https://yeongseon.dev/azure-functions-python/logging/configuration/#hostjson-level-conflict-warning) · [Troubleshooting](https://yeongseon.dev/azure-functions-python/logging/troubleshooting/#hostjson-conflict-warning-appears)
 
 ### Noise control & PII redaction
 
 `SamplingFilter` rate-limits chatty third-party loggers (e.g. `azure-core`, `urllib3`); `RedactionFilter` masks sensitive keys (passwords, tokens, secrets, connection strings, and more — case-insensitive, recursive) before logs reach aggregation. Attach either to your root handlers, and pass `sensitive_keys=[...]` to customize redaction.
 
-→ [API: `SamplingFilter`](https://yeongseon.github.io/azure-functions-logging-python/api/#samplingfilter) · [API: `RedactionFilter`](https://yeongseon.github.io/azure-functions-logging-python/api/#redactionfilter)
+→ [API: `SamplingFilter`](https://yeongseon.dev/azure-functions-python/logging/api/#samplingfilter) · [API: `RedactionFilter`](https://yeongseon.dev/azure-functions-python/logging/api/#redactionfilter)
 
 ### Context binding
 
 `logger.bind(key=value)` returns a logger that attaches request-scoped metadata to every subsequent log without threading it through each call. Create bound loggers per-invocation; don't cache them at module level.
 
-→ [Usage: context binding](https://yeongseon.github.io/azure-functions-logging-python/usage/#4-context-binding-with-functionloggerbind)
+→ [Usage: context binding](https://yeongseon.dev/azure-functions-python/logging/usage/#4-context-binding-with-functionloggerbind)
 
 ### Global LogRecordFactory (opt-in)
 
 `setup_logging(use_record_factory=True)` installs a global `LogRecordFactory` that injects context at record-creation time so **every** `LogRecord` carries it regardless of handler/filter wiring — useful when handlers are added after `setup_logging()` or loggers bypass the filter chain. It is mutually exclusive with the default `ContextFilter` mode.
 
-→ [Configuration: `use_record_factory`](https://yeongseon.github.io/azure-functions-logging-python/configuration/#parameter-use_record_factory)
+→ [Configuration: `use_record_factory`](https://yeongseon.dev/azure-functions-python/logging/configuration/#parameter-use_record_factory)
 
 ### Local vs cloud
 
 `setup_logging()` detects `FUNCTIONS_WORKER_RUNTIME`: colorized human-readable output locally, host-managed NDJSON in Azure / Core Tools (context filters only — no duplicate handlers), and machine-parseable JSON in CI.
 
-→ [Configuration: environment detection](https://yeongseon.github.io/azure-functions-logging-python/configuration/#environment-detection)
+→ [Configuration: environment detection](https://yeongseon.dev/azure-functions-python/logging/configuration/#environment-detection)
 
 ## When to use
 
@@ -359,10 +359,10 @@ At startup the library warns when your `host.json` — or `AzureFunctionsJobHost
 
 ## Documentation
 
-- Full docs: [yeongseon.github.io/azure-functions-logging-python](https://yeongseon.github.io/azure-functions-logging-python/)
-- [Configuration reference](https://yeongseon.github.io/azure-functions-logging-python/configuration/)
-- [Troubleshooting guide](https://yeongseon.github.io/azure-functions-logging-python/troubleshooting/)
-- [API reference](https://yeongseon.github.io/azure-functions-logging-python/api/)
+- Full docs: [yeongseon.dev/azure-functions-python/logging](https://yeongseon.dev/azure-functions-python/logging/)
+- [Configuration reference](https://yeongseon.dev/azure-functions-python/logging/configuration/)
+- [Troubleshooting guide](https://yeongseon.dev/azure-functions-python/logging/troubleshooting/)
+- [API reference](https://yeongseon.dev/azure-functions-python/logging/api/)
 
 ## Ecosystem
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -10,7 +10,7 @@
 [![Security Scans](https://github.com/yeongseon/azure-functions-logging-python/actions/workflows/security.yml/badge.svg)](https://github.com/yeongseon/azure-functions-logging-python/actions/workflows/security.yml)
 [![codecov](https://codecov.io/gh/yeongseon/azure-functions-logging-python/branch/main/graph/badge.svg)](https://codecov.io/gh/yeongseon/azure-functions-logging-python)
 [![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit)](https://pre-commit.com/)
-[![Docs](https://img.shields.io/badge/docs-gh--pages-blue)](https://yeongseon.github.io/azure-functions-logging-python/)
+[![Docs](https://img.shields.io/badge/docs-yeongseon.dev-blue)](https://yeongseon.dev/azure-functions-python/logging/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
 阅读其他语言版本: [English](README.md) | [한국어](README.ko.md) | [日本語](README.ja.md)
@@ -65,7 +65,7 @@ with logging_context(context):
     logger.info("processing")  # OpenTelemetry 记录继承调用的 trace_id / span_id
 ```
 
-这是 **关联，而非追踪** — 库从不创建、记录或导出 span。它补充而非替代 OpenTelemetry 或 Application Insights SDK，后者仍负责产生 span。参见 [OpenTelemetry 追踪关联指南](https://yeongseon.github.io/azure-functions-logging-python/opentelemetry/)。
+这是 **关联，而非追踪** — 库从不创建、记录或导出 span。它补充而非替代 OpenTelemetry 或 Application Insights SDK，后者仍负责产生 span。参见 [OpenTelemetry 追踪关联指南](https://yeongseon.dev/azure-functions-python/logging/opentelemetry/)。
 
 更倾向于按调用激活？跳过进程级默认设置，直接传入：`with logging_context(context, activate_trace_context=True):`。
 
@@ -200,7 +200,7 @@ traces
 本包不拥有:
 
 - **替换 stdlib logging** — 它包装并丰富 Python 标准 `logging`，从不替换它
-- **分布式追踪** — 它会**绑定** Azure Functions 主机的 W3C 追踪上下文，使你已有的 OpenTelemetry 日志记录继承调用 span 的 `trace_id` / `span_id`，但它自身绝不创建、记录或导出 span —— 是关联（correlation）而非追踪。请使用 OpenTelemetry 或 Application Insights SDK 来生成 span。参见 [OpenTelemetry 追踪关联](https://yeongseon.github.io/azure-functions-logging-python/opentelemetry/)
+- **分布式追踪** — 它会**绑定** Azure Functions 主机的 W3C 追踪上下文，使你已有的 OpenTelemetry 日志记录继承调用 span 的 `trace_id` / `span_id`，但它自身绝不创建、记录或导出 span —— 是关联（correlation）而非追踪。请使用 OpenTelemetry 或 Application Insights SDK 来生成 span。参见 [OpenTelemetry 追踪关联](https://yeongseon.dev/azure-functions-python/logging/opentelemetry/)
 - **API 文档** — API 文档和 spec 生成请使用 [`azure-functions-openapi`](https://github.com/yeongseon/azure-functions-openapi-python)
 
 ## 安装
@@ -280,7 +280,7 @@ curl -s "https://<your-app>.azurewebsites.net/api/logme?correlation_id=demo-123"
 
 ## 核心功能
 
-下面每一项能力在[文档站点](https://yeongseon.github.io/azure-functions-logging-python/)上都有完整的操作指南 —— 本节只概述每项能力的作用并链接到唯一来源，从而让 README 保持为快速概览，而不是文档的第二份副本。
+下面每一项能力在[文档站点](https://yeongseon.dev/azure-functions-python/logging/)上都有完整的操作指南 —— 本节只概述每项能力的作用并链接到唯一来源，从而让 README 保持为快速概览，而不是文档的第二份副本。
 
 ### 调用上下文
 
@@ -290,44 +290,44 @@ curl -s "https://<your-app>.azurewebsites.net/api/logme?correlation_id=demo-123"
 
 > **工作实例。** 每条记录还携带 `host_instance_id`，这是产生该日志的工作实例的尽力而为的标识符（按 `WEBSITE_INSTANCE_ID` → `WEBSITE_POD_NAME` → `CONTAINER_NAME` → `socket.gethostname()` 的顺序解析）。它是 Application Insights 的 `cloud_RoleInstance` 的补充，但不保证与其完全一致。
 
-→ [Usage: context injection](https://yeongseon.github.io/azure-functions-logging-python/usage/#3-context-injection-in-azure-functions) · [API: `with_context`](https://yeongseon.github.io/azure-functions-logging-python/api/#with_context)
+→ [Usage: context injection](https://yeongseon.dev/azure-functions-python/logging/usage/#3-context-injection-in-azure-functions) · [API: `with_context`](https://yeongseon.dev/azure-functions-python/logging/api/#with_context)
 
 ### 结构化 JSON 输出
 
 传入 `setup_logging(functions_formatter=JsonFormatter())`，即可在宿主托管的 handler 上输出可直接用于 Application Insights 的 NDJSON（或用 `format="json"` 用于独立/CI 场景）。额外字段会归入 `extra`；可选择开启 `truncate_native_strings=True` 以裁剪过长的字符串值。
 
-→ [Usage: JSON output](https://yeongseon.github.io/azure-functions-logging-python/usage/#2-json-output-for-production) · [API: `JsonFormatter`](https://yeongseon.github.io/azure-functions-logging-python/api/#jsonformatter)
+→ [Usage: JSON output](https://yeongseon.dev/azure-functions-python/logging/usage/#2-json-output-for-production) · [API: `JsonFormatter`](https://yeongseon.dev/azure-functions-python/logging/api/#jsonformatter)
 
 ### host.json 冲突检测
 
 启动时，当你的 `host.json` —— 或 `AzureFunctionsJobHost__logging__logLevel__...` 应用设置覆盖 —— 抑制了应用实际发出的日志级别时，本库会发出警告。`host.json` 会从工作目录（或 `AzureWebJobsScriptRoot`）向上遍历自动发现；可传入 `host_json_path=` 覆盖。
 
-→ [Configuration: host.json conflict](https://yeongseon.github.io/azure-functions-logging-python/configuration/#hostjson-level-conflict-warning) · [Troubleshooting](https://yeongseon.github.io/azure-functions-logging-python/troubleshooting/#hostjson-conflict-warning-appears)
+→ [Configuration: host.json conflict](https://yeongseon.dev/azure-functions-python/logging/configuration/#hostjson-level-conflict-warning) · [Troubleshooting](https://yeongseon.dev/azure-functions-python/logging/troubleshooting/#hostjson-conflict-warning-appears)
 
 ### 噪声控制与 PII 脱敏
 
 `SamplingFilter` 对话痨式的第三方 logger（如 `azure-core`、`urllib3`）进行限流；`RedactionFilter` 在日志到达聚合之前对敏感键（密码、令牌、密钥、连接字符串等 —— 不区分大小写、递归）进行掩码。将两者中的任意一个附加到根 handler，并可传入 `sensitive_keys=[...]` 自定义脱敏。
 
-→ [API: `SamplingFilter`](https://yeongseon.github.io/azure-functions-logging-python/api/#samplingfilter) · [API: `RedactionFilter`](https://yeongseon.github.io/azure-functions-logging-python/api/#redactionfilter)
+→ [API: `SamplingFilter`](https://yeongseon.dev/azure-functions-python/logging/api/#samplingfilter) · [API: `RedactionFilter`](https://yeongseon.dev/azure-functions-python/logging/api/#redactionfilter)
 
 ### 上下文绑定
 
 `logger.bind(key=value)` 返回一个 logger，它会把请求作用域的元数据附加到之后的每一条日志上，而无需逐次调用传递。请按调用创建绑定的 logger；不要在模块级别缓存它们。
 
-→ [Usage: context binding](https://yeongseon.github.io/azure-functions-logging-python/usage/#4-context-binding-with-functionloggerbind)
+→ [Usage: context binding](https://yeongseon.dev/azure-functions-python/logging/usage/#4-context-binding-with-functionloggerbind)
 
 ### 全局 LogRecordFactory（可选启用）
 
 
 `setup_logging(use_record_factory=True)` 会安装一个全局 `LogRecordFactory`，在记录创建时注入上下文，因此**每一条** `LogRecord` 都会携带上下文，而不受 handler/filter 接线方式的影响 —— 当 handler 在 `setup_logging()` 之后才添加，或 logger 绕过 filter 链时尤其有用。它与默认的 `ContextFilter` 模式互斥。
 
-→ [Configuration: `use_record_factory`](https://yeongseon.github.io/azure-functions-logging-python/configuration/#parameter-use_record_factory)
+→ [Configuration: `use_record_factory`](https://yeongseon.dev/azure-functions-python/logging/configuration/#parameter-use_record_factory)
 
 ### 本地 vs 云端
 
 `setup_logging()` 会检测 `FUNCTIONS_WORKER_RUNTIME`：本地输出彩色可读格式，在 Azure / Core Tools 中输出宿主托管的 NDJSON（仅 context filter —— 不添加重复 handler），在 CI 中输出机器可解析的 JSON。
 
-→ [Configuration: environment detection](https://yeongseon.github.io/azure-functions-logging-python/configuration/#environment-detection)
+→ [Configuration: environment detection](https://yeongseon.dev/azure-functions-python/logging/configuration/#environment-detection)
 ## 何时使用
 
 - 您需要在 Application Insights 中获得结构化、可查询的日志时
@@ -338,10 +338,10 @@ curl -s "https://<your-app>.azurewebsites.net/api/logme?correlation_id=demo-123"
 
 ## 文档
 
-- 完整文档: [yeongseon.github.io/azure-functions-logging-python](https://yeongseon.github.io/azure-functions-logging-python/)
-- [Configuration reference](https://yeongseon.github.io/azure-functions-logging-python/configuration/)
-- [Troubleshooting guide](https://yeongseon.github.io/azure-functions-logging-python/troubleshooting/)
-- [API reference](https://yeongseon.github.io/azure-functions-logging-python/api/)
+- 完整文档: [yeongseon.dev/azure-functions-python/logging](https://yeongseon.dev/azure-functions-python/logging/)
+- [Configuration reference](https://yeongseon.dev/azure-functions-python/logging/configuration/)
+- [Troubleshooting guide](https://yeongseon.dev/azure-functions-python/logging/troubleshooting/)
+- [API reference](https://yeongseon.dev/azure-functions-python/logging/api/)
 
 ## 生态系统
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -5,21 +5,21 @@
 Part of the **Azure Functions Python DX Toolkit**. Drop-in structured (JSON) logging with context injection and binding for Azure Functions Python, so logs are queryable in Application Insights without boilerplate. Install from PyPI with `pip install azure-functions-logging`.
 
 ## Getting Started
-- [Installation](https://yeongseon.github.io/azure-functions-logging-python/installation/): Install the package.
-- [Quickstart](https://yeongseon.github.io/azure-functions-logging-python/getting-started/): Minimal end-to-end example.
-- [Configuration](https://yeongseon.github.io/azure-functions-logging-python/configuration/): Configure formatters and levels.
+- [Installation](https://yeongseon.dev/azure-functions-python/logging/installation/): Install the package.
+- [Quickstart](https://yeongseon.dev/azure-functions-python/logging/getting-started/): Minimal end-to-end example.
+- [Configuration](https://yeongseon.dev/azure-functions-python/logging/configuration/): Configure formatters and levels.
 
 ## User Guide
-- [Usage](https://yeongseon.github.io/azure-functions-logging-python/usage/): Helper reference and injection modes.
-- [Architecture](https://yeongseon.github.io/azure-functions-logging-python/architecture/): How the logging pipeline works.
+- [Usage](https://yeongseon.dev/azure-functions-python/logging/usage/): Helper reference and injection modes.
+- [Architecture](https://yeongseon.dev/azure-functions-python/logging/architecture/): How the logging pipeline works.
 
 ## Examples
-- [Basic Setup](https://yeongseon.github.io/azure-functions-logging-python/examples/basic_setup/): Get started fast.
-- [JSON Output](https://yeongseon.github.io/azure-functions-logging-python/examples/json_output/): Structured logs.
-- [Context Injection](https://yeongseon.github.io/azure-functions-logging-python/examples/context_injection/): Enrich records with context.
-- [Third-Party Noise Control](https://yeongseon.github.io/azure-functions-logging-python/examples/third_party_noise_control/): Quiet noisy loggers.
+- [Basic Setup](https://yeongseon.dev/azure-functions-python/logging/examples/basic_setup/): Get started fast.
+- [JSON Output](https://yeongseon.dev/azure-functions-python/logging/examples/json_output/): Structured logs.
+- [Context Injection](https://yeongseon.dev/azure-functions-python/logging/examples/context_injection/): Enrich records with context.
+- [Third-Party Noise Control](https://yeongseon.dev/azure-functions-python/logging/examples/third_party_noise_control/): Quiet noisy loggers.
 
 ## Reference
-- [API Reference](https://yeongseon.github.io/azure-functions-logging-python/api/): Public API surface.
-- [FAQ](https://yeongseon.github.io/azure-functions-logging-python/faq/): Frequently asked questions.
-- [Troubleshooting](https://yeongseon.github.io/azure-functions-logging-python/troubleshooting/): Common issues and fixes.
+- [API Reference](https://yeongseon.dev/azure-functions-python/logging/api/): Public API surface.
+- [FAQ](https://yeongseon.dev/azure-functions-python/logging/faq/): Frequently asked questions.
+- [Troubleshooting](https://yeongseon.dev/azure-functions-python/logging/troubleshooting/): Common issues and fixes.

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -8,7 +8,7 @@
 - Version: 0.7.1
 - Python: >=3.10, <3.15
 - License: MIT
-- Docs: https://yeongseon.github.io/azure-functions-logging-python/
+- Docs: https://yeongseon.dev/azure-functions-python/logging/
 - Repository: https://github.com/yeongseon/azure-functions-logging-python
 
 ## Installation

--- a/llms.txt
+++ b/llms.txt
@@ -8,7 +8,7 @@
 - Version: 0.7.1
 - Python: >=3.10, <3.15
 - License: MIT
-- Docs: https://yeongseon.github.io/azure-functions-logging-python/
+- Docs: https://yeongseon.dev/azure-functions-python/logging/
 - Repository: https://github.com/yeongseon/azure-functions-logging-python
 
 ## What It Does
@@ -75,11 +75,11 @@ def handler(req, context):
 
 ## Documentation
 
-- [Getting Started](https://yeongseon.github.io/azure-functions-logging-python/getting-started/)
-- [API Reference](https://yeongseon.github.io/azure-functions-logging-python/api/)
-- [Configuration](https://yeongseon.github.io/azure-functions-logging-python/configuration/)
-- [Examples](https://yeongseon.github.io/azure-functions-logging-python/examples/)
-- [Troubleshooting](https://yeongseon.github.io/azure-functions-logging-python/troubleshooting/)
+- [Getting Started](https://yeongseon.dev/azure-functions-python/logging/getting-started/)
+- [API Reference](https://yeongseon.dev/azure-functions-python/logging/api/)
+- [Configuration](https://yeongseon.dev/azure-functions-python/logging/configuration/)
+- [Examples](https://yeongseon.dev/azure-functions-python/logging/examples/basic_setup/)
+- [Troubleshooting](https://yeongseon.dev/azure-functions-python/logging/troubleshooting/)
 
 ## Ecosystem
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,7 +1,7 @@
 site_name: Azure Functions Logging
 site_description: Developer-friendly logging helpers for Azure Functions Python
 site_author: Yeongseon Choe
-site_url: https://yeongseon.github.io/azure-functions-logging-python/
+site_url: https://yeongseon.dev/azure-functions-python/logging/
 repo_url: https://github.com/yeongseon/azure-functions-logging-python
 edit_uri: edit/main/docs/
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,8 +23,8 @@ classifiers = [
 ]
 
 [project.urls]
-Homepage = "https://yeongseon.github.io/azure-functions-logging-python/"
-Documentation = "https://yeongseon.github.io/azure-functions-logging-python/"
+Homepage = "https://yeongseon.dev/azure-functions-python/logging/"
+Documentation = "https://yeongseon.dev/azure-functions-python/logging/"
 Repository = "https://github.com/yeongseon/azure-functions-logging-python"
 Issues = "https://github.com/yeongseon/azure-functions-logging-python/issues"
 


### PR DESCRIPTION
## Summary
Consolidate the official documentation URL onto the new canonical domain `https://yeongseon.dev/azure-functions-python/logging/`.

- `pyproject.toml`: `Homepage`/`Documentation` → new URL; `Repository`/`Issues` unchanged (GitHub `-python`).
- `mkdocs.yml`: `site_url` → new URL; `repo_url`/`edit_uri` unchanged (GitHub).
- README (en/ja/ko/zh-CN): docs links + badge updated.
- `llms.txt`, `docs/llms.txt`, `llms-full.txt`: base path + preserved subpaths/anchors updated.

## Verification
- All 14 base doc URLs return 200 (curl -L).
- All deep-link anchors resolve (id present, count=1).
- Remapped `[Examples]` root index (404 on both old/new) to valid `examples/basic_setup/`.
- `mkdocs build --strict` passes (INFO-only, no strict abort).
- No stale `github.io/azure-functions-logging` refs remain.

## Notes
Redirect stubs (meta refresh + canonical), not HTTP 301. Repository/Issues intentionally stay on GitHub.

Closes #338