### PR TITLE
ci(e2e): certify the release candidate wheel, not the PyPI build

### DIFF
--- a/.github/workflows/e2e-azure.yml
+++ b/.github/workflows/e2e-azure.yml
@@ -113,6 +113,38 @@ jobs:
           pip install -e ".[dev]"
           pip install requests pytest pytest-html
 
+      - name: Build candidate wheel and bundle into e2e app
+        run: |
+          python -m pip install --upgrade pip build
+          FILE_VERSION=$(grep -Po '(?<=__version__ = ")[^"]*' src/azure_functions_logging/__init__.py)
+          REQ_VERSION="${{ inputs.version }}"
+          if [ -n "$REQ_VERSION" ] && [ "$REQ_VERSION" != "$FILE_VERSION" ]; then
+            echo "::error ::Requested version ($REQ_VERSION) != source version ($FILE_VERSION)"
+            exit 1
+          fi
+          RESOLVED_VERSION="${REQ_VERSION:-$FILE_VERSION}"
+          echo "RESOLVED_VERSION=${RESOLVED_VERSION}" >> "$GITHUB_ENV"
+          python -m build --wheel --outdir dist
+          shopt -s nullglob
+          wheels=(dist/azure_functions_logging-${RESOLVED_VERSION}-*.whl)
+          if [ ${#wheels[@]} -eq 0 ]; then
+            echo "::error ::No candidate wheel matching version ${RESOLVED_VERSION} produced by python -m build"
+            exit 1
+          fi
+          if [ ${#wheels[@]} -gt 1 ]; then
+            echo "::error ::Expected exactly one candidate wheel for ${RESOLVED_VERSION}, found ${#wheels[@]}: ${wheels[*]}"
+            exit 1
+          fi
+          WHEEL="${wheels[0]}"
+          mkdir -p examples/e2e_app/wheels
+          cp "$WHEEL" examples/e2e_app/wheels/
+          BASENAME=$(basename "$WHEEL")
+          # Append the locally-built candidate so the remote Oryx build installs it
+          # instead of resolving azure-functions-logging from PyPI.
+          echo "./wheels/${BASENAME}" >> examples/e2e_app/requirements.txt
+          echo "Bundled candidate wheel: ${BASENAME} (version ${RESOLVED_VERSION})"
+          cat examples/e2e_app/requirements.txt
+
       - name: Publish function app
         working-directory: examples/e2e_app
         run: |
@@ -122,6 +154,7 @@ jobs:
         run: pytest tests/e2e -v --no-cov --html=e2e-report/report.html --self-contained-html
         env:
           E2E_BASE_URL: https://${{ steps.names.outputs.app }}.azurewebsites.net
+          E2E_EXPECTED_VERSION: ${{ env.RESOLVED_VERSION }}
           APPINSIGHTS_NAME: ${{ steps.names.outputs.ai }}
           E2E_RESOURCE_GROUP: ${{ steps.names.outputs.rg }}
 

--- a/examples/e2e_app/function_app.py
+++ b/examples/e2e_app/function_app.py
@@ -10,6 +10,7 @@ Exposes four endpoints:
 
 from __future__ import annotations
 
+import importlib.metadata
 import json
 import logging
 
@@ -31,6 +32,18 @@ app = func.FunctionApp()
 def health(req: func.HttpRequest) -> func.HttpResponse:
     return func.HttpResponse(json.dumps({"status": "ok"}), mimetype="application/json")
 
+
+@app.route(route="version", auth_level=func.AuthLevel.ANONYMOUS)
+def version(req: func.HttpRequest) -> func.HttpResponse:
+    """Report the installed package version so e2e can certify the candidate.
+
+    Proves the deployed host is running the exact wheel bundled by CI rather
+    than whatever is currently published on PyPI.
+    """
+    installed = importlib.metadata.version("azure-functions-logging")
+    return func.HttpResponse(
+        json.dumps({"version": installed}), mimetype="application/json"
+    )
 
 # ── BEFORE: plain Python logging, no library context ─────────────────────
 #

--- a/examples/e2e_app/requirements.txt
+++ b/examples/e2e_app/requirements.txt
@@ -1,2 +1,4 @@
 azure-functions
-azure-functions-logging
+# azure-functions-logging is injected as a locally-built candidate wheel by
+# .github/workflows/e2e-azure.yml (see the "Build candidate wheel" step) so the
+# remote Oryx build certifies the release candidate, not the published PyPI build.

--- a/tests/e2e/test_logging_e2e.py
+++ b/tests/e2e/test_logging_e2e.py
@@ -23,6 +23,7 @@ import pytest
 import requests
 
 BASE_URL = os.environ.get("E2E_BASE_URL", "").rstrip("/")
+EXPECTED_VERSION = os.environ.get("E2E_EXPECTED_VERSION", "").strip()
 APPINSIGHTS_NAME = os.environ.get("APPINSIGHTS_NAME", "")
 APPINSIGHTS_RG = os.environ.get("E2E_RESOURCE_GROUP", "")
 SKIP_REASON = "E2E_BASE_URL not set — skipping real-Azure e2e tests"
@@ -132,3 +133,23 @@ def test_structured_log_appears_in_app_insights() -> None:
     assert len(rows) > 0
     row = rows[0]
     assert CORRELATION_ID in row.get("message", "")
+
+
+@pytest.mark.skipif(not BASE_URL, reason=SKIP_REASON)
+def test_deployed_version_matches_candidate() -> None:
+    """Certify the deployed host runs the candidate wheel, not the PyPI build."""
+    r = _get("/api/version")
+    assert r.status_code == 200
+    deployed = r.json()["version"]
+    # Fail closed: when this test runs at all (BASE_URL is set), a missing/blank
+    # E2E_EXPECTED_VERSION means the workflow wiring regressed and the
+    # certification can no longer prove the deployed host ran the candidate wheel.
+    assert EXPECTED_VERSION, (
+        "E2E_EXPECTED_VERSION is not set — cannot certify that the deployed "
+        "host runs the candidate wheel. Check the e2e-azure workflow wiring."
+    )
+    assert deployed == EXPECTED_VERSION, (
+        f"Deployed version {deployed!r} != expected candidate "
+        f"{EXPECTED_VERSION!r} — remote build did not install the "
+        "bundled wheel"
+    )


### PR DESCRIPTION
## Summary
The real-Azure certification (`e2e-azure.yml`) deployed the e2e app with `--build remote` and an **unpinned**
`azure-functions-logging` in `requirements.txt`, so the remote Oryx build resolved the package from **PyPI**
(the last-published version) rather than the release candidate. The runner's `pip install -e ".[dev]"` only
affected the local pytest client, which makes pure-HTTP requests and never imports the package — so the
certification could pass while the release commit's own runtime was never exercised on Azure.

Fix (mirrors OpenAPI #417 / LangGraph #305, keeping `--build remote`):
- Build a wheel from the checked-out release ref (`python -m build --wheel`), bundle it into
  `examples/e2e_app/wheels/`, and append the local path to the e2e app `requirements.txt` so the remote build
  installs the **candidate** wheel.
- Remove the unpinned `azure-functions-logging` requirement so PyPI is no longer resolved.
- Add a `/api/version` route reporting `importlib.metadata.version("azure-functions-logging")` and an e2e test
  (`test_deployed_version_matches_candidate`) asserting the deployed version equals the resolved release
  version (`E2E_EXPECTED_VERSION`). The test **fails closed** if the expected version is unset, so a workflow
  wiring regression cannot silently pass certification.

## Verification
- `python -m py_compile` and `ruff check` clean on the changed Python files; workflow YAML parses.
- Full certification requires a `workflow_dispatch` run on real Azure (validated post-merge before the next release).

Closes #322