### PR TITLE
docs: fix stale repo URLs in module docstrings

### DIFF
--- a/src/azure_functions_logging/_decorator.py
+++ b/src/azure_functions_logging/_decorator.py
@@ -3,7 +3,7 @@
 Provides ``with_context`` — a decorator that calls ``inject_context()``
 before the handler runs and restores previous context variables after it completes.
 
-Ref: https://github.com/yeongseon/azure-functions-logging/issues/22
+Ref: https://github.com/yeongseon/azure-functions-logging-python/issues/22
 """
 
 from __future__ import annotations

--- a/src/azure_functions_logging/_metadata_helpers.py
+++ b/src/azure_functions_logging/_metadata_helpers.py
@@ -11,7 +11,7 @@ The primitive is intentionally kept as a small, dependency-free unit so the
 packages are independent PyPI distributions with no shared base dependency, so
 "shared" here means a canonical, synced definition rather than a common import.
 
-Ref: https://github.com/yeongseon/azure-functions-logging/issues/216
+Ref: https://github.com/yeongseon/azure-functions-logging-python/issues/216
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## Summary
- Fix stale `Ref:` URLs in `_decorator.py` and `_metadata_helpers.py` that pointed at the old `azure-functions-logging` repo path instead of the current `azure-functions-logging-python` repo.

Closes #349

## Notes
- Docstring-only change; no runtime behavior affected.
- The `azure-functions-logging` mention in `_metadata_helpers.py` prose (a PyPI distribution name, not a URL) is intentionally left unchanged.