### PR TITLE
fix(logger): report user call sites from FunctionLogger

### DIFF
--- a/src/azure_functions_logging/_logger.py
+++ b/src/azure_functions_logging/_logger.py
@@ -10,6 +10,12 @@ from ._constants import _LIBRARY_RESERVED_KEYS as _LIBRARY_RESERVED_KEYS
 from ._constants import _RESERVED_LOG_RECORD_KEYS as _RESERVED_LOG_RECORD_KEYS
 from ._constants import _STDLIB_RECORD_KEYS as _STDLIB_RECORD_KEYS
 
+# Wrapper frames between a user call and ``self._logger.log(...)``: the public
+# method (e.g. ``info``) and ``_log``. User-facing ``stacklevel`` keeps stdlib
+# semantics (``1`` == caller of the public method); this offset is added
+# internally so records report the user's call site, not a FunctionLogger frame.
+_WRAPPER_STACKLEVEL_OFFSET = 2
+
 
 def _sanitize_extra(extra: dict[str, Any]) -> dict[str, Any]:
     """Rename keys that collide with reserved ``LogRecord`` attributes.
@@ -93,7 +99,7 @@ class FunctionLogger:
         args: tuple[Any, ...],
         exc_info: Any = None,
         stack_info: bool = False,
-        stacklevel: int = 2,
+        stacklevel: int = 1,
         **kwargs: Any,
     ) -> None:
         """Internal log dispatch with context injection."""
@@ -108,7 +114,7 @@ class FunctionLogger:
             *args,
             exc_info=exc_info,
             stack_info=stack_info,
-            stacklevel=stacklevel,
+            stacklevel=stacklevel + _WRAPPER_STACKLEVEL_OFFSET,
             extra=extra,
         )
 

--- a/src/azure_functions_logging/_setup.py
+++ b/src/azure_functions_logging/_setup.py
@@ -72,10 +72,13 @@ def setup_logging(
 
     - **Azure / Core Tools** (``use_record_factory=False``, default): Installs
       ``ContextFilter`` on the root logger's existing handlers **and** on the
-      root logger itself (so handlers attached later also receive context
-      fields). Does NOT add new handlers or modify the root logger level
-      (respects ``host.json`` configuration). If ``functions_formatter`` is
-      provided, it is applied to every root handler before the filter is added.
+      root logger itself (so records emitted directly on the root logger also
+      carry context fields; note this does not cover records that merely
+      propagate up from named child loggers — those are filtered only by the
+      handler-level filters). Does NOT add new handlers or modify the root
+      logger level (respects ``host.json`` configuration). If
+      ``functions_formatter`` is provided, it is applied to every root handler
+      before the filter is added.
       When ``use_record_factory=True``, no ``ContextFilter`` is attached;
       context injection happens via the global ``LogRecordFactory`` instead.
     - **Standalone local development**: Adds a ``StreamHandler`` with
@@ -198,8 +201,10 @@ def setup_logging(
                 if context_filter is not None:
                     handler.addFilter(context_filter)
                 configured_handlers.add(handler)
-            # Install filter on root logger itself so handlers attached later
-            # (before the next setup_logging() call) also inherit it.
+            # Install the filter on the root logger itself so records emitted
+            # directly on the root logger also carry context. This does NOT
+            # apply to records propagating up from named child loggers, which
+            # are only seen by the handler-level filters added above.
             if context_filter is not None and context_filter not in root.filters:
                 root.addFilter(context_filter)
 

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -395,3 +395,118 @@ def test_stdlib_record_keys_are_immune_to_custom_logrecord_factory() -> None:
         )
     finally:
         logging.setLogRecordFactory(original_factory)
+
+
+# ---------------------------------------------------------------------------
+# Caller source-location contract (issue #347)
+#
+# The emitted LogRecord must report the *user's* call site, not a frame inside
+# FunctionLogger. These use a real logging.Logger + capturing handler because
+# pathname/lineno/funcName are computed by logging.Logger.findCaller, which a
+# MagicMock underlying logger bypasses entirely.
+# ---------------------------------------------------------------------------
+
+
+class _RecordCapture(logging.Handler):
+    def __init__(self) -> None:
+        super().__init__()
+        self.records: list[logging.LogRecord] = []
+
+    def emit(self, record: logging.LogRecord) -> None:
+        self.records.append(record)
+
+
+def _capturing_logger(name: str) -> tuple[FunctionLogger, _RecordCapture]:
+    base = logging.getLogger(name)
+    base.handlers.clear()
+    base.setLevel(logging.DEBUG)
+    base.propagate = False
+    capture = _RecordCapture()
+    base.addHandler(capture)
+    return FunctionLogger(base), capture
+
+
+@pytest.mark.parametrize("method", ["debug", "info", "warning", "error", "critical"])
+def test_public_methods_report_caller_source_location(method: str) -> None:
+    logger, capture = _capturing_logger(f"test.stacklevel.{method}")
+
+    getattr(logger, method)("msg")
+
+    record = capture.records[-1]
+    assert record.filename == "test_logger.py"
+    assert record.funcName == "test_public_methods_report_caller_source_location"
+
+
+def test_exception_reports_caller_source_location() -> None:
+    logger, capture = _capturing_logger("test.stacklevel.exception")
+
+    try:
+        raise ValueError("boom")
+    except ValueError:
+        logger.exception("failed")
+
+    record = capture.records[-1]
+    assert record.filename == "test_logger.py"
+    assert record.funcName == "test_exception_reports_caller_source_location"
+    assert record.exc_info is not None
+
+
+def test_log_reports_caller_source_location() -> None:
+    logger, capture = _capturing_logger("test.stacklevel.logmethod")
+
+    logger.log(logging.INFO, "msg")
+
+    record = capture.records[-1]
+    assert record.filename == "test_logger.py"
+    assert record.funcName == "test_log_reports_caller_source_location"
+
+
+def test_caller_resolution_matches_stdlib_exactly() -> None:
+    """FunctionLogger resolves the identical call site stdlib does.
+
+    Both loggers emit through the *same* helper function, so a correct
+    implementation must agree with the standard library on filename, funcName
+    and lineno across the supported Python matrix — no brittle line arithmetic.
+    """
+    fl, fl_cap = _capturing_logger("test.stacklevel.parity.fl")
+    std = logging.getLogger("test.stacklevel.parity.std")
+    std.handlers.clear()
+    std.setLevel(logging.DEBUG)
+    std.propagate = False
+    std_cap = _RecordCapture()
+    std.addHandler(std_cap)
+
+    def _emit(lg: object) -> None:
+        lg.info("x")  # type: ignore[attr-defined]
+
+    _emit(fl)
+    _emit(std)
+
+    fl_record, std_record = fl_cap.records[-1], std_cap.records[-1]
+    assert fl_record.funcName == std_record.funcName == "_emit"
+    assert fl_record.filename == std_record.filename == "test_logger.py"
+    assert fl_record.lineno == std_record.lineno
+
+
+def test_explicit_stacklevel_walks_further_up_like_stdlib() -> None:
+    """User-facing stacklevel keeps stdlib semantics: 2 == the caller's caller."""
+    fl, fl_cap = _capturing_logger("test.stacklevel.explicit.fl")
+    std = logging.getLogger("test.stacklevel.explicit.std")
+    std.handlers.clear()
+    std.setLevel(logging.DEBUG)
+    std.propagate = False
+    std_cap = _RecordCapture()
+    std.addHandler(std_cap)
+
+    def _emit(lg: object) -> None:
+        lg.info("msg", stacklevel=2)  # type: ignore[attr-defined]
+
+    def _caller(lg: object) -> None:
+        _emit(lg)
+
+    _caller(fl)
+    _caller(std)
+
+    fl_record, std_record = fl_cap.records[-1], std_cap.records[-1]
+    assert fl_record.funcName == std_record.funcName == "_caller"
+    assert fl_record.lineno == std_record.lineno


### PR DESCRIPTION
## Summary

- `FunctionLogger`'s public methods forwarded through **two** wrapper frames (the public method + `_log`), but `_log` defaulted `stacklevel=2`, so every emitted record's `pathname`/`filename`/`lineno`/`funcName` — and, under OpenTelemetry, `code.filepath`/`code.lineno`/`code.function` — pointed inside `_logger.py` instead of the user's call site.
- User-facing `stacklevel` now carries standard `logging` semantics (`1` == the direct caller of the public method); a fixed wrapper offset (`_WRAPPER_STACKLEVEL_OFFSET = 2`) is added internally before forwarding to `logging.Logger.log`. This also fixes explicit `stacklevel=` (e.g. `logger.info(..., stacklevel=2)`), which previously landed inside `FunctionLogger`.
- Corrects the misleading root-filter comment/docstring in `_setup.py` that implied late-attached handlers "inherit" root filters (untrue for records propagating from named child loggers).

## Tests

- Adds output-contract regression tests using a real `logging.Logger` + capturing handler (a `MagicMock` bypasses `findCaller`, the exact thing under test):
  - `debug`/`info`/`warning`/`error`/`critical` and `exception`/`log` resolve `filename`/`funcName` to the caller, not `_logger.py`.
  - Stdlib-parity check: emitting through a shared helper yields identical `filename`/`funcName`/`lineno` to a raw stdlib logger (version-robust, no brittle line arithmetic).
  - Explicit `stacklevel=2` walks one further frame, matching stdlib.
- Full suite green, coverage 96.59% (>= 95% gate). `ruff check`, `ruff format --check`, `mypy` all clean.

Closes #347