### PR TITLE
fix(otel): don't overwrite an active local span in activated_trace_context

### DIFF
--- a/src/azure_functions_logging/_otel.py
+++ b/src/azure_functions_logging/_otel.py
@@ -81,6 +81,15 @@ def activated_trace_context(
     * OpenTelemetry is not installed (:func:`is_available` is ``False``);
     * the extracted span context is invalid (a no-op span) -- attaching it
       would break the trace tree, so the current context is left untouched;
+    * a valid **local** span is already active in the current context (e.g. the
+      OTel distro's auto-instrumentation or the user's
+      ``start_as_current_span``); overwriting it with the host's non-recording
+      remote span would strip the real ``span_id`` from log records and
+      re-parent nested spans, so the already-active local span is left in
+      place -- it already supplies correlation. A currently-active *remote*
+      span (i.e. a host traceparent attached by an enclosing activation) is
+      NOT protected: a nested activation may replace it with its own host
+      context;
     * extraction/attach fails for any reason (malformed header, etc.).
 
     Args:
@@ -106,12 +115,29 @@ def activated_trace_context(
     token = None
     try:
         extracted = otel_extract(carrier)
-        # Only attach a valid remote span context. An invalid/no-op span
-        # context (e.g. the host emitted no real trace) must not be attached,
-        # otherwise downstream log records get parented to an invalid context
-        # and the trace tree breaks. Leave the current context untouched.
+        # Attach the host's remote span context only when it is BOTH valid AND
+        # there is no already-active *real local* span in the current context.
+        #
+        # An invalid/no-op extracted context (e.g. the host emitted no real
+        # trace) must not be attached: downstream records would be parented to
+        # an invalid context and the trace tree would break.
+        #
+        # A currently-active *local* span (worker auto-instrumentation or the
+        # user's own ``start_as_current_span``) must win: this helper exists to
+        # rescue records orphaned (``span_id=0``) precisely BECAUSE no span is
+        # active. Overwriting a real local span with the host's non-recording
+        # remote span would break the very log<->span correlation the feature
+        # promises and flatten nested spans -- leave it untouched.
+        #
+        # A currently-active *remote* span is only a previously-attached host
+        # traceparent, not a real worker span, so a nested activation is allowed
+        # to replace it (see test_spike_nested_contexts_restore_outer_span).
         span_context = otel_trace.get_current_span(extracted).get_span_context()
-        if span_context.is_valid:
+        current_span_context = otel_trace.get_current_span().get_span_context()
+        current_is_real_local_span = (
+            current_span_context.is_valid and not current_span_context.is_remote
+        )
+        if span_context.is_valid and not current_is_real_local_span:
             token = otel_context.attach(extracted)
     except Exception:  # nosec B110 — Principle 3: context failures are silent
         token = None

--- a/tests/test_otel.py
+++ b/tests/test_otel.py
@@ -129,6 +129,57 @@ def test_activated_trace_context_invalid_preserves_existing_context() -> None:
     assert not trace.get_current_span().get_span_context().is_valid
 
 
+def test_activated_trace_context_preserves_already_active_span() -> None:
+    # F1 (issue #358): when a valid *local* span is ALREADY active in the
+    # current context (e.g. auto-instrumentation or the user's own
+    # ``start_as_current_span``), the host's non-recording remote span must
+    # NOT overwrite it. Overwriting would strip the real ``span_id`` from log
+    # records and re-parent nested spans. The already-active local span wins.
+    pytest.importorskip("opentelemetry.sdk.trace")
+    from opentelemetry import trace
+    from opentelemetry.sdk.trace import TracerProvider
+
+    tracer = TracerProvider().get_tracer("afl.otel.f1")
+    with tracer.start_as_current_span("active") as active_span:
+        active_sc = active_span.get_span_context()
+        assert active_sc.is_valid
+        # Activation must be a no-op: the real active span stays current, and
+        # the host's ``_PARENT_ID_HEX`` span_id never takes over.
+        with _otel.activated_trace_context(_TRACEPARENT):
+            current = trace.get_current_span().get_span_context()
+            assert current.span_id == active_sc.span_id
+            assert current.trace_id == active_sc.trace_id
+            assert format(current.span_id, "016x") != _PARENT_ID_HEX
+        # Still the real active span after the block (nothing detached).
+        assert trace.get_current_span().get_span_context().span_id == active_sc.span_id
+
+
+def test_activated_trace_context_nested_host_override() -> None:
+    # F1 boundary (issue #358): a currently-active *remote* span is only a
+    # previously-attached host traceparent, not a real worker span, so a nested
+    # host activation IS allowed to override it (mirrors the public-API spike
+    # test_spike_nested_contexts_restore_outer_span). The outer host span is
+    # restored on exit of the inner block.
+    pytest.importorskip("opentelemetry.context")
+    from opentelemetry import trace
+
+    _TRACE_ID_B = "0af7651916cd43dd8448eb211c80319c"
+    _PARENT_ID_B = "b7ad6b7169203331"
+    _TRACEPARENT_B = f"00-{_TRACE_ID_B}-{_PARENT_ID_B}-01"
+
+    with _otel.activated_trace_context(_TRACEPARENT):
+        outer = trace.get_current_span().get_span_context()
+        assert format(outer.span_id, "016x") == _PARENT_ID_HEX
+        with _otel.activated_trace_context(_TRACEPARENT_B):
+            inner = trace.get_current_span().get_span_context()
+            # The nested host context overrides the enclosing remote one.
+            assert format(inner.span_id, "016x") == _PARENT_ID_B
+            assert format(inner.trace_id, "032x") == _TRACE_ID_B
+        # Outer host span restored (LIFO detach).
+        assert format(trace.get_current_span().get_span_context().span_id, "016x") == _PARENT_ID_HEX
+    assert not trace.get_current_span().get_span_context().is_valid
+
+
 # ---------------------------------------------------------------------------
 # Integration: activation wired through the public entry points
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

`activated_trace_context()` bound the host's remote W3C trace context whenever the extracted span was valid, **without inspecting the current execution context**. When a real *local* span was already active — e.g. the Azure Monitor OTel distro's auto-instrumentation (requests/urllib3) or the user's own `start_as_current_span` — `attach()` replaced it with the host's non-recording remote span for the duration of the block.

Consequences (the exact correlation the feature promises, broken):
- Log records inside the block inherited the **host** `span_id` instead of the real active span's.
- Spans created inside the block were re-parented to the host remote span, flattening the trace tree.

## Fix

Attach the host context **only when there is no active real *local* span**:

```python
current_is_real_local_span = (
    current_span_context.is_valid and not current_span_context.is_remote
)
if span_context.is_valid and not current_is_real_local_span:
    token = otel_context.attach(extracted)
```

A currently-active *remote* span is only a previously-attached host traceparent (not a real worker span), so a **nested** activation may still override it — preserving the documented nested-override behaviour (`test_spike_nested_contexts_restore_outer_span` stays green).

This semantics was validated with the Oracle: protect real local spans; treat remote extracted contexts as replaceable. Trace-id comparison was explicitly rejected as the wrong axis.

## Tests
- `test_activated_trace_context_preserves_already_active_span` — a live `start_as_current_span` is **not** overwritten by host activation.
- `test_activated_trace_context_nested_host_override` — a nested host traceparent **does** override an enclosing remote context, and the outer span is restored (LIFO) on exit.
- Existing `test_spike_nested_contexts_restore_outer_span` unchanged and passing.

## Verification
- `make lint` ✅  `make typecheck` ✅
- Full suite: 473 passed, 5 skipped (the sole failure is the pre-existing unbuilt-env `test_version_matches_distribution_metadata`, unrelated).
- Coverage 96.59% (≥95% gate held).

Fixes #358