### PR TITLE
fix(setup): warn when extra_context_vars is ignored under use_record_factory

### DIFF
--- a/src/azure_functions_logging/_setup.py
+++ b/src/azure_functions_logging/_setup.py
@@ -120,7 +120,8 @@ def setup_logging(
             whose current values ``ContextFilter`` also copies onto each
             LogRecord, alongside the four built-in context fields. Field names
             must not collide with the built-in fields. Only applies to the
-            ``ContextFilter`` strategy (ignored when ``use_record_factory=True``).
+            ``ContextFilter`` strategy; a warning is emitted if it is provided
+            when ``use_record_factory=True``.
         activate_trace_context: Sets the process-wide default that
             ``logging_context`` and ``with_context`` consult to attach the
             host's W3C trace context (via OpenTelemetry) — making OTel log
@@ -144,6 +145,19 @@ def setup_logging(
     if format not in {"color", "json"}:
         msg = "format must be 'color' or 'json'"
         raise ValueError(msg)
+
+    # A caller-supplied extra_context_vars has no effect in record-factory
+    # mode (context is injected by the global LogRecordFactory, which does not
+    # read it). Silently dropping an explicit argument is a config footgun, so
+    # warn rather than ignore it. Only warn when the argument is actually set.
+    if use_record_factory and extra_context_vars:
+        warnings.warn(
+            "extra_context_vars is ignored when use_record_factory=True: context "
+            "is injected via the global LogRecordFactory, which does not read "
+            "extra_context_vars. Use the default ContextFilter mode "
+            "(use_record_factory=False) to apply them.",
+            stacklevel=2,
+        )
 
     # Install the global LogRecordFactory only after argument validation,
     # so an invalid call does not leave persistent global side effects.

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
 from collections.abc import Iterator
+import contextvars
 import logging
 import os
 from types import SimpleNamespace
 from unittest.mock import patch
+import warnings
 
 import pytest
 
@@ -771,3 +773,43 @@ def test_setup_logging_root_logger_propagation_untouched() -> None:
         root.handlers = saved_root_handlers
         root.filters.clear()
         root.propagate = saved_propagate
+
+
+def test_extra_context_vars_with_record_factory_warns() -> None:
+    # Passing extra_context_vars while use_record_factory=True has no effect;
+    # setup_logging must warn rather than silently drop the argument (#366).
+    extra = {"tenant": contextvars.ContextVar("tenant", default=None)}
+    with patch.dict(os.environ, {}, clear=True):
+        with pytest.warns(UserWarning, match="extra_context_vars is ignored"):
+            setup_logging(
+                logger_name="afl.test.warn_extra_ctx",
+                use_record_factory=True,
+                extra_context_vars=extra,
+            )
+
+
+def test_extra_context_vars_without_record_factory_does_not_warn() -> None:
+    # In the default ContextFilter mode extra_context_vars is honored, so no
+    # warning should be emitted.
+    extra = {"tenant": contextvars.ContextVar("tenant2", default=None)}
+    with patch.dict(os.environ, {}, clear=True):
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            setup_logging(
+                logger_name="afl.test.no_warn_extra_ctx",
+                use_record_factory=False,
+                extra_context_vars=extra,
+            )
+    assert not [w for w in caught if "extra_context_vars is ignored" in str(w.message)]
+
+
+def test_record_factory_without_extra_context_vars_does_not_warn() -> None:
+    # use_record_factory=True alone (no extra_context_vars) must not warn.
+    with patch.dict(os.environ, {}, clear=True):
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            setup_logging(
+                logger_name="afl.test.factory_no_extra",
+                use_record_factory=True,
+            )
+    assert not [w for w in caught if "extra_context_vars is ignored" in str(w.message)]


### PR DESCRIPTION
## Summary
- `setup_logging(extra_context_vars=..., use_record_factory=True)` previously dropped `extra_context_vars` silently — context in that mode comes from the global `LogRecordFactory`, which never reads it.
- Now emit a `UserWarning` (stacklevel=2) when a non-empty `extra_context_vars` is passed together with `use_record_factory=True`, so a caller-supplied config isn't lost without a signal. No warning when the argument is empty or when using the default `ContextFilter` mode.
- Updated the `extra_context_vars` docstring accordingly.

## Tests
- `tests/test_setup.py`: warns for the ignored combination; does NOT warn in default mode; does NOT warn when `use_record_factory=True` without `extra_context_vars`.
- `make format`, `make lint`, `make typecheck` (mypy), `pytest tests/test_setup.py` all green.

Closes #366