### PR TITLE
fix(setup): stop double-logging on standalone named loggers

### DIFF
--- a/src/azure_functions_logging/_setup.py
+++ b/src/azure_functions_logging/_setup.py
@@ -84,7 +84,10 @@ def setup_logging(
     - **Standalone local development**: Adds a ``StreamHandler`` with
       ``ColorFormatter`` or ``JsonFormatter`` to the specified logger
       (or root logger if ``logger_name`` is None). Sets the level.
-      Pass an explicit ``logger_name`` to avoid modifying the root logger.
+      Pass an explicit ``logger_name`` to avoid modifying the root logger;
+      when a handler is added to a named logger this way, its
+      ``propagate`` flag is set to ``False`` so records are not also emitted
+      by an ancestor (e.g. root) handler, which would double-log.
 
     This function is idempotent per ``logger_name`` — calling it multiple times
     for the same logger has no additional effect.
@@ -232,6 +235,15 @@ def setup_logging(
                 if context_filter is not None:
                     handler.addFilter(context_filter)
                 target.addHandler(handler)
+                if logger_name is not None:
+                    # This named logger now owns its output via the handler we
+                    # just added. Stop propagation to ancestor loggers so a
+                    # handler already on the root logger (e.g. from
+                    # ``basicConfig``, pytest, or a framework) does not emit
+                    # every record a SECOND time. The root logger
+                    # (``logger_name=None``) has no ancestor to double-emit to,
+                    # so its propagation is left untouched.
+                    target.propagate = False
             elif context_filter is not None:
                 # Add filter to existing handlers
                 for handler in target.handlers:

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -699,3 +699,75 @@ class TestInjectionModeParity:
         assert {k: factory_fields[k] for k in context_derived} == expected, factory_fields
         assert isinstance(filter_fields["cold_start"], bool)
         assert isinstance(factory_fields["cold_start"], bool)
+
+
+def test_setup_logging_named_logger_disables_propagation() -> None:
+    # F2 (issue #359): when setup_logging adds its own handler to a NAMED
+    # logger, propagation must be disabled so a handler already on the root
+    # logger does not emit every record a second time (double-logging).
+    logger_name = "afl.test.no_double_log"
+    logger = logging.getLogger(logger_name)
+    logger.handlers.clear()
+    logger.filters.clear()
+    logger.propagate = True  # start from the stdlib default
+
+    with patch.dict(os.environ, {}, clear=True):
+        setup_logging(logger_name=logger_name)
+
+    assert logger.propagate is False
+    assert len(logger.handlers) == 1
+
+    logger.handlers.clear()
+    logger.filters.clear()
+    logger.propagate = True
+
+
+def test_setup_logging_named_logger_no_double_emit_when_root_has_handler(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    # End-to-end proof of #359: with a handler on the root logger, a record on
+    # the configured named logger must be emitted exactly ONCE.
+    logger_name = "afl.test.no_double_log.e2e"
+    root = logging.getLogger()
+    saved_root_handlers = root.handlers[:]
+    root_handler = logging.StreamHandler()
+    root_handler.setFormatter(logging.Formatter("ROOT %(message)s"))
+    root.handlers = [root_handler]
+
+    logger = logging.getLogger(logger_name)
+    logger.handlers.clear()
+    logger.filters.clear()
+    logger.propagate = True
+    try:
+        with patch.dict(os.environ, {}, clear=True):
+            setup_logging(logger_name=logger_name, format="json")
+        logger.info("once")
+    finally:
+        root.handlers = saved_root_handlers
+        logger.handlers.clear()
+        logger.filters.clear()
+        logger.propagate = True
+
+    captured = capsys.readouterr()
+    # The root handler prefixes with 'ROOT '; propagation off means it never
+    # fires, so the message is emitted exactly once (by our own handler).
+    assert "ROOT once" not in captured.err
+    assert captured.out.count("once") + captured.err.count("once") == 1
+
+
+def test_setup_logging_root_logger_propagation_untouched() -> None:
+    # The root logger (logger_name=None) has no ancestor to double-emit to, so
+    # its propagate flag must be left as-is (never forced to False).
+    root = logging.getLogger()
+    saved_root_handlers = root.handlers[:]
+    saved_propagate = root.propagate
+    root.handlers = []
+    root.filters.clear()
+    try:
+        with patch.dict(os.environ, {}, clear=True):
+            setup_logging(logger_name=None)
+        assert root.propagate is saved_propagate
+    finally:
+        root.handlers = saved_root_handlers
+        root.filters.clear()
+        root.propagate = saved_propagate


### PR DESCRIPTION
## Summary

In standalone/local mode, `setup_logging(logger_name=...)` added a `StreamHandler` to the named logger but left `propagate=True`. When the root logger already had a handler — `logging.basicConfig()`, pytest, or most frameworks — every record was emitted **twice**: once by our handler and once by the root handler via propagation.

The docstring explicitly recommends passing `logger_name` *"to avoid modifying the root logger"*, so the **recommended** path double-logged whenever root had any handler.

## Fix

When `setup_logging` adds its own handler to a **named** logger, set `propagate = False` so that named logger owns its output:

```python
target.addHandler(handler)
if logger_name is not None:
    target.propagate = False
```

- Only applies when we actually add our **own** handler (the `not target.handlers` branch). If the user's named logger already has handlers, we only attach filters and leave their propagation untouched.
- The **root** logger (`logger_name=None`) has no ancestor to double-emit to, so its propagation is never forced to `False`.

Fix approach validated with the Oracle: `propagate=False` on library-owned named-logger handlers is safer than `hasHandlers()` (which would skip our formatter/filter setup entirely when root has handlers).

## Tests
- `test_setup_logging_named_logger_disables_propagation` — named logger gets `propagate=False`.
- `test_setup_logging_named_logger_no_double_emit_when_root_has_handler` — end-to-end: with a root handler present, a record is emitted exactly once.
- `test_setup_logging_root_logger_propagation_untouched` — `logger_name=None` leaves root `propagate` as-is.

## Verification
- `make lint` ✅  `make typecheck` ✅
- Full suite: 487 passed, 5 skipped (sole failure is the pre-existing unbuilt-env `test_version_matches_distribution_metadata`, unrelated).
- Coverage 96.62% (≥95% gate held).

Fixes #359