### PR TITLE
fix(formatter): suppress color outside TTY and honor NO_COLOR

### DIFF
--- a/src/azure_functions_logging/_formatter.py
+++ b/src/azure_functions_logging/_formatter.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import os
 import sys
 from typing import Iterable
 
@@ -65,9 +66,10 @@ class ColorFormatter(logging.Formatter):
         # Time
         time_str = self.formatTime(record, "%H:%M:%S")
 
-        # Level with color
-        color = _COLORS.get(record.levelno, "")
-        level_str = f"{color}{record.levelname:<8}{_RESET}"
+        # Level with color (only on an interactive TTY and when NO_COLOR is unset)
+        color = _COLORS.get(record.levelno, "") if self._should_use_color() else ""
+        reset = _RESET if color else ""
+        level_str = f"{color}{record.levelname:<8}{reset}"
 
         # Logger name
         name_str = record.name
@@ -111,6 +113,12 @@ class ColorFormatter(logging.Formatter):
             base += f"\n{record.stack_info}"
 
         return base
+
+    @staticmethod
+    def _should_use_color() -> bool:
+        if os.environ.get("NO_COLOR") is not None:
+            return False
+        return ColorFormatter.is_tty()
 
     @staticmethod
     def is_tty() -> bool:

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import logging
 import sys
 
+import pytest
+
 from azure_functions_logging._formatter import ColorFormatter
 
 
@@ -156,3 +158,44 @@ def test_include_extra_with_allowlist_filters_keys() -> None:
 
     assert "user_id=u1" in output
     assert "request_id" not in output
+
+
+def test_non_tty_output_has_no_ansi_escape(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(ColorFormatter, "is_tty", staticmethod(lambda: False))
+    monkeypatch.delenv("NO_COLOR", raising=False)
+    formatter = ColorFormatter()
+
+    output = formatter.format(_make_record(msg="piped"))
+
+    assert "\033" not in output
+    assert "INFO" in output
+
+
+def test_no_color_env_suppresses_color_even_on_tty(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(ColorFormatter, "is_tty", staticmethod(lambda: True))
+    monkeypatch.setenv("NO_COLOR", "1")
+    formatter = ColorFormatter()
+
+    output = formatter.format(_make_record(msg="no color"))
+
+    assert "\033" not in output
+
+
+def test_interactive_tty_without_no_color_colorizes(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(ColorFormatter, "is_tty", staticmethod(lambda: True))
+    monkeypatch.delenv("NO_COLOR", raising=False)
+    formatter = ColorFormatter()
+
+    output = formatter.format(_make_record(msg="colored"))
+
+    assert "\033" in output
+
+
+def test_no_color_empty_string_still_suppresses(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(ColorFormatter, "is_tty", staticmethod(lambda: True))
+    monkeypatch.setenv("NO_COLOR", "")
+    formatter = ColorFormatter()
+
+    output = formatter.format(_make_record(msg="empty no color"))
+
+    assert "\033" not in output


### PR DESCRIPTION
## Summary
- `ColorFormatter.format()` now emits ANSI color only when writing to an interactive TTY (wires up the previously-dead `is_tty()` helper) and when the `NO_COLOR` env var is unset.
- Adds `_should_use_color()` gate: `NO_COLOR` (set to any value, including empty string) suppresses color regardless of TTY status.

Closes #348

## Behavior
- Piped/redirected/CI output no longer leaks raw `\033[` escape sequences.
- Honors the [NO_COLOR](https://no-color.org/) convention for interactive opt-out.

## Tests
- non-TTY output contains no `\033` escape
- `NO_COLOR` set suppresses color even on a simulated TTY (incl. empty-string value)
- interactive TTY without `NO_COLOR` still colorizes

Coverage 96.61% (>= 95%); ruff + mypy clean.