### PR TITLE
docs: unify basic-usage guides onto one recommended path and fix contradictions

### DIFF
--- a/docs/examples/basic_setup.md
+++ b/docs/examples/basic_setup.md
@@ -106,7 +106,7 @@ Inside `function_app.py`:
 
 ```python
 import azure.functions as func
-from azure_functions_logging import get_logger, inject_context, setup_logging
+from azure_functions_logging import get_logger, logging_context, setup_logging
 
 setup_logging()
 logger = get_logger(__name__)
@@ -116,9 +116,9 @@ app = func.FunctionApp()
 
 @app.route(route="ping")
 def ping(req: func.HttpRequest, context: func.Context) -> func.HttpResponse:
-    inject_context(context)
-    logger.info("ping received")
-    return func.HttpResponse("pong")
+    with logging_context(context):
+        logger.info("ping received")
+        return func.HttpResponse("pong")
 ```
 
 This adds invocation context fields automatically when available.
@@ -128,7 +128,7 @@ This adds invocation context fields automatically when available.
 - No logs: confirm `setup_logging()` executed before first log call.
 - Missing DEBUG: ensure `level=logging.DEBUG`.
 - Duplicate logs: ensure no extra root handlers were added elsewhere.
-- Missing context fields: ensure `inject_context(context)` runs per invocation.
+- Missing context fields: ensure handler body is wrapped in `with logging_context(context):`.
 
 ## Production Notes
 

--- a/docs/examples/cold_start_detection.md
+++ b/docs/examples/cold_start_detection.md
@@ -1,6 +1,6 @@
 # Example: Cold Start Detection
 
-`azure-functions-logging` automatically flags cold starts through the `cold_start` field when `inject_context(context)` is called.
+`azure-functions-logging` automatically flags cold starts through the `cold_start` field when `logging_context(context)` is used.
 
 ## Goal
 
@@ -10,7 +10,7 @@ Track first-invocation behavior and build simple metrics patterns from logs.
 
 Cold start logic is process-scoped:
 
-- First call to `inject_context(context)` in a process sets `cold_start=True`.
+- First call within `logging_context(context)` in a process sets `cold_start=True`.
 - Subsequent calls set `cold_start=False`.
 
 No manual counters are required in your code.
@@ -19,9 +19,9 @@ No manual counters are required in your code.
 
 ```python
 import azure.functions as func
-from azure_functions_logging import get_logger, inject_context, setup_logging
+from azure_functions_logging import JsonFormatter, get_logger, logging_context, setup_logging
 
-setup_logging(format="json")
+setup_logging(functions_formatter=JsonFormatter())
 logger = get_logger("cold-start-demo")
 
 app = func.FunctionApp()
@@ -29,9 +29,9 @@ app = func.FunctionApp()
 
 @app.route(route="status")
 def status(req: func.HttpRequest, context: func.Context) -> func.HttpResponse:
-    inject_context(context)
-    logger.info("status endpoint hit")
-    return func.HttpResponse("ok")
+    with logging_context(context):
+        logger.info("status endpoint hit")
+        return func.HttpResponse("ok")
 ```
 
 ## Expected Event Pattern
@@ -103,7 +103,7 @@ request_logger.info("request begin")
 
 Now each event includes:
 
-- Invocation metadata from `inject_context(context)`.
+- Invocation metadata from `logging_context(context)`.
 - Route/request metadata from `bind()`.
 
 ## Caveats

--- a/docs/examples/context_binding.md
+++ b/docs/examples/context_binding.md
@@ -71,9 +71,9 @@ After `clear_context()`, bound fields from that instance are removed.
 
 ```python
 import azure.functions as func
-from azure_functions_logging import get_logger, inject_context, setup_logging
+from azure_functions_logging import JsonFormatter, get_logger, logging_context, setup_logging
 
-setup_logging(format="json")
+setup_logging(functions_formatter=JsonFormatter())
 logger = get_logger("orders")
 
 app = func.FunctionApp()
@@ -81,19 +81,18 @@ app = func.FunctionApp()
 
 @app.route(route="orders/{order_id}")
 def get_order(req: func.HttpRequest, context: func.Context) -> func.HttpResponse:
-    inject_context(context)
+    with logging_context(context):
+        order_id = req.route_params.get("order_id")
+        request_logger = logger.bind(order_id=order_id, method=req.method)
 
-    order_id = req.route_params.get("order_id")
-    request_logger = logger.bind(order_id=order_id, method=req.method)
-
-    request_logger.info("lookup started")
-    request_logger.info("lookup completed")
-    return func.HttpResponse("ok")
+        request_logger.info("lookup started")
+        request_logger.info("lookup completed")
+        return func.HttpResponse("ok")
 ```
 
 This combines:
 
-- Global invocation fields from `inject_context(context)`.
+- Global invocation fields from `logging_context(context)`.
 - Per-request keys from `bind()`.
 
 ## Recommended Binding Dimensions

--- a/docs/examples/context_injection.md
+++ b/docs/examples/context_injection.md
@@ -4,15 +4,15 @@
 
 ## Goal
 
-Call `inject_context(context)` once per invocation and observe `invocation_id`, `function_name`, `trace_id`, `span_id`, and `cold_start` in logs.
+Wrap the handler body in `with logging_context(context):` and observe `invocation_id`, `function_name`, `trace_id`, `span_id`, and `cold_start` in logs.
 
 ## Baseline Handler
 
 ```python
 import azure.functions as func
-from azure_functions_logging import get_logger, inject_context, setup_logging
+from azure_functions_logging import JsonFormatter, get_logger, logging_context, setup_logging
 
-setup_logging(format="json")
+setup_logging(functions_formatter=JsonFormatter())
 logger = get_logger(__name__)
 
 app = func.FunctionApp()
@@ -20,9 +20,9 @@ app = func.FunctionApp()
 
 @app.route(route="hello")
 def hello(req: func.HttpRequest, context: func.Context) -> func.HttpResponse:
-    inject_context(context)
-    logger.info("request started")
-    return func.HttpResponse("hello")
+    with logging_context(context):
+        logger.info("request started")
+        return func.HttpResponse("hello")
 ```
 
 ## Fields Added by `inject_context()`
@@ -35,9 +35,9 @@ def hello(req: func.HttpRequest, context: func.Context) -> func.HttpResponse:
 | `span_id` | `context.trace_context.trace_parent` (span ID portion) | `b7ad...` |
 | `cold_start` | internal first-call detection | `true` or `false` |
 
-## Why Call It Early
+## Why Open the Context Block Early
 
-Call it at the top of each handler before business logic:
+Open `with logging_context(context):` at the very top of each handler, before business logic:
 
 - Every subsequent log call includes invocation metadata.
 - Errors logged later in the pipeline still carry correlation fields.
@@ -48,9 +48,9 @@ Call it at the top of each handler before business logic:
 ```python
 import json
 import azure.functions as func
-from azure_functions_logging import get_logger, inject_context, setup_logging
+from azure_functions_logging import JsonFormatter, get_logger, logging_context, setup_logging
 
-setup_logging(format="json")
+setup_logging(functions_formatter=JsonFormatter())
 logger = get_logger("payments.handler")
 
 app = func.FunctionApp()
@@ -58,23 +58,23 @@ app = func.FunctionApp()
 
 @app.route(route="payments")
 def payments(req: func.HttpRequest, context: func.Context) -> func.HttpResponse:
-    inject_context(context)
-    logger.info("payments request received", method=req.method)
+    with logging_context(context):
+        logger.info("payments request received", method=req.method)
 
-    try:
-        body = req.get_json()
-        amount = body.get("amount")
-        logger.info("validating payload", amount=amount)
+        try:
+            body = req.get_json()
+            amount = body.get("amount")
+            logger.info("validating payload", amount=amount)
 
-        if amount is None:
-            logger.warning("missing amount field")
-            return func.HttpResponse("invalid payload", status_code=400)
+            if amount is None:
+                logger.warning("missing amount field")
+                return func.HttpResponse("invalid payload", status_code=400)
 
-        logger.info("payment accepted", amount=amount)
-        return func.HttpResponse(json.dumps({"status": "ok"}), mimetype="application/json")
-    except Exception:
-        logger.exception("payments handler failed")
-        return func.HttpResponse("internal error", status_code=500)
+            logger.info("payment accepted", amount=amount)
+            return func.HttpResponse(json.dumps({"status": "ok"}), mimetype="application/json")
+        except Exception:
+            logger.exception("payments handler failed")
+            return func.HttpResponse("internal error", status_code=500)
 ```
 
 ## Behavior Outside Azure
@@ -102,7 +102,7 @@ logger.info("local simulation")
 
 For each invocation:
 
-1. `inject_context(context)` immediately.
+1. Open `with logging_context(context):` at the top of the handler.
 2. Create optional bound logger for request metadata.
 3. Emit lifecycle logs for start, decision points, and completion.
 4. Use `logger.exception()` in failure paths.
@@ -126,12 +126,12 @@ This combines invocation metadata (context injection) with request metadata (bin
 
 ## Common Mistakes
 
-- Injecting context after first logs are already emitted.
+- Opening `with logging_context(context):` after first logs are already emitted.
 - Assuming `trace_id` is present when trace context is absent.
-- Forgetting injection in some handlers, causing partial correlation.
+- Forgetting the `with logging_context(context):` wrapper in some handlers, causing partial correlation.
 
 !!! tip
-    If you use decorators or middleware-like wrappers, place `inject_context(context)` in the outermost request entrypoint to guarantee consistency.
+    If you use decorators or middleware-like wrappers, open `with logging_context(context):` in the outermost request entrypoint to guarantee consistency.
 
 ## Related Examples
 

--- a/docs/examples/context_injection.md
+++ b/docs/examples/context_injection.md
@@ -1,6 +1,6 @@
 # Example: Context Injection
 
-`inject_context(context)` enriches log records with invocation metadata from Azure Functions context.
+`logging_context(context)` enriches log records with invocation metadata from Azure Functions context. It is the recommended scoped API; `inject_context()` / `restore_context()` is the lower-level manual-token form of the same behavior.
 
 ## Goal
 
@@ -25,7 +25,7 @@ def hello(req: func.HttpRequest, context: func.Context) -> func.HttpResponse:
         return func.HttpResponse("hello")
 ```
 
-## Fields Added by `inject_context()`
+## Fields Added by `logging_context()`
 
 | Field | Source | Example |
 | --- | --- | --- |

--- a/docs/examples/host_json_conflicts.md
+++ b/docs/examples/host_json_conflicts.md
@@ -76,9 +76,9 @@ This is useful when one function needs richer diagnostics.
 
 ```python
 import azure.functions as func
-from azure_functions_logging import get_logger, inject_context, setup_logging
+from azure_functions_logging import JsonFormatter, get_logger, logging_context, setup_logging
 
-setup_logging(format="json")
+setup_logging(functions_formatter=JsonFormatter())
 logger = get_logger("orders")
 
 app = func.FunctionApp()
@@ -86,10 +86,10 @@ app = func.FunctionApp()
 
 @app.route(route="orders")
 def orders(req: func.HttpRequest, context: func.Context) -> func.HttpResponse:
-    inject_context(context)
-    logger.info("orders request started")
-    logger.warning("orders validation warning")
-    return func.HttpResponse("ok")
+    with logging_context(context):
+        logger.info("orders request started")
+        logger.warning("orders validation warning")
+        return func.HttpResponse("ok")
 ```
 
 If `INFO` does not appear, inspect `host.json` first.

--- a/docs/examples/json_output.md
+++ b/docs/examples/json_output.md
@@ -82,9 +82,9 @@ print(record["extra"].get("order_id"))
 
 ```python
 import azure.functions as func
-from azure_functions_logging import get_logger, inject_context, setup_logging
+from azure_functions_logging import JsonFormatter, get_logger, logging_context, setup_logging
 
-setup_logging(format="json")
+setup_logging(functions_formatter=JsonFormatter())
 logger = get_logger(__name__)
 
 app = func.FunctionApp()
@@ -92,9 +92,9 @@ app = func.FunctionApp()
 
 @app.route(route="orders")
 def create_order(req: func.HttpRequest, context: func.Context) -> func.HttpResponse:
-    inject_context(context)
-    logger.info("request received", method=req.method, route="/orders")
-    return func.HttpResponse("ok", status_code=200)
+    with logging_context(context):
+        logger.info("request received", method=req.method, route="/orders")
+        return func.HttpResponse("ok", status_code=200)
 ```
 
 With context injection, invocation fields are populated for every event in this request context.

--- a/docs/examples/logger_name_targeting.md
+++ b/docs/examples/logger_name_targeting.md
@@ -59,9 +59,9 @@ If migrating a large app:
 
 ```python
 import azure.functions as func
-from azure_functions_logging import get_logger, inject_context, setup_logging
+from azure_functions_logging import JsonFormatter, get_logger, logging_context, setup_logging
 
-setup_logging(format="json", logger_name="payments")
+setup_logging(functions_formatter=JsonFormatter(), logger_name="payments")
 logger = get_logger("payments.http")
 
 app = func.FunctionApp()
@@ -69,10 +69,10 @@ app = func.FunctionApp()
 
 @app.route(route="payments")
 def payments(req: func.HttpRequest, context: func.Context) -> func.HttpResponse:
-    inject_context(context)
-    request_logger = logger.bind(route="/payments", method=req.method)
-    request_logger.info("payments request")
-    return func.HttpResponse("ok")
+    with logging_context(context):
+        request_logger = logger.bind(route="/payments", method=req.method)
+        request_logger.info("payments request")
+        return func.HttpResponse("ok")
 ```
 
 ## Common Pitfalls

--- a/docs/examples/third_party_noise_control.md
+++ b/docs/examples/third_party_noise_control.md
@@ -40,9 +40,9 @@ This suppresses low-value dependency info/debug chatter.
 
 ```python
 import azure.functions as func
-from azure_functions_logging import get_logger, inject_context, setup_logging
+from azure_functions_logging import JsonFormatter, get_logger, logging_context, setup_logging
 
-setup_logging(format="json")
+setup_logging(functions_formatter=JsonFormatter())
 logger = get_logger("orders")
 
 app = func.FunctionApp()
@@ -50,11 +50,11 @@ app = func.FunctionApp()
 
 @app.route(route="orders")
 def orders(req: func.HttpRequest, context: func.Context) -> func.HttpResponse:
-    inject_context(context)
-    request_logger = logger.bind(route="/orders", method=req.method)
-    request_logger.info("request started")
-    request_logger.info("request completed")
-    return func.HttpResponse("ok")
+    with logging_context(context):
+        request_logger = logger.bind(route="/orders", method=req.method)
+        request_logger.info("request started")
+        request_logger.info("request completed")
+        return func.HttpResponse("ok")
 ```
 
 With noise controls, these app events remain visible and query-friendly.
@@ -102,7 +102,7 @@ After configuration:
 
 Noise control is strongest when combined with structured app logs:
 
-- `inject_context(context)` for invocation correlation.
+- `with logging_context(context):` for invocation correlation.
 - `bind()` for request-level dimensions.
 - Namespace level controls for dependency suppression.
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -36,7 +36,7 @@ If you pin dependencies, add to `requirements.txt`:
 
 ```text
 azure-functions
-azure-functions-logging==0.2.1
+azure-functions-logging>=0.10,<1
 ```
 
 !!! note
@@ -52,7 +52,7 @@ from azure_functions_logging import get_logger, setup_logging
 setup_logging()
 logger = get_logger(__name__)
 
-logger.info("Logging is ready")
+logger.info("logging initialized")
 ```
 
 What this does:
@@ -67,7 +67,7 @@ Use this pattern for HTTP triggers:
 
 ```python
 import azure.functions as func
-from azure_functions_logging import get_logger, inject_context, setup_logging
+from azure_functions_logging import get_logger, logging_context, setup_logging
 
 setup_logging()
 logger = get_logger(__name__)
@@ -77,16 +77,27 @@ app = func.FunctionApp()
 
 @app.route(route="health")
 def health(req: func.HttpRequest, context: func.Context) -> func.HttpResponse:
-    inject_context(context)
-    logger.info("Health check called")
-    return func.HttpResponse("ok", status_code=200)
+    with logging_context(context):
+        logger.info("Health check called")
+        return func.HttpResponse("ok", status_code=200)
 ```
 
-Why `inject_context(context)` matters:
+Why `logging_context(context)` matters:
 
 - Adds invocation metadata to each log record.
 - Enables automatic `cold_start` flagging.
 - Keeps your handler code clean and explicit.
+- Always restores prior context on exit, even on exceptions.
+
+### Which context API do I use?
+
+Three ways to attach invocation context — pick one:
+
+- `with logging_context(context):` — **recommended.** Scoped, always restores prior context on exit (even on exceptions).
+- `@with_context` — decorator form of the same behavior; good when you want the whole handler wrapped implicitly.
+- `tokens = inject_context(context)` / `restore_context(tokens)` — manual token form for middleware or framework integrations where you cannot use a `with` block. You are responsible for calling `restore_context(tokens)` in a `finally`.
+
+Bare `inject_context(context)` without a paired `restore_context()` can leak context between invocations in a reused worker — prefer `logging_context`.
 
 ## Expected Local Output
 
@@ -148,7 +159,7 @@ Important behavior in Core Tools and Azure environments:
 Avoid these early pitfalls:
 
 - Calling `setup_logging()` in multiple modules expecting different formats.
-- Forgetting `inject_context(context)` at the top of the handler.
+- Forgetting to wrap the handler body in `with logging_context(context):`.
 - Expecting app-level `level` to override restrictive `host.json` log level.
 
 ## Next Steps
@@ -168,7 +179,7 @@ Use this checklist before shipping:
 
 - `setup_logging()` called once during startup.
 - `get_logger(__name__)` used in modules.
-- `inject_context(context)` called per invocation.
+- Handler body wrapped in `with logging_context(context):`.
 - Chosen format is aligned with environment (`color` for local, `json` for production pipelines).
 - `host.json` logging level reviewed for conflicts.
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -104,7 +104,7 @@ Bare `inject_context(context)` without a paired `restore_context()` can leak con
 With default `format="color"`, you should see lines shaped like:
 
 ```text
-14:32:10 INFO     my_module  Logging is ready
+14:32:10 INFO     my_module  logging initialized
 14:32:12 INFO     function_app  Health check called  [invocation_id=..., function_name=health, trace_id=..., cold_start=true]
 ```
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,7 +9,7 @@ Production-oriented, developer-friendly logging for the Azure Functions Python v
 Copy this into your function module:
 
 ```python
-from azure_functions_logging import get_logger, logging_context, setup_logging
+from azure_functions_logging import get_logger, setup_logging
 
 setup_logging()
 logger = get_logger(__name__)

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -86,15 +86,15 @@ JSON best practices:
 - Put event dimensions in structured keys.
 - Use stable key naming conventions (`tenant_id`, `request_id`, `operation`).
 
-## 3) Context Injection in Azure Functions
+## 3) Attaching Invocation Context in Azure Functions
 
-Call `inject_context(context)` once per invocation.
+Wrap each handler body in `with logging_context(context):`.
 
 ```python
 import azure.functions as func
-from azure_functions_logging import get_logger, inject_context, setup_logging
+from azure_functions_logging import JsonFormatter, get_logger, logging_context, setup_logging
 
-setup_logging(format="json")
+setup_logging(functions_formatter=JsonFormatter())
 logger = get_logger(__name__)
 
 app = func.FunctionApp()
@@ -102,10 +102,13 @@ app = func.FunctionApp()
 
 @app.route(route="hello")
 def hello(req: func.HttpRequest, context: func.Context) -> func.HttpResponse:
-    inject_context(context)
-    logger.info("request started")
-    return func.HttpResponse("ok")
+    with logging_context(context):
+        logger.info("request started")
+        return func.HttpResponse("ok")
 ```
+
+!!! note
+    On Azure host-managed handlers, `setup_logging(format="json")` is ignored — you must pass `functions_formatter=JsonFormatter()`. `format="json"` applies only to local/standalone scripts.
 
 Fields populated from context:
 
@@ -270,9 +273,9 @@ This design prevents duplicate logs in runtime-managed environments.
 import json
 import logging
 import azure.functions as func
-from azure_functions_logging import get_logger, inject_context, setup_logging
+from azure_functions_logging import JsonFormatter, get_logger, logging_context, setup_logging
 
-setup_logging(level=logging.INFO, format="json")
+setup_logging(level=logging.INFO, functions_formatter=JsonFormatter())
 logger = get_logger(__name__)
 
 app = func.FunctionApp()
@@ -280,24 +283,23 @@ app = func.FunctionApp()
 
 @app.route(route="process")
 def process(req: func.HttpRequest, context: func.Context) -> func.HttpResponse:
-    inject_context(context)
+    with logging_context(context):
+        request_logger = logger.bind(method=req.method, route="/process")
+        request_logger.info("request received")
 
-    request_logger = logger.bind(method=req.method, route="/process")
-    request_logger.info("request received")
+        try:
+            payload = req.get_json()
+            user_id = payload.get("user_id")
 
-    try:
-        payload = req.get_json()
-        user_id = payload.get("user_id")
+            user_logger = request_logger.bind(user_id=user_id)
+            user_logger.info("payload accepted")
 
-        user_logger = request_logger.bind(user_id=user_id)
-        user_logger.info("payload accepted")
-
-        result = {"status": "ok"}
-        user_logger.info("request completed", status="success")
-        return func.HttpResponse(json.dumps(result), mimetype="application/json")
-    except Exception:
-        request_logger.exception("request failed")
-        return func.HttpResponse("internal error", status_code=500)
+            result = {"status": "ok"}
+            user_logger.info("request completed", status="success")
+            return func.HttpResponse(json.dumps(result), mimetype="application/json")
+        except Exception:
+            request_logger.exception("request failed")
+            return func.HttpResponse("internal error", status_code=500)
 ```
 
 ## 9) Advanced Patterns
@@ -339,7 +341,7 @@ Before production rollout:
 
 - `setup_logging()` called once in startup path.
 - `format="json"` enabled where logs are machine-consumed.
-- `inject_context(context)` present in every handler.
+- Handler body wrapped in `with logging_context(context):`.
 - Request-level metadata attached through `bind()`.
 - `host.json` defaults reviewed against required visibility.
 - Dependency logger noise controlled with explicit levels.
@@ -347,7 +349,7 @@ Before production rollout:
 ## 11) Common Pitfalls
 
 - Multiple setup owners in the same process.
-- Missing context injection before first log event.
+- Missing `with logging_context(context):` wrapper before the first log event.
 - Expecting app-level level to override restrictive host policy.
 - Reusing one bound logger across unrelated invocations.
 - Emitting unstructured free-text fields that are hard to query.


### PR DESCRIPTION
## Summary
Closes #343.

The basic-usage docs read fine sentence-by-sentence but did not land as a single obvious path — and in places contradicted each other (a first-time reader learned a non-recommended, and on Azure non-functional, pattern). This unifies them.

## Changes
- **One canonical minimal starter** used verbatim in `index.md`, `getting-started.md`, and `usage.md` (no more three divergent entry snippets).
- **`with logging_context(context):` is now the primary taught pattern** in Quickstart and Usage. Bare `inject_context()` is demoted to an explicit manual-token subsection, with a new **"which context API do I use?"** decision note (`logging_context` vs `@with_context` vs `inject_context`/`restore_context`) and a callout that bare `inject_context()` without `restore_context()` can leak context.
- **Azure JSON examples fixed.** Every Azure Functions handler that emits JSON now uses `functions_formatter=JsonFormatter()` instead of the silently-ignored `setup_logging(format="json")`. `format="json"` is retained only for local/standalone snippets, with a one-line host-handler note at first use.
- **Stale pin fixed:** `azure-functions-logging==0.2.1` → `>=0.10,<1` in `getting-started.md`.
- **Cross-checked `docs/examples/*.md`** and applied the same two fixes to every Azure handler that had them (basic_setup, cold_start_detection, context_binding, context_injection, host_json_conflicts, json_output, logger_name_targeting, third_party_noise_control). Standalone/local `format="json"` snippets and the intentional non-Azure `inject_context` demo were left unchanged.

## Verification
- All 59 Python code blocks across the 12 touched docs parse cleanly (`ast.parse`).
- Automated scan confirms **no** Azure handler block (`@app.route` + `func.Context`) still contains `format="json"` or a bare `inject_context(context)`.

Docs-only; no runtime/API behavior change.