### PR TITLE
feat(logger): delegate unimplemented stdlib Logger attributes on FunctionLogger

### DIFF
--- a/src/azure_functions_logging/_logger.py
+++ b/src/azure_functions_logging/_logger.py
@@ -52,8 +52,15 @@ def _sanitize_extra(extra: dict[str, Any]) -> dict[str, Any]:
 class FunctionLogger:
     """Wrapper around a standard ``logging.Logger`` with context binding.
 
-    ``FunctionLogger`` delegates all standard logging methods to the underlying
-    logger. The ``bind()`` method returns a new wrapper with additional context
+    ``FunctionLogger`` forwards the common logging methods (``debug``,
+    ``info``, ``warning``, ``error``, ``critical``, ``exception``, ``log``)
+    through :meth:`_log`, which merges bound context and sanitizes reserved
+    ``extra`` keys. Any other attribute of the underlying ``logging.Logger``
+    (``addHandler``, ``handlers``, ``propagate``, ``level``, ``getChild``,
+    ...) is delegated via :meth:`__getattr__`, so a ``FunctionLogger``
+    behaves like the stdlib ``Logger`` it wraps.
+
+    The ``bind()`` method returns a new wrapper with additional context
     fields that are merged into ``extra`` on each log call.
 
     Context from ``bind()`` is supplementary to the ``ContextFilter``-based
@@ -167,3 +174,34 @@ class FunctionLogger:
     def hasHandlers(self) -> bool:
         """Return whether the underlying logger has any handlers configured."""
         return self._logger.hasHandlers()
+
+    def warn(self, msg: object, *args: Any, **kwargs: Any) -> None:
+        """Deprecated alias for :meth:`warning` (mirrors ``logging.Logger.warn``).
+
+        Implemented explicitly rather than delegated so bound context and
+        reserved-key sanitization still apply.
+        """
+        self._log(logging.WARNING, msg, args, **kwargs)
+
+    def fatal(self, msg: object, *args: Any, **kwargs: Any) -> None:
+        """Alias for :meth:`critical` (mirrors ``logging.Logger.fatal``).
+
+        Implemented explicitly rather than delegated so bound context and
+        reserved-key sanitization still apply.
+        """
+        self._log(logging.CRITICAL, msg, args, **kwargs)
+
+    def __getattr__(self, name: str) -> Any:
+        """Delegate unknown attributes to the wrapped ``logging.Logger``.
+
+        ``__getattr__`` only runs when normal lookup fails, so it never
+        shadows ``FunctionLogger``'s own slots or methods. It forwards the rest
+        of the stdlib ``Logger`` surface (``addHandler``, ``removeHandler``,
+        ``addFilter``, ``handlers``, ``propagate``, ``level``, ``disabled``,
+        ``parent``, ``manager``, ``getChild``, ...) to ``self._logger``.
+        """
+        # Guard the slot names so a missing ``_logger`` (e.g. before __init__)
+        # raises AttributeError instead of recursing infinitely.
+        if name in ("_logger", "_context"):
+            raise AttributeError(name)
+        return getattr(self._logger, name)

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -510,3 +510,60 @@ def test_explicit_stacklevel_walks_further_up_like_stdlib() -> None:
     fl_record, std_record = fl_cap.records[-1], std_cap.records[-1]
     assert fl_record.funcName == std_record.funcName == "_caller"
     assert fl_record.lineno == std_record.lineno
+
+
+class TestAttributeDelegation:
+    """FunctionLogger forwards the rest of the stdlib Logger surface (#365)."""
+
+    def test_delegates_addhandler_to_underlying(self) -> None:
+        underlying = _mock_underlying_logger()
+        logger = FunctionLogger(underlying)
+        handler = logging.NullHandler()
+
+        logger.addHandler(handler)
+
+        underlying.addHandler.assert_called_once_with(handler)
+
+    def test_delegates_propagate_attribute(self) -> None:
+        real = logging.getLogger("test.delegate.propagate")
+        real.propagate = False
+        logger = FunctionLogger(real)
+
+        assert logger.propagate is False
+
+    def test_delegates_getchild(self) -> None:
+        real = logging.getLogger("test.delegate.parent")
+        logger = FunctionLogger(real)
+
+        child = logger.getChild("sub")
+
+        assert child.name == "test.delegate.parent.sub"
+
+    def test_missing_attribute_raises_attribute_error(self) -> None:
+        logger = FunctionLogger(_mock_underlying_logger())
+
+        with pytest.raises(AttributeError):
+            _ = logger.definitely_not_a_real_logger_attribute
+
+    def test_warn_alias_routes_through_sanitization(self) -> None:
+        underlying = _mock_underlying_logger()
+        logger = FunctionLogger(underlying)
+
+        # ``filename`` is a reserved LogRecord key; sanitization must rename
+        # it so the call does not raise and the value survives under
+        # ``extra_filename``.
+        logger.warn("deprecated path", filename="collides")
+
+        underlying.log.assert_called_once()
+        _, kwargs = underlying.log.call_args
+        assert kwargs["extra"] == {"extra_filename": "collides"}
+
+    def test_fatal_alias_logs_at_critical(self) -> None:
+        underlying = _mock_underlying_logger()
+        logger = FunctionLogger(underlying)
+
+        logger.fatal("boom")
+
+        underlying.log.assert_called_once()
+        args, _ = underlying.log.call_args
+        assert args[0] == logging.CRITICAL


### PR DESCRIPTION
## Summary
- Add `__getattr__` to `FunctionLogger` that delegates unknown attribute reads to the wrapped `logging.Logger`, so the common stdlib surface (`addHandler`, `removeHandler`, `addFilter`, `handlers`, `propagate`, `level`, `disabled`, `parent`, `manager`, `getChild`, ...) works instead of raising `AttributeError`.
- Implement `warn`/`fatal` explicitly (not via delegation) so those aliases still route through `_log` and keep bound-context merge + reserved-key sanitization.
- Guard the `_logger`/`_context` slot names in `__getattr__` to avoid infinite recursion if accessed before `__init__`.

## Tests
- New `TestAttributeDelegation` in `tests/test_logger.py`: delegated `addHandler`/`propagate`/`getChild`, `AttributeError` for genuinely missing attrs, and `warn`/`fatal` routing through sanitization / CRITICAL level.
- `make lint`, `make typecheck` (mypy), `pytest tests/test_logger.py` all green.

Closes #365