### PR TITLE
docs(examples): show Application Insights query results for each example

### DIFF
--- a/docs/examples/basic_setup.md
+++ b/docs/examples/basic_setup.md
@@ -123,6 +123,27 @@ def ping(req: func.HttpRequest, context: func.Context) -> func.HttpResponse:
 
 This adds invocation context fields automatically when available.
 
+## In Application Insights
+
+After deploying this handler and sending a request to `/api/ping`, query the `traces` table in Application Insights Logs. The exact schema depends on your ingestion pipeline — the `customDimensions`-parsed shape is shown here (see the [deployment query guide](../deployment.md#inspect-traces-and-requests) for the raw-`message` variant).
+
+```kql
+traces
+| where customDimensions.function_name == "ping"
+| project timestamp, message, customDimensions.invocation_id, customDimensions.function_name, customDimensions.cold_start
+| order by timestamp asc
+```
+
+Expected result (first request on a fresh worker):
+
+| timestamp | message | invocation_id | function_name | cold_start |
+| --- | --- | --- | --- | --- |
+| 2026-03-14T10:20:30.12Z | ping received | `abc-123-def` | `ping` | `true` |
+
+The same `logger.info("ping received")` call is now correlated by `invocation_id` and carries a `cold_start` signal — no change to your logging calls.
+
+> If your pipeline leaves the JSON inside the `message` column instead, use `extend payload = parse_json(message)` and read `payload.invocation_id` / `payload.cold_start`.
+
 ## Troubleshooting Quick Checks
 
 - No logs: confirm `setup_logging()` executed before first log call.

--- a/docs/examples/cold_start_detection.md
+++ b/docs/examples/cold_start_detection.md
@@ -46,6 +46,41 @@ After starting a new process:
 
 The first invocation after startup is your cold start marker.
 
+## In Application Insights
+
+After deploying and sending a few requests to `/api/status`, query the `traces` table. The `customDimensions`-parsed shape is shown here (see the [deployment query guide](../deployment.md#inspect-traces-and-requests) for the raw-`message` variant).
+
+```kql
+traces
+| where customDimensions.function_name == "status"
+| where message == "status endpoint hit"
+| project timestamp, customDimensions.invocation_id, customDimensions.cold_start
+| order by timestamp asc
+```
+
+Expected result — only the first row of a fresh worker is flagged:
+
+| timestamp | invocation_id | cold_start |
+| --- | --- | --- |
+| 2026-03-14T10:20:30.12Z | `abc-123-def` | `true` |
+| 2026-03-14T10:20:41.55Z | `def-456-ghi` | `false` |
+| 2026-03-14T10:20:52.09Z | `ghi-789-jkl` | `false` |
+
+Cold start ratio over the last hour (matches the [metrics pattern](#metrics-pattern-cold-start-ratio) above):
+
+```kql
+traces
+| where timestamp > ago(1h)
+| summarize cold = countif(customDimensions.cold_start == "true"), total = count()
+| extend cold_start_ratio = todouble(cold) / total
+```
+
+| cold | total | cold_start_ratio |
+| --- | --- | --- |
+| 3 | 420 | 0.0071 |
+
+> If your pipeline leaves the JSON inside the `message` column instead, use `extend payload = parse_json(message)` and read `payload.cold_start`.
+
 ## Local Verification Steps
 
 1. Start local function host.

--- a/docs/examples/context_binding.md
+++ b/docs/examples/context_binding.md
@@ -95,6 +95,28 @@ This combines:
 - Global invocation fields from `logging_context(context)`.
 - Per-request keys from `bind()`.
 
+## In Application Insights
+
+After deploying and requesting `/api/orders/o-42`, query the `traces` table. Bound keys land under `customDimensions` alongside the injected invocation fields (see the [deployment query guide](../deployment.md#inspect-traces-and-requests) for the raw-`message` variant).
+
+```kql
+traces
+| where customDimensions.order_id == "o-42"
+| project timestamp, message, customDimensions.invocation_id, customDimensions.order_id, customDimensions.method
+| order by timestamp asc
+```
+
+Expected result — both lifecycle events share the same `invocation_id` and bound `order_id`/`method`:
+
+| timestamp | message | invocation_id | order_id | method |
+| --- | --- | --- | --- | --- |
+| 2026-03-14T10:20:30.12Z | lookup started | `abc-123-def` | `o-42` | `GET` |
+| 2026-03-14T10:20:30.34Z | lookup completed | `abc-123-def` | `o-42` | `GET` |
+
+The bound `order_id` lets you slice every log for one order in a single query, without threading it through each call.
+
+> If your pipeline leaves the JSON inside the `message` column instead, use `extend payload = parse_json(message)` and read `payload.order_id`.
+
 ## Recommended Binding Dimensions
 
 Good binding keys are stable per request scope:

--- a/docs/examples/context_injection.md
+++ b/docs/examples/context_injection.md
@@ -35,6 +35,27 @@ def hello(req: func.HttpRequest, context: func.Context) -> func.HttpResponse:
 | `span_id` | `context.trace_context.trace_parent` (span ID portion) | `b7ad...` |
 | `cold_start` | internal first-call detection | `true` or `false` |
 
+## In Application Insights
+
+After deploying the baseline handler and requesting `/api/hello`, query the `traces` table. The `customDimensions`-parsed shape is shown here (see the [deployment query guide](../deployment.md#inspect-traces-and-requests) for the raw-`message` variant).
+
+```kql
+traces
+| where customDimensions.function_name == "hello"
+| project timestamp, message, customDimensions.invocation_id, customDimensions.trace_id, customDimensions.span_id, customDimensions.cold_start
+| order by timestamp asc
+```
+
+Expected result:
+
+| timestamp | message | invocation_id | trace_id | span_id | cold_start |
+| --- | --- | --- | --- | --- | --- |
+| 2026-03-14T10:20:30.12Z | request started | `9f87...` | `7ed7...` | `b7ad...` | `true` |
+
+`trace_id` and `span_id` are populated only when the host supplies W3C trace context; otherwise they appear as `null`. All events emitted inside the same `with logging_context(context):` block share the same `invocation_id`.
+
+> If your pipeline leaves the JSON inside the `message` column instead, use `extend payload = parse_json(message)` and read `payload.invocation_id` / `payload.trace_id`.
+
 ## Why Open the Context Block Early
 
 Open `with logging_context(context):` at the very top of each handler, before business logic:

--- a/docs/examples/host_json_conflicts.md
+++ b/docs/examples/host_json_conflicts.md
@@ -94,6 +94,34 @@ def orders(req: func.HttpRequest, context: func.Context) -> func.HttpResponse:
 
 If `INFO` does not appear, inspect `host.json` first.
 
+## In Application Insights
+
+`host.json` conflicts are visible as *missing rows*, not error messages. After deploying and requesting `/api/orders`, query the `traces` table by severity level (see the [deployment query guide](../deployment.md#inspect-traces-and-requests) for the raw-`message` variant).
+
+```kql
+traces
+| where customDimensions.function_name == "orders"
+| project timestamp, message, severityLevel, customDimensions.invocation_id
+| order by timestamp asc
+```
+
+With a **conflicting** `host.json` (`"default": "Warning"`), the `INFO` line never reaches Application Insights — only the warning is ingested:
+
+| timestamp | message | severityLevel |
+| --- | --- | --- |
+| 2026-03-14T10:20:30.34Z | orders validation warning | 2 |
+
+With the **corrected** `host.json` (`"default": "Information"`), both events appear:
+
+| timestamp | message | severityLevel |
+| --- | --- | --- |
+| 2026-03-14T10:20:30.12Z | orders request started | 1 |
+| 2026-03-14T10:20:30.34Z | orders validation warning | 2 |
+
+The library's startup conflict warning tells you *before* you go hunting for these missing rows.
+
+> If your pipeline leaves the JSON inside the `message` column instead, use `extend payload = parse_json(message)` and read `payload.message`.
+
 ## Validation Checklist
 
 1. Verify app setup level.

--- a/docs/examples/json_output.md
+++ b/docs/examples/json_output.md
@@ -99,6 +99,27 @@ def create_order(req: func.HttpRequest, context: func.Context) -> func.HttpRespo
 
 With context injection, invocation fields are populated for every event in this request context.
 
+## In Application Insights
+
+After deploying and requesting `/api/orders`, query the `traces` table. Top-level fields and `extra.*` keys land under `customDimensions` (see the [deployment query guide](../deployment.md#inspect-traces-and-requests) for the raw-`message` variant).
+
+```kql
+traces
+| where customDimensions.function_name == "create_order"
+| project timestamp, message, customDimensions.invocation_id, customDimensions.method, customDimensions.route
+| order by timestamp asc
+```
+
+Expected result:
+
+| timestamp | message | invocation_id | method | route |
+| --- | --- | --- | --- | --- |
+| 2026-03-14T10:20:30.12Z | request received | `abc-123-def` | `GET` | `/orders` |
+
+Application-specific dimensions passed as keyword arguments (e.g. `order_id`, `tenant_id`) surface the same way, so you can slice on `customDimensions.tenant_id` for multi-tenant analysis.
+
+> If your pipeline leaves the JSON inside the `message` column instead, use `extend payload = parse_json(message)` and read `payload.method` / `payload.route`.
+
 ## Production Query Patterns
 
 Typical query dimensions from JSON output:

--- a/docs/examples/logger_name_targeting.md
+++ b/docs/examples/logger_name_targeting.md
@@ -75,6 +75,27 @@ def payments(req: func.HttpRequest, context: func.Context) -> func.HttpResponse:
         return func.HttpResponse("ok")
 ```
 
+## In Application Insights
+
+After deploying and requesting `/api/payments`, query the `traces` table filtered by logger name. The named-logger identity is preserved in `customDimensions.logger` (see the [deployment query guide](../deployment.md#inspect-traces-and-requests) for the raw-`message` variant).
+
+```kql
+traces
+| where customDimensions.logger == "payments.http"
+| project timestamp, message, customDimensions.logger, customDimensions.invocation_id, customDimensions.route
+| order by timestamp asc
+```
+
+Expected result — only the targeted `payments.*` hierarchy appears:
+
+| timestamp | message | logger | invocation_id | route |
+| --- | --- | --- | --- | --- |
+| 2026-03-14T10:20:30.12Z | payments request | `payments.http` | `abc-123-def` | `/payments` |
+
+Filtering on `customDimensions.logger` lets you build a dashboard scoped to one subsystem while other hierarchies (e.g. `inventory`) stay out of view.
+
+> If your pipeline leaves the JSON inside the `message` column instead, use `extend payload = parse_json(message)` and read `payload.logger`.
+
 ## Common Pitfalls
 
 - Mixing unrelated logger names and expecting same behavior.

--- a/docs/examples/third_party_noise_control.md
+++ b/docs/examples/third_party_noise_control.md
@@ -59,6 +59,37 @@ def orders(req: func.HttpRequest, context: func.Context) -> func.HttpResponse:
 
 With noise controls, these app events remain visible and query-friendly.
 
+## In Application Insights
+
+Noise control changes *what does not arrive*. After deploying and requesting `/api/orders`, your application events surface cleanly instead of being buried under dependency chatter (see the [deployment query guide](../deployment.md#inspect-traces-and-requests) for the raw-`message` variant).
+
+```kql
+traces
+| where customDimensions.logger == "orders"
+| project timestamp, message, customDimensions.invocation_id, customDimensions.route
+| order by timestamp asc
+```
+
+Expected result — clean application lifecycle events, undiluted by `urllib3` / `azure.core` info logs:
+
+| timestamp | message | invocation_id | route |
+| --- | --- | --- | --- |
+| 2026-03-14T10:20:30.12Z | request started | `abc-123-def` | `/orders` |
+| 2026-03-14T10:20:30.28Z | request completed | `abc-123-def` | `/orders` |
+
+To confirm the suppression worked, compare dependency volume before and after tuning:
+
+```kql
+traces
+| where timestamp > ago(1h)
+| summarize count() by tostring(customDimensions.logger)
+| order by count_ desc
+```
+
+Suppressed namespaces (`urllib3`, `azure`, `azure.core.pipeline.policies.http_logging_policy`) should drop to warnings-and-above volume, while `orders` keeps full `INFO` visibility.
+
+> If your pipeline leaves the JSON inside the `message` column instead, use `extend payload = parse_json(message)` and read `payload.logger`.
+
 ## Suggested Namespace Policies
 
 | Namespace | Suggested Level | Reason |


### PR DESCRIPTION
## Context

The `docs/examples/*.md` guides previously demonstrated only *usage* — setup code plus expected local terminal/JSON output. They stopped short of showing what those logs look like once they reach Azure. This adds, to each of the 8 example guides, an **"In Application Insights"** section so readers see the end-to-end result: the KQL query to run against the `traces` table plus an expected result table.

Per the repo's cross-cloud constraint (real Azure portal screenshots require a live deployment the agent can't produce — tracked in #298), these are **text-based** results (KQL + expected-result tables), consistent with the shape already established in `README.md` and `docs/deployment.md`.

## What changed

Each example now has a tailored "In Application Insights" section using that example's actual route / logger / message / fields:

- `basic_setup.md` — `/api/ping`, invocation_id + cold_start
- `cold_start_detection.md` — `/api/status`, cold_start flagging + cold-start-ratio summarize query
- `context_binding.md` — `/api/orders/{order_id}`, bound `order_id`/`method` under customDimensions
- `context_injection.md` — `/api/hello`, invocation_id/trace_id/span_id/cold_start
- `json_output.md` — `/api/orders`, top-level + `extra.*` fields as customDimensions
- `host_json_conflicts.md` — severity-level query showing the suppressed INFO row (missing vs present)
- `logger_name_targeting.md` — filter on `customDimensions.logger == "payments.http"`
- `third_party_noise_control.md` — app events surfacing + before/after dependency-volume query

Every section follows the `customDimensions`-parsed shape as primary and links to the existing [deployment query guide](../deployment.md#inspect-traces-and-requests) for the raw-`message` variant, matching the README's scope disclaimer.

## Acceptance Checklist

- [x] All 8 example guides gain an "In Application Insights" section
- [x] Queries use each example's real route/logger/message/field names
- [x] `mkdocs build --strict` passes locally (no broken links/anchors)
- [x] Intra-docs links only (no links outside `docs_dir`)

## Out of scope

- Real Azure portal screenshots for the example guides — requires a live deployment; tracked in #298.

## References

- Convention source: `README.md` "Query in Application Insights", `docs/deployment.md` "Inspect traces and requests"